### PR TITLE
feat: updated createdAt in move endpoints

### DIFF
--- a/src/features/share/commands/handlers/transactional/move-endpoints.handler.ts
+++ b/src/features/share/commands/handlers/transactional/move-endpoints.handler.ts
@@ -46,6 +46,7 @@ export class MoveEndpointsHandler
       where: { id: endpointId },
       data: {
         revisionId,
+        createdAt: new Date(),
       },
     });
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Endpoint timestamps now refresh when endpoints are moved between revisions, ensuring createdAt accurately reflects the move time and improves sorting and auditing consistency.

* **Tests**
  * Expanded coverage to validate revision relationships and timestamp updates during endpoint moves, improving reliability of related behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->