### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
 name: Server CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/revisium/revisium-core/security/code-scanning/10](https://github.com/revisium/revisium-core/security/code-scanning/10)

To fix the issue, we will add a `permissions` block at the root level of the workflow to define the least privileges required. Based on the actions used in the workflow:
- `contents: read` is sufficient for most steps, such as checking out the repository and running tests.
- Additional permissions (e.g., `contents: write`, `statuses: write`) are not required unless explicitly needed by the actions, which is not evident in this workflow.

The `permissions` block will be added after the `name` field (line 4) to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
