### PR TITLE
fix: mime type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@revisium/core",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@revisium/core",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@apollo/server": "^4.12.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revisium/core",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Revisium is a tool (UI/API) inspired by JSON (JSON Schema) and Git, designed to provide a flexible and low-level headless CMS solution.",
   "private": false,
   "homepage": "https://revisium.io",

--- a/src/api/rest-api/openapi.json
+++ b/src/api/rest-api/openapi.json
@@ -1345,7 +1345,7 @@
     "contact": {},
     "description": "",
     "title": "Revisium API",
-    "version": "2.1.0"
+    "version": "2.1.1"
   },
   "openapi": "3.0.0",
   "paths": {

--- a/src/features/plugin/file/utils/validate-file-data-for-restore.ts
+++ b/src/features/plugin/file/utils/validate-file-data-for-restore.ts
@@ -64,7 +64,7 @@ const validateMimeTypeFormat = (mimeType: string): void => {
       throw new Error('mimeType too long - maximum 100 characters');
     }
     if (
-      !/^[a-zA-Z0-9][a-zA-Z0-9!#$&\-^_]*\/[a-zA-Z0-9][a-zA-Z0-9!#$&\-^_.]*$/.test(
+      !/^[a-zA-Z0-9][a-zA-Z0-9!#$&\-^_]*\/[a-zA-Z0-9][a-zA-Z0-9!#$&\-^_.+]*$/.test(
         mimeType,
       )
     ) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Bug Fixes
  * Expanded MIME type validation to accept subtypes with “+”, improving restore compatibility for additional formats.

* Documentation
  * Updated API specification version to 2.1.1 with no functional changes.

* Tests
  * Added tests covering valid MIME types in the restore flow.

* Chores
  * Bumped application version to 2.1.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->