### PR TITLE
fix: copying publishedAt during get-or-create-draft-rows.handler.ts

### DIFF
--- a/src/features/draft/commands/handlers/__tests__/transactional/internal-update-rows.spec.ts
+++ b/src/features/draft/commands/handlers/__tests__/transactional/internal-update-rows.spec.ts
@@ -159,7 +159,7 @@ describe('UpdateRowsHandler', () => {
     expect(row.schemaHash).toBe(objectHash(testSchema));
     expect(row.createdId).toBe(rowCreatedId);
     expect(row.createdAt).not.toStrictEqual(row.updatedAt);
-    expect(row.publishedAt).not.toStrictEqual(row.updatedAt);
+    expect(row.publishedAt).toStrictEqual(row.createdAt);
   });
 
   it('should update the rows in a new created table if conditions are met', async () => {
@@ -227,7 +227,7 @@ describe('UpdateRowsHandler', () => {
     expect(row.createdId).toBe(rowCreatedId);
     expect(table.versionId).not.toBe(draftTableVersionId);
     expect(row.createdAt).not.toStrictEqual(row.updatedAt);
-    expect(row.publishedAt).not.toStrictEqual(row.updatedAt);
+    expect(row.publishedAt).toStrictEqual(row.createdAt);
   });
 
   it('should update a new created row in the table if conditions are met', async () => {
@@ -295,7 +295,7 @@ describe('UpdateRowsHandler', () => {
     expect(row.schemaHash).toBe(objectHash(testSchema));
     expect(table.versionId).toBe(draftTableVersionId);
     expect(row.createdAt).not.toStrictEqual(row.updatedAt);
-    expect(row.publishedAt).not.toStrictEqual(row.updatedAt);
+    expect(row.publishedAt).toStrictEqual(row.createdAt);
   });
 
   function runTransaction(command: InternalUpdateRowsCommand): Promise<void> {

--- a/src/features/draft/commands/handlers/transactional/get-or-create-draft-rows.handler.ts
+++ b/src/features/draft/commands/handlers/transactional/get-or-create-draft-rows.handler.ts
@@ -88,6 +88,7 @@ export class GetOrCreateDraftRowsHandler
     const inputs: Prisma.RowCreateManyInput[] =
       generatedRows.map<Prisma.RowCreateManyInput>((row) => ({
         createdAt: row.createdAt,
+        publishedAt: row.publishedAt,
         versionId: row.versionId,
         createdId: row.createdId,
         id: row.id,


### PR DESCRIPTION
closes #187 