### PR TITLE
feat: init cache

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,8 @@ PORT=8080
 
 DATABASE_URL="postgresql://revisium:password@localhost:5433/revisium-dev?schema=public&connection_limit=10"
 
+EXPERIMENTAL_CACHE=false
+
 JWT_SECRET=secret
 
 ENDPOINT_PORT=6380

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "graphql-type-json": "^0.3.2",
         "handlebars": "^4.7.8",
         "ioredis": "^5.6.1",
+        "lru-cache": "^11.2.1",
         "nanoid": "^3.3.11",
         "nodemailer": "^7.0.3",
         "object-hash": "^3.0.0",
@@ -46,6 +47,7 @@
         "passport-jwt": "^4.0.1",
         "pg": "^8.16.3",
         "prom-client": "^15.1.3",
+        "redis": "^5.8.2",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.2",
         "sharp": "^0.34.2"
@@ -4876,6 +4878,66 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
+    },
+    "node_modules/@redis/bloom": {
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-5.8.2.tgz",
+      "integrity": "sha512-855DR0ChetZLarblio5eM0yLwxA9Dqq50t8StXKp5bAtLT0G+rZ+eRzzqxl37sPqQKjUudSYypz55o6nNhbz0A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.8.2"
+      }
+    },
+    "node_modules/@redis/client": {
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.8.2.tgz",
+      "integrity": "sha512-WtMScno3+eBpTac1Uav2zugXEoXqaU23YznwvFgkPwBQVwEHTDgOG7uEAObtZ/Nyn8SmAMbqkEubJaMOvnqdsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cluster-key-slot": "1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@redis/json": {
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-5.8.2.tgz",
+      "integrity": "sha512-uxpVfas3I0LccBX9rIfDgJ0dBrUa3+0Gc8sEwmQQH0vHi7C1Rx1Qn8Nv1QWz5bohoeIXMICFZRcyDONvum2l/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.8.2"
+      }
+    },
+    "node_modules/@redis/search": {
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-5.8.2.tgz",
+      "integrity": "sha512-cNv7HlgayavCBXqPXgaS97DRPVWFznuzsAmmuemi2TMCx5scwLiP50TeZvUS06h/MG96YNPe6A0Zt57yayfxwA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.8.2"
+      }
+    },
+    "node_modules/@redis/time-series": {
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-5.8.2.tgz",
+      "integrity": "sha512-g2NlHM07fK8H4k+613NBsk3y70R2JIM2dPMSkhIjl2Z17SYvaYKdusz85d7VYOrZBWtDrHV/WD2E3vGu+zni8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.8.2"
+      }
     },
     "node_modules/@scarf/scarf": {
       "version": "1.4.0",
@@ -11132,10 +11194,9 @@
       "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
     },
     "node_modules/lru-cache": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.1.0.tgz",
-      "integrity": "sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==",
-      "dev": true,
+      "version": "11.2.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.1.tgz",
+      "integrity": "sha512-r8LA6i4LP4EeWOhqBaZZjDWwehd1xUJPCJd9Sv300H0ZmcUER4+JPh7bqqZeqs1o5pgtgvXm+d9UGrB5zZGDiQ==",
       "license": "ISC",
       "engines": {
         "node": "20 || >=22"
@@ -12596,6 +12657,22 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/redis": {
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-5.8.2.tgz",
+      "integrity": "sha512-31vunZj07++Y1vcFGcnNWEf5jPoTkGARgfWI4+Tk55vdwHxhAvug8VEtW7Cx+/h47NuJTEg/JL77zAwC6E0OeA==",
+      "license": "MIT",
+      "dependencies": {
+        "@redis/bloom": "5.8.2",
+        "@redis/client": "5.8.2",
+        "@redis/json": "5.8.2",
+        "@redis/search": "5.8.2",
+        "@redis/time-series": "5.8.2"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/redis-errors": {

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "graphql-type-json": "^0.3.2",
     "handlebars": "^4.7.8",
     "ioredis": "^5.6.1",
+    "lru-cache": "^11.2.1",
     "nanoid": "^3.3.11",
     "nodemailer": "^7.0.3",
     "object-hash": "^3.0.0",
@@ -82,6 +83,7 @@
     "passport-jwt": "^4.0.1",
     "pg": "^8.16.3",
     "prom-client": "^15.1.3",
+    "redis": "^5.8.2",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.2",
     "sharp": "^0.34.2"

--- a/src/core/core.module.ts
+++ b/src/core/core.module.ts
@@ -7,6 +7,7 @@ import { AppOptionsModule } from 'src/core/app-options.module';
 
 import { AuthModule } from 'src/features/auth/auth.module';
 import { BranchModule } from 'src/features/branch/branch.module';
+import { RevisiumCacheModule } from 'src/infrastructure/cache-manager/revisium-cache.module';
 import { CleanModule } from 'src/infrastructure/clean/clean.module';
 import { ConfigurationModule } from 'src/infrastructure/configuration/configuration.module';
 import { DatabaseModule } from 'src/infrastructure/database/database.module';
@@ -59,6 +60,7 @@ export class CoreModule {
         DraftModule,
         EndpointModule,
         MetricsModule,
+        RevisiumCacheModule.forRootAsync(),
       ],
     };
   }

--- a/src/features/auth/casl-ability.factory.ts
+++ b/src/features/auth/casl-ability.factory.ts
@@ -2,6 +2,7 @@ import { AbilityBuilder, createMongoAbility, MongoQuery } from '@casl/ability';
 import { AnyObject } from '@casl/ability/dist/types/types';
 import { Injectable } from '@nestjs/common';
 import { UserRole } from 'src/features/auth/consts';
+import { CachedMethod } from 'src/infrastructure/cache-manager/method-cache.decorator';
 import { PrismaService } from 'src/infrastructure/database/prisma.service';
 
 @Injectable()
@@ -22,6 +23,15 @@ export class CaslAbilityFactory {
     return build();
   }
 
+  @CachedMethod<
+    UserRole,
+    Array<{ action: string; subject: string; condition?: object }>
+  >({
+    keyPrefix: 'role:permissions',
+    makeKey: ([role]) => role,
+    makeTags: ([role]) => ['dict:roles', `role:${role}`],
+    ttlSec: 24 * 60 * 60,
+  })
   private getPermissions(role: UserRole) {
     return this.prisma.role
       .findUniqueOrThrow({

--- a/src/features/auth/commands/handlers/check-organization-permission.handler.ts
+++ b/src/features/auth/commands/handlers/check-organization-permission.handler.ts
@@ -16,6 +16,7 @@ export class CheckOrganizationPermissionHandler
   ) {}
 
   async execute({ data }: CheckOrganizationPermissionCommand): Promise<true> {
+    console.log('CheckOrganizationPermissionCommand');
     const systemRole = await this.getSystemRole(data);
     const organizationRole = await this.getOrganizationRole(data);
 

--- a/src/features/auth/commands/handlers/check-project-permission.handler.ts
+++ b/src/features/auth/commands/handlers/check-project-permission.handler.ts
@@ -17,6 +17,7 @@ export class CheckProjectPermissionHandler
   ) {}
 
   async execute({ data }: CheckProjectPermissionCommand): Promise<true> {
+    console.log('CheckProjectPermissionCommand');
     const project = await this.resolveProject(data);
 
     const systemRole = await this.getSystemRole(data);

--- a/src/features/auth/commands/handlers/check-system-permission.handler.ts
+++ b/src/features/auth/commands/handlers/check-system-permission.handler.ts
@@ -23,6 +23,7 @@ export class CheckSystemPermissionHandler
   ) {}
 
   async execute({ data }: CheckSystemPermissionCommand) {
+    console.log('CheckSystemPermissionCommand');
     const systemRole = await this.getSystemRole(data);
 
     const ability = await this.casl.createAbility(systemRole);

--- a/src/infrastructure/cache-manager/__tests__/cache.service.l1.spec.ts
+++ b/src/infrastructure/cache-manager/__tests__/cache.service.l1.spec.ts
@@ -1,0 +1,228 @@
+import { CacheService } from '../services/cache.service';
+import { InMemoryAdapter } from '../adapters/in-memory.adapter';
+
+describe('CacheService (L1 only)', () => {
+  let l1: InMemoryAdapter;
+  let service: CacheService;
+
+  beforeEach(() => {
+    l1 = new InMemoryAdapter();
+    service = new CacheService(l1); // L1 only, no L2
+  });
+
+  describe('basic operations', () => {
+    it('miss → set → hit workflow', async () => {
+      // Initial miss
+      expect(await service.get('key1')).toBeUndefined();
+
+      // Set value
+      await service.set('key1', 'value1');
+
+      // Now hit
+      expect(await service.get('key1')).toBe('value1');
+    });
+
+    it('del removes single key', async () => {
+      await service.set('key1', 'value1');
+      await service.set('key2', 'value2');
+
+      await service.del('key1');
+
+      expect(await service.get('key1')).toBeUndefined();
+      expect(await service.get('key2')).toBe('value2'); // still exists
+    });
+
+    it('handles various data types', async () => {
+      const testCases: Array<[string, any]> = [
+        ['string', 'hello world'],
+        ['number', 42],
+        ['boolean', true],
+        ['object', { a: 1, b: 'test', nested: { c: 3 } }],
+        ['array', [1, 'two', { three: 3 }]],
+        ['null', null],
+      ];
+
+      // Set all values
+      for (const [key, value] of testCases) {
+        await service.set(key, value);
+      }
+
+      // Verify all values
+      for (const [key, expectedValue] of testCases) {
+        expect(await service.get(key)).toEqual(expectedValue);
+      }
+    });
+  });
+
+  describe('tag-based operations', () => {
+    it('delByTags removes multiple keys with same tag', async () => {
+      await service.set('user:1', { name: 'Alice' }, { tags: ['users'] });
+      await service.set('user:2', { name: 'Bob' }, { tags: ['users'] });
+      await service.set('post:1', { title: 'Hello' }, { tags: ['posts'] });
+
+      // Delete all users
+      await service.delByTags(['users']);
+
+      expect(await service.get('user:1')).toBeUndefined();
+      expect(await service.get('user:2')).toBeUndefined();
+      expect(await service.get('post:1')).toEqual({ title: 'Hello' }); // still exists
+    });
+
+    it('delByTags with multiple tags removes keys with any of those tags', async () => {
+      await service.set('key1', 'value1', { tags: ['tag1'] });
+      await service.set('key2', 'value2', { tags: ['tag2'] });
+      await service.set('key3', 'value3', { tags: ['tag3'] });
+      await service.set('key4', 'value4', { tags: ['tag1', 'tag2'] }); // multiple tags
+
+      await service.delByTags(['tag1', 'tag2']);
+
+      expect(await service.get('key1')).toBeUndefined(); // tag1
+      expect(await service.get('key2')).toBeUndefined(); // tag2
+      expect(await service.get('key4')).toBeUndefined(); // tag1 + tag2
+      expect(await service.get('key3')).toBe('value3'); // tag3, still exists
+    });
+
+    it('delByTags with empty array does nothing', async () => {
+      await service.set('key1', 'value1', { tags: ['tag1'] });
+
+      await service.delByTags([]);
+
+      expect(await service.get('key1')).toBe('value1'); // still exists
+    });
+
+    it('delByTags with non-existent tags does nothing', async () => {
+      await service.set('key1', 'value1', { tags: ['tag1'] });
+
+      await service.delByTags(['nonexistent']);
+
+      expect(await service.get('key1')).toBe('value1'); // still exists
+    });
+
+    it('set without tags works normally', async () => {
+      await service.set('key1', 'value1'); // no tags
+      expect(await service.get('key1')).toBe('value1');
+
+      await service.delByTags(['any-tag']);
+      expect(await service.get('key1')).toBe('value1'); // unaffected
+    });
+  });
+
+  describe('TTL support', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('respects TTL expiration', async () => {
+      await service.set('key1', 'value1', { ttlSec: 5 });
+
+      // Initially accessible
+      expect(await service.get('key1')).toBe('value1');
+
+      // Still valid after 4 seconds
+      jest.advanceTimersByTime(4000);
+      expect(await service.get('key1')).toBe('value1');
+
+      // Expired after 6 seconds
+      jest.advanceTimersByTime(2000);
+      expect(await service.get('key1')).toBeUndefined();
+    });
+
+    it('TTL works with tags', async () => {
+      await service.set('key1', 'value1', { ttlSec: 1, tags: ['temp'] });
+
+      // Before expiration, tag deletion should work
+      await service.delByTags(['temp']);
+      expect(await service.get('key1')).toBeUndefined();
+    });
+
+    it('entries without TTL never expire', async () => {
+      await service.set('key1', 'value1'); // no TTL
+
+      jest.advanceTimersByTime(1000000); // long time
+
+      expect(await service.get('key1')).toBe('value1');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles key overwrite correctly', async () => {
+      await service.set('key1', 'value1', { tags: ['tag1'] });
+      await service.set('key1', 'value2', { tags: ['tag2'] }); // overwrite with different tags
+
+      expect(await service.get('key1')).toBe('value2');
+
+      // Note: Current implementation doesn't clean up old tag references on overwrite
+      // This is a known limitation - deleting by old tag will still remove the key
+      await service.delByTags(['tag2']);
+      expect(await service.get('key1')).toBeUndefined();
+    });
+
+    it('del non-existent key does not error', async () => {
+      await expect(service.del('nonexistent')).resolves.not.toThrow();
+    });
+
+    it('get after del returns undefined', async () => {
+      await service.set('key1', 'value1');
+      await service.del('key1');
+
+      expect(await service.get('key1')).toBeUndefined();
+    });
+
+    it('multiple operations on same key', async () => {
+      await service.set('counter', 1);
+      expect(await service.get('counter')).toBe(1);
+
+      await service.set('counter', 2);
+      expect(await service.get('counter')).toBe(2);
+
+      await service.del('counter');
+      expect(await service.get('counter')).toBeUndefined();
+
+      await service.set('counter', 3);
+      expect(await service.get('counter')).toBe(3);
+    });
+  });
+
+  describe('L1 adapter integration', () => {
+    it('delegates operations to L1 adapter', async () => {
+      // Spy on L1 adapter methods
+      const getSpy = jest.spyOn(l1, 'get');
+      const setSpy = jest.spyOn(l1, 'set');
+      const delSpy = jest.spyOn(l1, 'del');
+      const delByTagsSpy = jest.spyOn(l1, 'delByTags');
+
+      await service.set('key1', 'value1', { ttlSec: 60, tags: ['tag1'] });
+      await service.get('key1');
+      await service.del('key1');
+      await service.delByTags(['tag1']);
+
+      expect(setSpy).toHaveBeenCalledWith('key1', 'value1', {
+        ttlSec: 60,
+        tags: ['tag1'],
+      });
+      expect(getSpy).toHaveBeenCalledWith('key1');
+      expect(delSpy).toHaveBeenCalledWith('key1');
+      expect(delByTagsSpy).toHaveBeenCalledWith(['tag1']);
+
+      // Clean up spies
+      getSpy.mockRestore();
+      setSpy.mockRestore();
+      delSpy.mockRestore();
+      delByTagsSpy.mockRestore();
+    });
+
+    it('does not call L2 methods when L2 is not provided', async () => {
+      // This test ensures the service correctly handles the optional L2 parameter
+      await service.set('key1', 'value1');
+      await service.get('key1');
+      await service.del('key1');
+      await service.delByTags(['tag1']);
+
+      // Should not throw any errors about L2 being undefined
+    });
+  });
+});

--- a/src/infrastructure/cache-manager/__tests__/cache.service.l1l2.spec.ts
+++ b/src/infrastructure/cache-manager/__tests__/cache.service.l1l2.spec.ts
@@ -1,0 +1,306 @@
+import { CacheService } from '../services/cache.service';
+import { InMemoryAdapter } from '../adapters/in-memory.adapter';
+import { CacheAdapter } from '../adapters/cache.adapter';
+
+// Mock L2 adapter for testing L1+L2 scenarios
+const createMockL2Adapter = (): jest.Mocked<CacheAdapter> => {
+  const storage = new Map<string, any>();
+  const tagIndex = new Map<string, Set<string>>();
+
+  return {
+    get: jest.fn().mockImplementation(async (key: string) => {
+      return storage.get(key);
+    }),
+    set: jest
+      .fn()
+      .mockImplementation(async (key: string, value: any, opts?: any) => {
+        storage.set(key, value);
+
+        // Handle tags
+        if (opts?.tags?.length) {
+          opts.tags.forEach((tag: string) => {
+            if (!tagIndex.has(tag)) {
+              tagIndex.set(tag, new Set());
+            }
+            tagIndex.get(tag)!.add(key);
+          });
+        }
+      }),
+    del: jest.fn().mockImplementation(async (key: string) => {
+      storage.delete(key);
+
+      // Clean up tag references
+      for (const [tag, keys] of tagIndex.entries()) {
+        if (keys.has(key)) {
+          keys.delete(key);
+          if (keys.size === 0) {
+            tagIndex.delete(tag);
+          }
+        }
+      }
+    }),
+    delByTags: jest.fn().mockImplementation(async (tags: string[]) => {
+      const keysToDelete = new Set<string>();
+
+      tags.forEach((tag) => {
+        const keys = tagIndex.get(tag);
+        if (keys) {
+          keys.forEach((key) => keysToDelete.add(key));
+        }
+      });
+
+      keysToDelete.forEach((key) => {
+        storage.delete(key);
+      });
+
+      tags.forEach((tag) => {
+        tagIndex.delete(tag);
+      });
+    }),
+  };
+};
+
+describe('CacheService (L1 + L2)', () => {
+  let l1: InMemoryAdapter;
+  let l2: jest.Mocked<CacheAdapter>;
+  let service: CacheService;
+
+  beforeEach(() => {
+    l1 = new InMemoryAdapter();
+    l2 = createMockL2Adapter();
+    service = new CacheService(l1, l2);
+  });
+
+  describe('L2 hydration to L1', () => {
+    it('L1 miss + L2 hit → hydrates L1', async () => {
+      // Put value directly in L2 (bypassing L1)
+      l2.set.mockImplementation(async (key, value) => {
+        (l2 as any).storage = (l2 as any).storage || new Map();
+        (l2 as any).storage.set(key, value);
+      });
+      l2.get.mockResolvedValueOnce('l2-value');
+
+      // First get should fetch from L2 and hydrate L1
+      const result1 = await service.get('key1');
+      expect(result1).toBe('l2-value');
+
+      // Verify L2 was called
+      expect(l2.get).toHaveBeenCalledWith('key1');
+
+      // Verify L1 was hydrated (by checking if we can get from L1 directly)
+      const directL1Result = await l1.get('key1');
+      expect(directL1Result).toBe('l2-value');
+
+      // Second get should hit L1 (not call L2 again)
+      l2.get.mockClear();
+      const result2 = await service.get('key1');
+      expect(result2).toBe('l2-value');
+      expect(l2.get).not.toHaveBeenCalled();
+    });
+
+    it('L1 miss + L2 miss → returns undefined', async () => {
+      l2.get.mockResolvedValue(undefined);
+
+      const result = await service.get('nonexistent');
+      expect(result).toBeUndefined();
+
+      expect(l2.get).toHaveBeenCalledWith('nonexistent');
+    });
+
+    it('L1 hit → does not check L2', async () => {
+      // Set value normally (goes to both L1 and L2)
+      await service.set('key1', 'cached-value');
+
+      // Clear L2 mock calls
+      l2.get.mockClear();
+
+      // Get should hit L1 and not call L2
+      const result = await service.get('key1');
+      expect(result).toBe('cached-value');
+      expect(l2.get).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('dual-layer operations', () => {
+    it('set writes to both L1 and L2', async () => {
+      await service.set('key1', 'value1', { ttlSec: 60, tags: ['tag1'] });
+
+      expect(l2.set).toHaveBeenCalledWith('key1', 'value1', {
+        ttlSec: 60,
+        tags: ['tag1'],
+      });
+
+      // Verify both layers have the value
+      expect(await l1.get('key1')).toBe('value1');
+
+      l2.get.mockResolvedValue('value1');
+      expect(await l2.get('key1')).toBe('value1');
+    });
+
+    it('del removes from both L1 and L2', async () => {
+      await service.set('key1', 'value1');
+      await service.del('key1');
+
+      expect(l2.del).toHaveBeenCalledWith('key1');
+
+      // Verify both layers are cleared
+      expect(await l1.get('key1')).toBeUndefined();
+    });
+
+    it('delByTags clears both L1 and L2', async () => {
+      await service.set('key1', 'value1', { tags: ['tag1'] });
+      await service.set('key2', 'value2', { tags: ['tag1'] });
+
+      await service.delByTags(['tag1']);
+
+      expect(l2.delByTags).toHaveBeenCalledWith(['tag1']);
+
+      // Verify both layers are cleared
+      expect(await l1.get('key1')).toBeUndefined();
+      expect(await l1.get('key2')).toBeUndefined();
+    });
+  });
+
+  describe('L1/L2 consistency scenarios', () => {
+    it('handles L1 cleared but L2 intact', async () => {
+      // Set value in both layers
+      await service.set('key1', 'original-value');
+
+      // Simulate L1 being cleared (e.g., app restart)
+      await l1.del('key1');
+
+      // L2 still has the value
+      l2.get.mockResolvedValue('original-value');
+
+      // Should hydrate from L2
+      const result = await service.get('key1');
+      expect(result).toBe('original-value');
+
+      // L1 should now be hydrated
+      expect(await l1.get('key1')).toBe('original-value');
+    });
+
+    it('L2 failure does not prevent L1 operations', async () => {
+      // Set value normally
+      await service.set('key1', 'value1');
+
+      // L2 starts failing
+      l2.get.mockRejectedValue(new Error('L2 connection failed'));
+
+      // Should still work with L1
+      const result = await service.get('key1');
+      expect(result).toBe('value1');
+    });
+
+    it('L1 and L2 tag deletion works independently', async () => {
+      // Set values with tags
+      await service.set('key1', 'value1', { tags: ['shared-tag'] });
+      await service.set('key2', 'value2', { tags: ['l1-only'] });
+
+      // Manually add a value to L2 only (simulating external Redis usage)
+      l2.set('external-key', 'external-value', { tags: ['shared-tag'] });
+
+      // Delete by shared tag
+      await service.delByTags(['shared-tag']);
+
+      // Both layers should have processed the tag deletion
+      expect(l2.delByTags).toHaveBeenCalledWith(['shared-tag']);
+      expect(await l1.get('key1')).toBeUndefined();
+      expect(await l1.get('key2')).toBe('value2'); // different tag, should remain
+    });
+  });
+
+  describe('complex hydration scenarios', () => {
+    it('hydration preserves data types', async () => {
+      const complexValue = {
+        string: 'hello',
+        number: 42,
+        boolean: true,
+        array: [1, 2, 3],
+        nested: { a: 'b' },
+      };
+
+      // Put directly in L2
+      l2.get.mockResolvedValue(complexValue);
+
+      const result = await service.get('complex-key');
+      expect(result).toEqual(complexValue);
+
+      // Verify L1 hydration preserved the structure
+      expect(await l1.get('complex-key')).toEqual(complexValue);
+    });
+
+    it('hydration without TTL or tags', async () => {
+      l2.get.mockResolvedValue('simple-value');
+
+      const result = await service.get('simple-key');
+      expect(result).toBe('simple-value');
+
+      // L1 should be hydrated without options
+      expect(await l1.get('simple-key')).toBe('simple-value');
+    });
+
+    it('multiple concurrent gets with L2 hydration', async () => {
+      let callCount = 0;
+      l2.get.mockImplementation(async () => {
+        callCount++;
+        return 'l2-value';
+      });
+
+      // Make multiple concurrent gets
+      const promises = [
+        service.get('concurrent-key'),
+        service.get('concurrent-key'),
+        service.get('concurrent-key'),
+      ];
+
+      const results = await Promise.all(promises);
+
+      // All should return the same value
+      results.forEach((result) => expect(result).toBe('l2-value'));
+
+      // L2 should have been called (though exact count may vary due to race conditions)
+      expect(callCount).toBeGreaterThan(0);
+
+      // Subsequent get should hit L1
+      l2.get.mockClear();
+      const cachedResult = await service.get('concurrent-key');
+      expect(cachedResult).toBe('l2-value');
+      expect(l2.get).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('error handling with L2', () => {
+    it('L2 set failure does not prevent L1 set', async () => {
+      l2.set.mockRejectedValue(new Error('L2 set failed'));
+
+      // Should not throw
+      await expect(service.set('key1', 'value1')).rejects.toThrow(
+        'L2 set failed',
+      );
+
+      // But L1 should still have the value if we had proper error handling
+      // (Note: Current implementation doesn't handle L2 failures gracefully)
+    });
+
+    it('L2 get failure falls back to undefined', async () => {
+      l2.get.mockRejectedValue(new Error('L2 get failed'));
+
+      await expect(service.get('key1')).rejects.toThrow('L2 get failed');
+
+      // In a production system, we might want this to fall back gracefully
+      // rather than throw, but current implementation propagates L2 errors
+    });
+
+    it('L2 delete failure does not prevent L1 delete', async () => {
+      await service.set('key1', 'value1');
+
+      l2.del.mockRejectedValue(new Error('L2 del failed'));
+
+      await expect(service.del('key1')).rejects.toThrow('L2 del failed');
+
+      // Current implementation doesn't handle L2 failures gracefully
+      // In production, we might want to continue with L1 operations
+    });
+  });
+});

--- a/src/infrastructure/cache-manager/__tests__/cached-method.decorator.spec.ts
+++ b/src/infrastructure/cache-manager/__tests__/cached-method.decorator.spec.ts
@@ -1,0 +1,412 @@
+import { CachedMethod } from '../method-cache.decorator';
+import { registerCacheService, getCacheServiceOrThrow } from '../cache.locator';
+import { CacheService } from '../services/cache.service';
+import { InMemoryAdapter } from '../adapters/in-memory.adapter';
+import { NoopCacheService } from '../services/noop-cache.service';
+import { CacheAdapter } from '../adapters/cache.adapter';
+
+// Mock L2 adapter for testing
+const createMockL2Adapter = (): jest.Mocked<CacheAdapter> => {
+  const storage = new Map<string, any>();
+
+  return {
+    get: jest.fn().mockImplementation(async (key: string) => storage.get(key)),
+    set: jest.fn().mockImplementation(async (key: string, value: any) => {
+      storage.set(key, value);
+    }),
+    del: jest.fn().mockImplementation(async (key: string) => {
+      storage.delete(key);
+    }),
+    delByTags: jest.fn().mockImplementation(async (_tags: string[]) => {
+      // Simple implementation for testing
+      for (const [key] of storage.entries()) {
+        storage.delete(key);
+      }
+    }),
+  };
+};
+
+describe('@CachedMethod', () => {
+  // Test service class with decorated methods
+  class TestService {
+    public callCount = 0;
+
+    @CachedMethod({
+      keyPrefix: 'user',
+      makeKey: (args: [{ id: number }]) => String(args[0].id),
+      makeTags: (args: [{ id: number }]) => [`user:${args[0].id}`],
+      ttlSec: 60,
+    })
+    async getUser(arg: { id: number }): Promise<string> {
+      this.callCount++;
+      return `user:${arg.id}:data`;
+    }
+
+    @CachedMethod({
+      keyPrefix: 'compute',
+      makeKey: (args) => JSON.stringify(args),
+      ttlSec: 30,
+    })
+    async expensiveComputation(
+      a: number,
+      b: string,
+    ): Promise<{ result: string }> {
+      this.callCount++;
+      return { result: `${a}-${b}-computed` };
+    }
+
+    @CachedMethod({
+      keyPrefix: 'noargs',
+    })
+    async getConstantValue(): Promise<string> {
+      this.callCount++;
+      return 'constant';
+    }
+
+    @CachedMethod({
+      keyPrefix: 'tagged',
+      makeTags: ([category]) => [`category:${category}`],
+    })
+    async getByCategory(category: string): Promise<string[]> {
+      this.callCount++;
+      return [`item1-${category}`, `item2-${category}`];
+    }
+  }
+
+  let testService: TestService;
+
+  beforeEach(() => {
+    testService = new TestService();
+  });
+
+  afterEach(() => {
+    // Reset call counters and cache state between tests
+    testService.callCount = 0;
+  });
+
+  describe('when cache is disabled (NoopCacheService)', () => {
+    beforeEach(() => {
+      registerCacheService(new NoopCacheService());
+    });
+
+    it('always executes method (no caching)', async () => {
+      const result1 = await testService.getUser({ id: 1 });
+      const result2 = await testService.getUser({ id: 1 });
+
+      expect(result1).toBe('user:1:data');
+      expect(result2).toBe('user:1:data');
+      expect(testService.callCount).toBe(2); // called both times
+    });
+
+    it('works with multiple arguments', async () => {
+      const result1 = await testService.expensiveComputation(42, 'test');
+      const result2 = await testService.expensiveComputation(42, 'test');
+
+      expect(result1).toEqual({ result: '42-test-computed' });
+      expect(result2).toEqual({ result: '42-test-computed' });
+      expect(testService.callCount).toBe(2); // no caching
+    });
+  });
+
+  describe('with L1 cache (InMemoryAdapter)', () => {
+    beforeEach(() => {
+      const l1 = new InMemoryAdapter();
+      registerCacheService(new CacheService(l1));
+    });
+
+    it('caches result on second call', async () => {
+      const result1 = await testService.getUser({ id: 1 });
+      const result2 = await testService.getUser({ id: 1 });
+
+      expect(result1).toBe('user:1:data');
+      expect(result2).toBe('user:1:data');
+      expect(testService.callCount).toBe(1); // only called once
+    });
+
+    it('makeKey produces distinct keys for different args', async () => {
+      const result1 = await testService.getUser({ id: 1 });
+      const result2 = await testService.getUser({ id: 2 });
+      const result3 = await testService.getUser({ id: 1 }); // same as first
+
+      expect(result1).toBe('user:1:data');
+      expect(result2).toBe('user:2:data');
+      expect(result3).toBe('user:1:data');
+      expect(testService.callCount).toBe(2); // id:1 cached, id:2 new
+    });
+
+    it('makeTags enables tag-based invalidation', async () => {
+      // Cache user 1
+      const result1 = await testService.getUser({ id: 1 });
+      expect(result1).toBe('user:1:data');
+      expect(testService.callCount).toBe(1);
+
+      // Invalidate by tag
+      const cache = getCacheServiceOrThrow();
+      await cache.delByTags(['user:1']);
+
+      // Should execute again
+      const result2 = await testService.getUser({ id: 1 });
+      expect(result2).toBe('user:1:data');
+      expect(testService.callCount).toBe(2);
+    });
+
+    it('handles methods with multiple arguments', async () => {
+      const result1 = await testService.expensiveComputation(42, 'test');
+      const result2 = await testService.expensiveComputation(42, 'test');
+      const result3 = await testService.expensiveComputation(43, 'test'); // different args
+
+      expect(result1).toEqual({ result: '42-test-computed' });
+      expect(result2).toEqual({ result: '42-test-computed' });
+      expect(result3).toEqual({ result: '43-test-computed' });
+      expect(testService.callCount).toBe(2); // first two cached together
+    });
+
+    it('handles methods with no arguments', async () => {
+      const result1 = await testService.getConstantValue();
+      const result2 = await testService.getConstantValue();
+
+      expect(result1).toBe('constant');
+      expect(result2).toBe('constant');
+      expect(testService.callCount).toBe(1);
+    });
+
+    it('default makeKey uses JSON.stringify', async () => {
+      // This tests the default key generation
+      await testService.expensiveComputation(42, 'test');
+      await testService.expensiveComputation(42, 'test');
+
+      expect(testService.callCount).toBe(1);
+
+      // Key should be based on JSON.stringify([42, 'test'])
+      const cache = getCacheServiceOrThrow();
+      const cachedValue = await cache.get(
+        'compute:' + JSON.stringify([42, 'test']),
+      );
+      expect(cachedValue).toEqual({ result: '42-test-computed' });
+    });
+
+    it('tag-based operations work with complex scenarios', async () => {
+      // Cache items for different categories
+      await testService.getByCategory('electronics');
+      await testService.getByCategory('books');
+      expect(testService.callCount).toBe(2);
+
+      // Cache hits
+      await testService.getByCategory('electronics');
+      await testService.getByCategory('books');
+      expect(testService.callCount).toBe(2); // no additional calls
+
+      // Invalidate one category
+      const cache = getCacheServiceOrThrow();
+      await cache.delByTags(['category:electronics']);
+
+      // Electronics should be recomputed, books should be cached
+      await testService.getByCategory('electronics');
+      await testService.getByCategory('books');
+      expect(testService.callCount).toBe(3); // one additional call for electronics
+    });
+  });
+
+  describe('with L1 + L2 cache', () => {
+    let l2: jest.Mocked<CacheAdapter>;
+
+    beforeEach(() => {
+      const l1 = new InMemoryAdapter();
+      l2 = createMockL2Adapter();
+      registerCacheService(new CacheService(l1, l2));
+    });
+
+    it('hydrates from L2 when L1 misses', async () => {
+      // Simulate value only in L2
+      l2.get.mockResolvedValueOnce('user:1:data');
+
+      const result = await testService.getUser({ id: 1 });
+      expect(result).toBe('user:1:data');
+      expect(testService.callCount).toBe(0); // served from L2, no method execution
+
+      // Second call should hit L1 (now hydrated)
+      l2.get.mockClear();
+      const result2 = await testService.getUser({ id: 1 });
+      expect(result2).toBe('user:1:data');
+      expect(testService.callCount).toBe(0); // still no method execution
+      expect(l2.get).not.toHaveBeenCalled(); // L1 hit
+    });
+
+    it('writes to both L1 and L2 on cache miss', async () => {
+      const result = await testService.getUser({ id: 1 });
+
+      expect(result).toBe('user:1:data');
+      expect(testService.callCount).toBe(1);
+
+      // L2 should have been written to
+      expect(l2.set).toHaveBeenCalledWith('user:1', 'user:1:data', {
+        ttlSec: 60,
+        tags: ['user:1'],
+      });
+    });
+
+    it('tag invalidation clears both layers', async () => {
+      // Cache a value
+      await testService.getUser({ id: 1 });
+
+      // Invalidate by tag
+      const cache = getCacheServiceOrThrow();
+      await cache.delByTags(['user:1']);
+
+      // Should have called L2 delByTags
+      expect(l2.delByTags).toHaveBeenCalledWith(['user:1']);
+
+      // Next call should execute method again
+      const result = await testService.getUser({ id: 1 });
+      expect(result).toBe('user:1:data');
+      expect(testService.callCount).toBe(2); // called twice
+    });
+  });
+
+  describe('decorator configuration', () => {
+    class ConfigTestService {
+      public callCount = 0;
+
+      @CachedMethod({
+        keyPrefix: 'config-test',
+        makeKey: (args) => `custom-${args[0]}`,
+        makeTags: (args, result) => [`result:${result?.length || 0}`],
+        ttlSec: 120,
+      })
+      async getItems(filter: string): Promise<string[]> {
+        this.callCount++;
+        return [`item-${filter}-1`, `item-${filter}-2`];
+      }
+
+      // Test default values
+      @CachedMethod({
+        keyPrefix: 'defaults',
+      })
+      async getWithDefaults(): Promise<string> {
+        this.callCount++;
+        return 'default-result';
+      }
+    }
+
+    let configService: ConfigTestService;
+
+    beforeEach(() => {
+      configService = new ConfigTestService();
+      const l1 = new InMemoryAdapter();
+      registerCacheService(new CacheService(l1));
+    });
+
+    it('uses custom makeKey function', async () => {
+      await configService.getItems('test');
+
+      const cache = getCacheServiceOrThrow();
+      const cachedValue = await cache.get('config-test:custom-test');
+      expect(cachedValue).toEqual(['item-test-1', 'item-test-2']);
+    });
+
+    it('uses makeTags with result parameter', async () => {
+      await configService.getItems('test');
+
+      const cache = getCacheServiceOrThrow();
+
+      // Tag should be based on result length (2 items)
+      await cache.delByTags(['result:2']);
+
+      // Should cause re-execution
+      await configService.getItems('test');
+      expect(configService.callCount).toBe(2);
+    });
+
+    it('uses custom TTL', async () => {
+      // This is hard to test without time manipulation, but we can verify the TTL is passed
+      const cache = getCacheServiceOrThrow();
+      const setSpy = jest.spyOn(cache, 'set');
+
+      await configService.getItems('test');
+
+      expect(setSpy).toHaveBeenCalledWith(
+        'config-test:custom-test',
+        ['item-test-1', 'item-test-2'],
+        { ttlSec: 120, tags: ['result:2'] },
+      );
+
+      setSpy.mockRestore();
+    });
+
+    it('uses default values when not specified', async () => {
+      const cache = getCacheServiceOrThrow();
+      const setSpy = jest.spyOn(cache, 'set');
+
+      await configService.getWithDefaults();
+
+      expect(setSpy).toHaveBeenCalledWith(
+        'defaults:[]',
+        'default-result',
+        { ttlSec: 3600, tags: [] }, // default TTL and empty tags
+      );
+
+      setSpy.mockRestore();
+    });
+  });
+
+  describe('error scenarios', () => {
+    beforeEach(() => {
+      const l1 = new InMemoryAdapter();
+      registerCacheService(new CacheService(l1));
+    });
+
+    it('method errors are not cached', async () => {
+      class ErrorService {
+        public callCount = 0;
+
+        @CachedMethod({ keyPrefix: 'error' })
+        async maybeError(shouldError: boolean): Promise<string> {
+          this.callCount++;
+          if (shouldError) {
+            throw new Error('Method failed');
+          }
+          return 'success';
+        }
+      }
+
+      const service = new ErrorService();
+
+      // First call fails
+      await expect(service.maybeError(true)).rejects.toThrow('Method failed');
+      expect(service.callCount).toBe(1);
+
+      // Second call should still execute (error not cached)
+      const result = await service.maybeError(false);
+      expect(result).toBe('success');
+      expect(service.callCount).toBe(2);
+
+      // Third call should use cached success result
+      const result2 = await service.maybeError(false);
+      expect(result2).toBe('success');
+      expect(service.callCount).toBe(2); // no additional call
+    });
+
+    it('throws error when cache service not registered', async () => {
+      // Clear the cache service
+      const cache = getCacheServiceOrThrow();
+      registerCacheService(undefined as any);
+
+      class UnregisteredService {
+        @CachedMethod({ keyPrefix: 'unregistered' })
+        async test(): Promise<string> {
+          return 'test';
+        }
+      }
+
+      const service = new UnregisteredService();
+
+      // Should throw when trying to get cache service
+      await expect(service.test()).rejects.toThrow(
+        'CacheService is not registered yet',
+      );
+
+      // Restore cache service
+      registerCacheService(cache);
+    });
+  });
+});

--- a/src/infrastructure/cache-manager/__tests__/in-memory.adapter.spec.ts
+++ b/src/infrastructure/cache-manager/__tests__/in-memory.adapter.spec.ts
@@ -180,5 +180,20 @@ describe('InMemoryAdapter', () => {
       await adapter.delByTags([]);
       expect(await adapter.get('key1')).toBe('value1'); // still exists
     });
+
+    it('properly cleans up tag index when deleting by tags', async () => {
+      // Test case for key with multiple tags - ensures no hanging refs
+      await adapter.set('key1', 'value1', { tags: ['tag1', 'tag2'] });
+
+      // Delete by first tag
+      await adapter.delByTags(['tag1']);
+      expect(await adapter.get('key1')).toBeUndefined();
+
+      // Delete by second tag should not cause issues (no hanging refs)
+      await expect(adapter.delByTags(['tag2'])).resolves.not.toThrow();
+
+      // Verify clean state
+      expect(await adapter.get('key1')).toBeUndefined();
+    });
   });
 });

--- a/src/infrastructure/cache-manager/__tests__/in-memory.adapter.spec.ts
+++ b/src/infrastructure/cache-manager/__tests__/in-memory.adapter.spec.ts
@@ -1,0 +1,184 @@
+import { InMemoryAdapter } from '../adapters/in-memory.adapter';
+
+describe('InMemoryAdapter', () => {
+  let adapter: InMemoryAdapter;
+
+  beforeEach(() => {
+    adapter = new InMemoryAdapter();
+  });
+
+  describe('basic set/get/del operations', () => {
+    it('set/get roundtrip', async () => {
+      await adapter.set('key1', 'value1');
+      expect(await adapter.get('key1')).toBe('value1');
+    });
+
+    it('get non-existent key returns undefined', async () => {
+      expect(await adapter.get('nonexistent')).toBeUndefined();
+    });
+
+    it('del removes value', async () => {
+      await adapter.set('key1', 'value1');
+      expect(await adapter.get('key1')).toBe('value1');
+
+      await adapter.del('key1');
+      expect(await adapter.get('key1')).toBeUndefined();
+    });
+
+    it('handles various data types', async () => {
+      await adapter.set('string', 'hello');
+      await adapter.set('number', 42);
+      await adapter.set('boolean', true);
+      await adapter.set('object', { a: 1, b: 'test' });
+      await adapter.set('array', [1, 2, 3]);
+
+      expect(await adapter.get('string')).toBe('hello');
+      expect(await adapter.get('number')).toBe(42);
+      expect(await adapter.get('boolean')).toBe(true);
+      expect(await adapter.get('object')).toEqual({ a: 1, b: 'test' });
+      expect(await adapter.get('array')).toEqual([1, 2, 3]);
+    });
+  });
+
+  describe('tag-based operations', () => {
+    it('set with tags and retrieve normally', async () => {
+      await adapter.set('key1', 'value1', { tags: ['tag1', 'tag2'] });
+      expect(await adapter.get('key1')).toBe('value1');
+    });
+
+    it('delByTags removes all keys with specified tags', async () => {
+      await adapter.set('key1', 'value1', { tags: ['tag1', 'tag2'] });
+      await adapter.set('key2', 'value2', { tags: ['tag1'] });
+      await adapter.set('key3', 'value3', { tags: ['tag3'] });
+      await adapter.set('key4', 'value4'); // no tags
+
+      // Delete by tag1 - should remove key1 and key2
+      await adapter.delByTags(['tag1']);
+
+      expect(await adapter.get('key1')).toBeUndefined();
+      expect(await adapter.get('key2')).toBeUndefined();
+      expect(await adapter.get('key3')).toBe('value3'); // still exists
+      expect(await adapter.get('key4')).toBe('value4'); // still exists
+    });
+
+    it('delByTags with multiple tags removes keys with any of the tags', async () => {
+      await adapter.set('key1', 'value1', { tags: ['tag1'] });
+      await adapter.set('key2', 'value2', { tags: ['tag2'] });
+      await adapter.set('key3', 'value3', { tags: ['tag3'] });
+
+      await adapter.delByTags(['tag1', 'tag2']);
+
+      expect(await adapter.get('key1')).toBeUndefined();
+      expect(await adapter.get('key2')).toBeUndefined();
+      expect(await adapter.get('key3')).toBe('value3'); // still exists
+    });
+
+    it('delByTags with non-existent tag does nothing', async () => {
+      await adapter.set('key1', 'value1', { tags: ['tag1'] });
+
+      await adapter.delByTags(['nonexistent-tag']);
+
+      expect(await adapter.get('key1')).toBe('value1'); // still exists
+    });
+
+    it('handles overlapping tags correctly', async () => {
+      await adapter.set('key1', 'value1', { tags: ['tag1', 'tag2'] });
+      await adapter.set('key2', 'value2', { tags: ['tag2', 'tag3'] });
+
+      await adapter.delByTags(['tag2']);
+
+      expect(await adapter.get('key1')).toBeUndefined(); // removed
+      expect(await adapter.get('key2')).toBeUndefined(); // removed
+    });
+  });
+
+  describe('TTL (time-to-live) support', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('respects TTL expiration', async () => {
+      const ttlSec = 5;
+      await adapter.set('key1', 'value1', { ttlSec });
+
+      // Initially should be accessible
+      expect(await adapter.get('key1')).toBe('value1');
+
+      // Advance time by 4 seconds - still valid
+      jest.advanceTimersByTime(4000);
+      expect(await adapter.get('key1')).toBe('value1');
+
+      // Advance time by 2 more seconds (6 total) - now expired
+      jest.advanceTimersByTime(2000);
+      expect(await adapter.get('key1')).toBeUndefined();
+    });
+
+    it('expired entries are cleaned up on access', async () => {
+      const ttlSec = 1;
+      await adapter.set('key1', 'value1', { ttlSec });
+
+      // Advance past expiration
+      jest.advanceTimersByTime(2000);
+
+      // First get should return undefined and clean up
+      expect(await adapter.get('key1')).toBeUndefined();
+
+      // Verify it's actually removed (not just expired but still in cache)
+      expect(await adapter.get('key1')).toBeUndefined();
+    });
+
+    it('entries without TTL never expire', async () => {
+      await adapter.set('key1', 'value1'); // no TTL
+
+      // Advance time significantly
+      jest.advanceTimersByTime(1000000);
+
+      expect(await adapter.get('key1')).toBe('value1');
+    });
+
+    it('TTL with tags works correctly', async () => {
+      await adapter.set('key1', 'value1', { ttlSec: 1, tags: ['tag1'] });
+
+      // Before expiration, delByTags should work
+      await adapter.delByTags(['tag1']);
+      expect(await adapter.get('key1')).toBeUndefined();
+    });
+  });
+
+  describe('complex scenarios', () => {
+    it('handles key overwrite correctly', async () => {
+      await adapter.set('key1', 'value1', { tags: ['tag1'] });
+      await adapter.set('key1', 'value2', { tags: ['tag2'] }); // overwrite
+
+      expect(await adapter.get('key1')).toBe('value2');
+
+      // Note: Current implementation doesn't clean up old tag references on overwrite
+      // This is a known limitation - deleting by old tag will still remove the key
+      await adapter.delByTags(['tag2']);
+      expect(await adapter.get('key1')).toBeUndefined();
+    });
+
+    it('del cleans up tag references', async () => {
+      await adapter.set('key1', 'value1', { tags: ['tag1'] });
+      await adapter.set('key2', 'value2', { tags: ['tag1'] });
+
+      await adapter.del('key1');
+
+      // key2 should still be deletable by tag
+      await adapter.delByTags(['tag1']);
+      expect(await adapter.get('key2')).toBeUndefined();
+    });
+
+    it('handles empty tags array', async () => {
+      await adapter.set('key1', 'value1', { tags: [] });
+      expect(await adapter.get('key1')).toBe('value1');
+
+      await adapter.delByTags([]);
+      expect(await adapter.get('key1')).toBe('value1'); // still exists
+    });
+  });
+});

--- a/src/infrastructure/cache-manager/__tests__/locator-bootstrapper.spec.ts
+++ b/src/infrastructure/cache-manager/__tests__/locator-bootstrapper.spec.ts
@@ -1,0 +1,98 @@
+import { Test } from '@nestjs/testing';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { getCacheServiceOrThrow, registerCacheService } from '../cache.locator';
+import { RevisiumCacheModule } from '../revisium-cache.module';
+import { CACHE_SERVICE } from '../services/cache.tokens';
+import { NoopCacheService } from '../services/noop-cache.service';
+import { CacheService } from '../services/cache.service';
+import { InMemoryAdapter } from '../adapters/in-memory.adapter';
+
+describe('CacheBootstrapper and Locator', () => {
+  beforeEach(() => {
+    // Reset the global locator state before each test
+    // We need to clear the internal _cacheService variable
+    // Since it's not exported, we'll use a try/catch to detect if it's set
+    try {
+      getCacheServiceOrThrow();
+    } catch {
+      // Good, it's not set
+    }
+  });
+
+  describe('getCacheServiceOrThrow before module init', () => {
+    it('throws clear error when not initialized', () => {
+      expect(() => getCacheServiceOrThrow()).toThrow(
+        'CacheService is not registered yet. Ensure CacheModule.forRoot() is imported and module initialized before using @CachedMethod.',
+      );
+    });
+  });
+
+  describe('after module initialization', () => {
+    it('returns NoopCacheService instance when disabled', async () => {
+      const moduleRef = await Test.createTestingModule({
+        imports: [
+          ConfigModule.forRoot({
+            isGlobal: true,
+            load: [() => ({})], // disabled
+          }),
+          RevisiumCacheModule.forRootAsync(),
+        ],
+      })
+        .overrideProvider(ConfigService)
+        .useValue({
+          get: (_key: string) => undefined, // no config values - disabled
+        })
+        .compile();
+
+      // Module initialization should trigger bootstrapper
+      await moduleRef.init();
+
+      const serviceFromDI = moduleRef.get(CACHE_SERVICE);
+      const serviceFromLocator = getCacheServiceOrThrow();
+
+      expect(serviceFromDI).toBeInstanceOf(NoopCacheService);
+      expect(serviceFromLocator).toBe(serviceFromDI); // pointer equality
+    });
+
+    it('returns CacheService instance when enabled', async () => {
+      const moduleRef = await Test.createTestingModule({
+        imports: [
+          ConfigModule.forRoot({
+            isGlobal: true,
+            load: [() => ({ EXPERIMENTAL_CACHE: '1' })],
+          }),
+          RevisiumCacheModule.forRootAsync(),
+        ],
+      }).compile();
+
+      await moduleRef.init();
+
+      const serviceFromDI = moduleRef.get(CACHE_SERVICE);
+      const serviceFromLocator = getCacheServiceOrThrow();
+
+      expect(serviceFromDI).toBeInstanceOf(CacheService);
+      expect(serviceFromLocator).toBe(serviceFromDI); // pointer equality
+    });
+  });
+
+  describe('manual registration (for testing)', () => {
+    it('allows manual registration for testing purposes', () => {
+      const mockService = new NoopCacheService();
+      registerCacheService(mockService);
+
+      const retrieved = getCacheServiceOrThrow();
+      expect(retrieved).toBe(mockService);
+    });
+
+    it('can replace service via registerCacheService', () => {
+      const service1 = new NoopCacheService();
+      const service2 = new CacheService(new InMemoryAdapter());
+
+      registerCacheService(service1);
+      expect(getCacheServiceOrThrow()).toBe(service1);
+
+      registerCacheService(service2);
+      expect(getCacheServiceOrThrow()).toBe(service2);
+    });
+  });
+});

--- a/src/infrastructure/cache-manager/__tests__/module-modes.spec.ts
+++ b/src/infrastructure/cache-manager/__tests__/module-modes.spec.ts
@@ -131,7 +131,7 @@ describe('RevisiumCacheModule modes', () => {
     expect(svc).toBeInstanceOf(CacheService);
     expect(errorSpy).toHaveBeenCalledWith(
       expect.stringContaining('Redis connect failed'),
-      expect.anything(),
+      expect.any(String), // stack string
     );
     // Service should still be created (fallback to L1 only)
     // but Redis error was logged

--- a/src/infrastructure/cache-manager/__tests__/module-modes.spec.ts
+++ b/src/infrastructure/cache-manager/__tests__/module-modes.spec.ts
@@ -1,0 +1,211 @@
+import { Test } from '@nestjs/testing';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { Logger } from '@nestjs/common';
+import { RevisiumCacheModule } from '../revisium-cache.module';
+import { CACHE_SERVICE } from '../services/cache.tokens';
+import { NoopCacheService } from '../services/noop-cache.service';
+import { CacheService } from '../services/cache.service';
+
+describe('RevisiumCacheModule modes', () => {
+  let logSpy: jest.SpyInstance,
+    warnSpy: jest.SpyInstance,
+    errorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    logSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation(() => {});
+    warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => {});
+    errorSpy = jest
+      .spyOn(Logger.prototype, 'error')
+      .mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('disabled (default) → Noop + warn', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        ConfigModule.forRoot({
+          isGlobal: true,
+          load: [() => ({})], // no flags
+        }),
+        RevisiumCacheModule.forRootAsync(),
+      ],
+    })
+      .overrideProvider(ConfigService)
+      .useValue({
+        get: (_key: string) => undefined, // no config values
+      })
+      .compile();
+
+    // Initialize the module to trigger the factory
+    await moduleRef.init();
+
+    const svc = moduleRef.get(CACHE_SERVICE);
+    expect(svc).toBeInstanceOf(NoopCacheService);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Cache disabled'),
+    );
+  });
+
+  it('L1 only → CacheService + log', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        ConfigModule.forRoot({
+          isGlobal: true,
+          load: [() => ({ EXPERIMENTAL_CACHE: '1' })],
+        }),
+        RevisiumCacheModule.forRootAsync(),
+      ],
+    })
+      .overrideProvider(ConfigService)
+      .useValue({
+        get: (key: string) => {
+          if (key === 'EXPERIMENTAL_CACHE') return '1';
+          if (key === 'EXPERIMENTAL_CACHE_L2_REDIS_URL') return null;
+          return undefined;
+        },
+      })
+      .compile();
+
+    await moduleRef.init();
+
+    const svc = moduleRef.get(CACHE_SERVICE);
+    expect(svc).toBeInstanceOf(CacheService);
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('L1 only'));
+  });
+
+  it('L1+L2 attempt with Redis URL → would connect if Redis available', async () => {
+    // Note: This test assumes Redis is NOT running, so it will fallback
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        ConfigModule.forRoot({
+          isGlobal: true,
+          load: [
+            () => ({
+              EXPERIMENTAL_CACHE: 'true',
+              EXPERIMENTAL_CACHE_L2_REDIS_URL: 'redis://localhost:6379/0',
+            }),
+          ],
+        }),
+        RevisiumCacheModule.forRootAsync(),
+      ],
+    }).compile();
+
+    const svc = moduleRef.get(CACHE_SERVICE);
+    expect(svc).toBeInstanceOf(CacheService);
+    // This will either log L1+L2 success or error+L1 fallback
+    expect(logSpy).toHaveBeenCalled();
+  });
+
+  it('Redis failure → fallback to L1 + error', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        ConfigModule.forRoot({
+          isGlobal: true,
+          load: [
+            () => ({
+              EXPERIMENTAL_CACHE: '1',
+              EXPERIMENTAL_CACHE_L2_REDIS_URL: 'redis://127.0.0.1:0/0', // invalid port
+            }),
+          ],
+        }),
+        RevisiumCacheModule.forRootAsync(),
+      ],
+    })
+      .overrideProvider(ConfigService)
+      .useValue({
+        get: (key: string) => {
+          if (key === 'EXPERIMENTAL_CACHE') return '1';
+          if (key === 'EXPERIMENTAL_CACHE_L2_REDIS_URL')
+            return 'redis://127.0.0.1:0/0';
+          return undefined;
+        },
+      })
+      .compile();
+
+    await moduleRef.init();
+
+    const svc = moduleRef.get(CACHE_SERVICE);
+    expect(svc).toBeInstanceOf(CacheService);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Redis connect failed'),
+      expect.anything(),
+    );
+    // Service should still be created (fallback to L1 only)
+    // but Redis error was logged
+  });
+
+  describe('parseBool cases via config', () => {
+    const testCases = [
+      { input: '1', expected: true },
+      { input: 'true', expected: true },
+      { input: 'TRUE', expected: true },
+      { input: 'on', expected: true },
+      { input: 'ON', expected: true },
+      { input: 'yes', expected: true },
+      { input: 'YES', expected: true },
+      { input: '0', expected: false },
+      { input: 'false', expected: false },
+      { input: 'off', expected: false },
+      { input: 'no', expected: false },
+      { input: 'random', expected: false },
+      { input: '', expected: false },
+    ];
+
+    testCases.forEach(({ input, expected }) => {
+      it(`parseBool("${input}") → ${expected} (via cache enablement)`, async () => {
+        const moduleRef = await Test.createTestingModule({
+          imports: [
+            ConfigModule.forRoot({
+              isGlobal: true,
+              load: [() => ({ EXPERIMENTAL_CACHE: input })],
+            }),
+            RevisiumCacheModule.forRootAsync(),
+          ],
+        })
+          .overrideProvider(ConfigService)
+          .useValue({
+            get: (key: string) => {
+              if (key === 'EXPERIMENTAL_CACHE') return input;
+              if (key === 'EXPERIMENTAL_CACHE_L2_REDIS_URL') return null;
+              return undefined;
+            },
+          })
+          .compile();
+
+        await moduleRef.init();
+
+        const svc = moduleRef.get(CACHE_SERVICE);
+        if (expected) {
+          expect(svc).toBeInstanceOf(CacheService);
+        } else {
+          expect(svc).toBeInstanceOf(NoopCacheService);
+        }
+      });
+    });
+
+    it('parseBool(undefined) → false (no EXPERIMENTAL_CACHE)', async () => {
+      const moduleRef = await Test.createTestingModule({
+        imports: [
+          ConfigModule.forRoot({
+            isGlobal: true,
+            load: [() => ({})], // no EXPERIMENTAL_CACHE
+          }),
+          RevisiumCacheModule.forRootAsync(),
+        ],
+      })
+        .overrideProvider(ConfigService)
+        .useValue({
+          get: (_key: string) => undefined, // no config values
+        })
+        .compile();
+
+      await moduleRef.init();
+
+      const svc = moduleRef.get(CACHE_SERVICE);
+      expect(svc).toBeInstanceOf(NoopCacheService);
+    });
+  });
+});

--- a/src/infrastructure/cache-manager/__tests__/redis.adapter.spec.ts
+++ b/src/infrastructure/cache-manager/__tests__/redis.adapter.spec.ts
@@ -1,0 +1,333 @@
+import { RedisAdapter } from '../adapters/redis.adapter';
+import { RedisClientType } from 'redis';
+
+// Mock Redis client for testing
+const createMockRedisClient = (): jest.Mocked<RedisClientType> => {
+  const storage = new Map<string, { value: string; expiry?: number }>();
+  const sets = new Map<string, Set<string>>();
+
+  return {
+    connect: jest.fn().mockResolvedValue(undefined),
+    get: jest.fn().mockImplementation((key: string) => {
+      const entry = storage.get(key);
+      if (!entry) return null;
+      if (entry.expiry && Date.now() > entry.expiry) {
+        storage.delete(key);
+        return null;
+      }
+      return entry.value;
+    }),
+    set: jest
+      .fn()
+      .mockImplementation((key: string, value: string, options?: any) => {
+        const expiry = options?.EX ? Date.now() + options.EX * 1000 : undefined;
+        storage.set(key, { value, expiry });
+        return 'OK';
+      }),
+    del: jest.fn().mockImplementation((...keys: string[]) => {
+      let deleted = 0;
+      keys.forEach((key) => {
+        if (storage.delete(key)) deleted++;
+        if (sets.delete(key)) deleted++;
+      });
+      return deleted;
+    }),
+    sAdd: jest
+      .fn()
+      .mockImplementation((setKey: string, ...values: string[]) => {
+        if (!sets.has(setKey)) {
+          sets.set(setKey, new Set());
+        }
+        const set = sets.get(setKey)!;
+        let added = 0;
+        values.forEach((value) => {
+          if (!set.has(value)) {
+            set.add(value);
+            added++;
+          }
+        });
+        return added;
+      }),
+    sMembers: jest.fn().mockImplementation((setKey: string) => {
+      const set = sets.get(setKey);
+      return set ? Array.from(set) : [];
+    }),
+    multi: jest.fn().mockImplementation(() => {
+      const commands: Array<{ command: string; args: any[] }> = [];
+
+      return {
+        get: jest.fn().mockImplementation((key: string) => {
+          commands.push({ command: 'get', args: [key] });
+          return this;
+        }),
+        set: jest
+          .fn()
+          .mockImplementation((key: string, value: string, options?: any) => {
+            commands.push({ command: 'set', args: [key, value, options] });
+            return this;
+          }),
+        del: jest.fn().mockImplementation((...keys: string[]) => {
+          commands.push({ command: 'del', args: keys });
+          return this;
+        }),
+        sAdd: jest
+          .fn()
+          .mockImplementation((setKey: string, ...values: string[]) => {
+            commands.push({ command: 'sAdd', args: [setKey, ...values] });
+            return this;
+          }),
+        sMembers: jest.fn().mockImplementation((setKey: string) => {
+          commands.push({ command: 'sMembers', args: [setKey] });
+          return this;
+        }),
+        exec: jest.fn().mockImplementation(() => {
+          return commands.map(({ command, args }) => {
+            switch (command) {
+              case 'get': {
+                return storage.get(args[0])?.value || null;
+              }
+              case 'set': {
+                const expiry = args[2]?.EX
+                  ? Date.now() + args[2].EX * 1000
+                  : undefined;
+                storage.set(args[0], { value: args[1], expiry });
+                return 'OK';
+              }
+              case 'del': {
+                let deleted = 0;
+                args.forEach((key: string) => {
+                  if (storage.delete(key)) deleted++;
+                  if (sets.delete(key)) deleted++;
+                });
+                return deleted;
+              }
+              case 'sAdd': {
+                const [setKey, ...values] = args;
+                if (!sets.has(setKey)) {
+                  sets.set(setKey, new Set());
+                }
+                const set = sets.get(setKey)!;
+                let added = 0;
+                values.forEach((value: string) => {
+                  if (!set.has(value)) {
+                    set.add(value);
+                    added++;
+                  }
+                });
+                return added;
+              }
+              case 'sMembers': {
+                const memberSet = sets.get(args[0]);
+                return memberSet ? Array.from(memberSet) : [];
+              }
+              default:
+                return null;
+            }
+          });
+        }),
+      };
+    }),
+    ttl: jest.fn().mockImplementation((key: string) => {
+      const entry = storage.get(key);
+      if (!entry || !entry.expiry) return -1; // no expiry
+      const ttl = Math.ceil((entry.expiry - Date.now()) / 1000);
+      return ttl > 0 ? ttl : -2; // -2 means expired
+    }),
+  } as any;
+};
+
+describe('RedisAdapter', () => {
+  let mockClient: jest.Mocked<RedisClientType>;
+  let adapter: RedisAdapter;
+
+  beforeEach(() => {
+    mockClient = createMockRedisClient();
+    adapter = new RedisAdapter(mockClient);
+  });
+
+  describe('static connect', () => {
+    it('creates client and connects', async () => {
+      const mockCreate = jest.fn().mockReturnValue(mockClient);
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const originalCreateClient = require('redis').createClient;
+
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      require('redis').createClient = mockCreate;
+
+      try {
+        const result = await RedisAdapter.connect('redis://localhost:6379');
+
+        expect(mockCreate).toHaveBeenCalledWith({
+          url: 'redis://localhost:6379',
+        });
+        expect(mockClient.connect).toHaveBeenCalled();
+        expect(result).toBeInstanceOf(RedisAdapter);
+      } finally {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        require('redis').createClient = originalCreateClient;
+      }
+    });
+  });
+
+  describe('basic set/get/del operations', () => {
+    it('set/get roundtrip with JSON serialization', async () => {
+      await adapter.set('key1', { data: 'value1', num: 42 });
+
+      const result = await adapter.get('key1');
+      expect(result).toEqual({ data: 'value1', num: 42 });
+
+      expect(mockClient.set).toHaveBeenCalledWith(
+        'key1',
+        '{"data":"value1","num":42}',
+      );
+    });
+
+    it('get non-existent key returns undefined', async () => {
+      const result = await adapter.get('nonexistent');
+      expect(result).toBeUndefined();
+    });
+
+    it('del removes key', async () => {
+      await adapter.set('key1', 'value1');
+      await adapter.del('key1');
+
+      expect(mockClient.del).toHaveBeenCalledWith('key1');
+    });
+
+    it('handles various data types', async () => {
+      await adapter.set('string', 'hello');
+      await adapter.set('number', 42);
+      await adapter.set('boolean', true);
+      await adapter.set('object', { a: 1, b: 'test' });
+      await adapter.set('array', [1, 2, 3]);
+
+      expect(await adapter.get('string')).toBe('hello');
+      expect(await adapter.get('number')).toBe(42);
+      expect(await adapter.get('boolean')).toBe(true);
+      expect(await adapter.get('object')).toEqual({ a: 1, b: 'test' });
+      expect(await adapter.get('array')).toEqual([1, 2, 3]);
+    });
+  });
+
+  describe('TTL support', () => {
+    it('sets TTL when ttlSec provided', async () => {
+      await adapter.set('key1', 'value1', { ttlSec: 60 });
+
+      expect(mockClient.set).toHaveBeenCalledWith('key1', '"value1"', {
+        EX: 60,
+      });
+    });
+
+    it('does not set TTL when ttlSec not provided', async () => {
+      await adapter.set('key1', 'value1');
+
+      expect(mockClient.set).toHaveBeenCalledWith('key1', '"value1"');
+    });
+
+    it('can verify TTL is set (if real Redis)', async () => {
+      // This test would work with real Redis to verify TTL > 0
+      await adapter.set('key1', 'value1', { ttlSec: 60 });
+
+      // With mock, we can at least verify the call was made correctly
+      expect(mockClient.set).toHaveBeenCalledWith('key1', '"value1"', {
+        EX: 60,
+      });
+    });
+  });
+
+  describe('tag-based operations', () => {
+    it('set with tags populates tag sets', async () => {
+      await adapter.set('key1', 'value1', { tags: ['tag1', 'tag2'] });
+
+      expect(mockClient.multi).toHaveBeenCalled();
+      // The multi operations would add keys to tag:tag1 and tag:tag2 sets
+    });
+
+    it('delByTags removes keys and clears tag sets', async () => {
+      // Setup: add some keys with tags
+      await adapter.set('key1', 'value1', { tags: ['tag1'] });
+      await adapter.set('key2', 'value2', { tags: ['tag1', 'tag2'] });
+
+      // Execute: delete by tags
+      await adapter.delByTags(['tag1']);
+
+      expect(mockClient.multi).toHaveBeenCalled();
+      // Multi would: 1) get keys from tag sets, 2) delete those keys, 3) delete tag sets
+    });
+
+    it('getKeysByTags (private method) aggregates keys from multiple tags', async () => {
+      // This tests the private method indirectly through delByTags
+      await adapter.set('key1', 'value1', { tags: ['tag1'] });
+      await adapter.set('key2', 'value2', { tags: ['tag2'] });
+      await adapter.set('key3', 'value3', { tags: ['tag1', 'tag2'] });
+
+      await adapter.delByTags(['tag1', 'tag2']);
+
+      // Should have gathered keys from both tag sets
+      expect(mockClient.multi).toHaveBeenCalled();
+    });
+
+    it('handles empty tags in delByTags', async () => {
+      await adapter.delByTags([]);
+
+      // Should still execute multi but with no operations
+      expect(mockClient.multi).toHaveBeenCalled();
+    });
+
+    it('handles non-existent tags gracefully', async () => {
+      await adapter.delByTags(['nonexistent-tag']);
+
+      // Should not error, just execute empty operations
+      expect(mockClient.multi).toHaveBeenCalled();
+    });
+  });
+
+  describe('complex scenarios', () => {
+    it('set with both TTL and tags', async () => {
+      await adapter.set('key1', 'value1', {
+        ttlSec: 30,
+        tags: ['tag1', 'tag2'],
+      });
+
+      expect(mockClient.set).toHaveBeenCalledWith('key1', '"value1"', {
+        EX: 30,
+      });
+      expect(mockClient.multi).toHaveBeenCalled();
+    });
+
+    it('delByTags removes all keys with specified tags', async () => {
+      // This is more of an integration test that would work with real Redis
+      await adapter.set('key1', 'value1', { tags: ['tag1'] });
+      await adapter.set('key2', 'value2', { tags: ['tag1'] });
+      await adapter.set('key3', 'value3', { tags: ['tag2'] });
+
+      await adapter.delByTags(['tag1']);
+
+      // With real Redis, key1 and key2 would be deleted, key3 would remain
+      expect(mockClient.multi).toHaveBeenCalled();
+    });
+
+    it('tag operations use correct tag set naming', async () => {
+      await adapter.set('key1', 'value1', { tags: ['user:123'] });
+
+      // Should create set with name "tag:user:123"
+      expect(mockClient.multi).toHaveBeenCalled();
+    });
+  });
+
+  describe('error handling', () => {
+    it('handles Redis connection errors gracefully', async () => {
+      mockClient.get.mockRejectedValue(new Error('Redis connection lost'));
+
+      await expect(adapter.get('key1')).rejects.toThrow(
+        'Redis connection lost',
+      );
+    });
+
+    it('handles invalid JSON in get', async () => {
+      mockClient.get.mockResolvedValue('invalid-json{');
+
+      await expect(adapter.get('key1')).rejects.toThrow();
+    });
+  });
+});

--- a/src/infrastructure/cache-manager/adapters/cache.adapter.ts
+++ b/src/infrastructure/cache-manager/adapters/cache.adapter.ts
@@ -7,4 +7,8 @@ export interface CacheAdapter {
   ): Promise<void>;
   del(key: string): Promise<void>;
   delByTags(tags: string[]): Promise<void>;
+
+  getWithMeta?<T>(
+    key: string,
+  ): Promise<{ value: T; ttlSec?: number; tags?: string[] } | undefined>;
 }

--- a/src/infrastructure/cache-manager/adapters/cache.adapter.ts
+++ b/src/infrastructure/cache-manager/adapters/cache.adapter.ts
@@ -1,0 +1,10 @@
+export interface CacheAdapter {
+  get<T>(key: string): Promise<T | undefined>;
+  set<T>(
+    key: string,
+    value: T,
+    opts?: { ttlSec?: number; tags?: string[] },
+  ): Promise<void>;
+  del(key: string): Promise<void>;
+  delByTags(tags: string[]): Promise<void>;
+}

--- a/src/infrastructure/cache-manager/adapters/in-memory.adapter.ts
+++ b/src/infrastructure/cache-manager/adapters/in-memory.adapter.ts
@@ -63,7 +63,7 @@ export class InMemoryAdapter implements CacheAdapter {
         continue;
       }
 
-      for (const key of keys) {
+      for (const key of Array.from(keys)) {
         this.cache.delete(key);
       }
 

--- a/src/infrastructure/cache-manager/adapters/in-memory.adapter.ts
+++ b/src/infrastructure/cache-manager/adapters/in-memory.adapter.ts
@@ -1,0 +1,73 @@
+import { LRUCache } from 'lru-cache';
+import { CacheAdapter } from './cache.adapter';
+
+type Entry<T> = { value: T; tags?: Set<string>; expiresAt?: number };
+
+export class InMemoryAdapter implements CacheAdapter {
+  private cache = new LRUCache<string, Entry<unknown>>({ max: 5000 });
+  private tagIndex = new Map<string, Set<string>>();
+
+  public async get<T>(key: string): Promise<T | undefined> {
+    const entry = this.cache.get(key);
+
+    if (!entry) {
+      return undefined;
+    }
+
+    if (entry.expiresAt && Date.now() > entry.expiresAt) {
+      await this.del(key);
+      return undefined;
+    }
+
+    return entry.value as T;
+  }
+
+  public async set<T>(
+    key: string,
+    value: T,
+    opts?: { ttlSec?: number; tags?: string[] },
+  ): Promise<void> {
+    const expiresAt = opts?.ttlSec
+      ? Date.now() + opts.ttlSec * 1000
+      : undefined;
+
+    const tags = new Set(opts?.tags ?? []);
+    this.cache.set(key, { value, tags, expiresAt });
+
+    for (const tag of tags) {
+      if (!this.tagIndex.has(tag)) {
+        this.tagIndex.set(tag, new Set());
+      }
+
+      this.tagIndex.get(tag)?.add(key);
+    }
+  }
+
+  public async del(key: string): Promise<void> {
+    const entry = this.cache.get(key);
+
+    if (entry?.tags) {
+      for (const tag of entry.tags) {
+        this.tagIndex.get(tag)?.delete(key);
+      }
+    }
+
+    this.cache.delete(key);
+  }
+
+  public async delByTags(tags: string[]): Promise<void> {
+    for (const tag of tags) {
+      const keys = this.tagIndex.get(tag);
+
+      if (!keys) {
+        continue;
+      }
+
+      for (const key of keys) {
+        this.cache.delete(key);
+      }
+
+      this.tagIndex.delete(tag);
+    }
+  }
+}

--- a/src/infrastructure/cache-manager/adapters/redis.adapter.ts
+++ b/src/infrastructure/cache-manager/adapters/redis.adapter.ts
@@ -1,0 +1,83 @@
+import { createClient, RedisClientType } from 'redis';
+import { CacheAdapter } from './cache.adapter';
+
+export class RedisAdapter implements CacheAdapter {
+  constructor(private readonly redis: RedisClientType) {}
+
+  static async connect(url: string) {
+    const client: RedisClientType = createClient({ url });
+    await client.connect();
+    return new RedisAdapter(client);
+  }
+
+  private tagSet(tag: string) {
+    return `tag:${tag}`;
+  }
+
+  public async get<T>(key: string): Promise<T | undefined> {
+    const raw = await this.redis.get(key);
+    return raw ? (JSON.parse(raw) as T) : undefined;
+  }
+
+  public async set<T>(
+    key: string,
+    value: T,
+    opts?: { ttlSec?: number; tags?: string[] },
+  ): Promise<void> {
+    const raw = JSON.stringify(value);
+
+    if (opts?.ttlSec) {
+      await this.redis.set(key, raw, { EX: opts.ttlSec });
+    } else {
+      await this.redis.set(key, raw);
+    }
+
+    if (opts?.tags?.length) {
+      const multi = this.redis.multi();
+
+      for (const tag of opts.tags) {
+        multi.sAdd(this.tagSet(tag), key);
+      }
+
+      await multi.exec();
+    }
+  }
+
+  public async del(key: string): Promise<void> {
+    await this.redis.del(key);
+  }
+
+  public async delByTags(tags: string[]): Promise<void> {
+    const keys = await this.getKeysByTags(tags);
+
+    const multi = this.redis.multi();
+
+    if (keys.length) {
+      multi.del(keys);
+    }
+
+    for (const tag of tags) {
+      multi.del(this.tagSet(tag));
+    }
+
+    await multi.exec();
+  }
+
+  private async getKeysByTags(tags: string[]): Promise<string[]> {
+    const multi = this.redis.multi();
+
+    for (const tag of tags) {
+      multi.sMembers(this.tagSet(tag));
+    }
+
+    const result = await multi.exec();
+
+    const keys = new Set<string>();
+
+    result.forEach((item) =>
+      (item as unknown as string[]).forEach((k) => keys.add(k)),
+    );
+
+    return Array.from(keys);
+  }
+}

--- a/src/infrastructure/cache-manager/cache.bootstrapper.ts
+++ b/src/infrastructure/cache-manager/cache.bootstrapper.ts
@@ -1,0 +1,19 @@
+import { Inject, Injectable, OnModuleInit } from '@nestjs/common';
+import {
+  CACHE_SERVICE,
+  CacheLike,
+} from 'src/infrastructure/cache-manager/services/cache.tokens';
+import { registerCacheService } from './cache.locator';
+
+/**
+ * On app/module init, capture the CacheService into the global locator.
+ * Keeps DI pure in most places while allowing decorators to access the service.
+ */
+@Injectable()
+export class CacheBootstrapper implements OnModuleInit {
+  constructor(@Inject(CACHE_SERVICE) private readonly cache: CacheLike) {}
+
+  onModuleInit() {
+    registerCacheService(this.cache);
+  }
+}

--- a/src/infrastructure/cache-manager/cache.locator.ts
+++ b/src/infrastructure/cache-manager/cache.locator.ts
@@ -1,0 +1,22 @@
+import { CacheLike } from 'src/infrastructure/cache-manager/services/cache.tokens';
+
+/**
+ * Tiny global locator for CacheService.
+ * Filled once during module init; read anywhere (incl. decorators).
+ * This avoids injecting CacheService into every consumer class.
+ */
+let _cacheService: CacheLike | null = null;
+
+export function registerCacheService(instance: CacheLike) {
+  _cacheService = instance;
+}
+
+export function getCacheServiceOrThrow(): CacheLike {
+  if (!_cacheService) {
+    throw new Error(
+      'CacheService is not registered yet. ' +
+        'Ensure CacheModule.forRoot() is imported and module initialized before using @CachedMethod.',
+    );
+  }
+  return _cacheService;
+}

--- a/src/infrastructure/cache-manager/method-cache.decorator.ts
+++ b/src/infrastructure/cache-manager/method-cache.decorator.ts
@@ -40,6 +40,11 @@ export function CachedMethod<Args = any, Ret = any>(
       }
 
       const result: Ret = await orig.apply(this, args);
+
+      if (result === undefined) {
+        return result;
+      }
+
       const tags = makeTags(args, result);
       await cache.set(key, result, { ttlSec, tags });
       return result;

--- a/src/infrastructure/cache-manager/method-cache.decorator.ts
+++ b/src/infrastructure/cache-manager/method-cache.decorator.ts
@@ -1,0 +1,49 @@
+import 'reflect-metadata';
+import { getCacheServiceOrThrow } from './cache.locator';
+
+// Options for a specific cached method
+export type MethodCacheOptions<Args = any, Ret = any> = {
+  keyPrefix: string; // e.g., 'role:permissions'
+  makeKey?: (args: Args[]) => string; // defaults to JSON.stringify(args)
+  makeTags?: (args: Args[], result?: Ret) => string[]; // defaults to []
+  ttlSec?: number; // 0 = no TTL (persist until explicit invalidation)
+};
+
+/**
+ * @CachedMethod wraps an async method and caches its result.
+ * It resolves CacheService from a global locator populated at module init,
+ */
+export function CachedMethod<Args = any, Ret = any>(
+  options: MethodCacheOptions<Args, Ret>,
+) {
+  const {
+    keyPrefix,
+    makeKey = (args) => JSON.stringify(args),
+    makeTags = () => [],
+    ttlSec = 3600,
+  } = options;
+
+  return function (
+    _target: any,
+    _propertyKey: string,
+    descriptor: PropertyDescriptor,
+  ) {
+    const orig = descriptor.value;
+    descriptor.value = async function (...args: Args[]) {
+      const cache = getCacheServiceOrThrow();
+
+      const key = `${keyPrefix}:${makeKey(args)}`;
+      const cached = await cache.get<Ret>(key);
+
+      if (cached !== undefined) {
+        return cached;
+      }
+
+      const result: Ret = await orig.apply(this, args);
+      const tags = makeTags(args, result);
+      await cache.set(key, result, { ttlSec, tags });
+      return result;
+    };
+    return descriptor;
+  };
+}

--- a/src/infrastructure/cache-manager/revisium-cache.module.ts
+++ b/src/infrastructure/cache-manager/revisium-cache.module.ts
@@ -1,0 +1,66 @@
+import { DynamicModule, Logger, Module } from '@nestjs/common';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { CacheBootstrapper } from './cache.bootstrapper';
+import { InMemoryAdapter } from './adapters/in-memory.adapter';
+import { RedisAdapter } from './adapters/redis.adapter';
+import { CacheService } from './services/cache.service';
+import { NoopCacheService } from './services/noop-cache.service';
+import { CACHE_SERVICE, CacheLike } from './services/cache.tokens';
+
+function parseBool(v?: string | null): boolean {
+  if (!v) return false;
+  return ['1', 'true', 'on', 'yes'].includes(String(v).toLowerCase());
+}
+
+@Module({})
+export class RevisiumCacheModule {
+  static forRootAsync(): DynamicModule {
+    return {
+      module: RevisiumCacheModule,
+      global: true,
+      imports: [ConfigModule],
+      providers: [
+        InMemoryAdapter,
+        {
+          provide: CACHE_SERVICE,
+          useFactory: async (
+            cfg: ConfigService,
+            l1: InMemoryAdapter,
+          ): Promise<CacheLike> => {
+            const logger = new Logger('RevisiumCacheModule');
+            const enabled = parseBool(cfg.get<string>('EXPERIMENTAL_CACHE'));
+
+            if (!enabled) {
+              logger.warn(
+                '⚠️ Cache disabled (NoopCacheService). Set EXPERIMENTAL_CACHE=1 to enable.',
+              );
+              return new NoopCacheService();
+            }
+
+            const redisUrl =
+              cfg.get<string>('EXPERIMENTAL_CACHE_L2_REDIS_URL') || null;
+            if (!redisUrl) {
+              logger.log('✅ Cache enabled: L1 only (InMemoryAdapter).');
+              return new CacheService(l1);
+            }
+
+            try {
+              const l2 = await RedisAdapter.connect(redisUrl);
+              logger.log(`✅ Cache enabled: L1 + L2 (Redis @ ${redisUrl}).`);
+              return new CacheService(l1, l2);
+            } catch (e) {
+              logger.error(
+                `❌ Redis connect failed (${redisUrl}), fallback to L1 only.`,
+                e as any,
+              );
+              return new CacheService(l1);
+            }
+          },
+          inject: [ConfigService, InMemoryAdapter],
+        },
+        CacheBootstrapper,
+      ],
+      exports: [CACHE_SERVICE],
+    };
+  }
+}

--- a/src/infrastructure/cache-manager/revisium-cache.module.ts
+++ b/src/infrastructure/cache-manager/revisium-cache.module.ts
@@ -45,9 +45,10 @@ export class RevisiumCacheModule {
               logger.log(`✅ Cache enabled: L1 + L2 (Redis @ ${redisUrl}).`);
               return new CacheService(l1, l2);
             } catch (e) {
+              const err = e as Error;
               logger.error(
                 `❌ Redis connect failed (${redisUrl}), fallback to L1 only.`,
-                e as any,
+                err?.stack ?? String(err),
               );
               return new CacheService(l1);
             }

--- a/src/infrastructure/cache-manager/revisium-cache.module.ts
+++ b/src/infrastructure/cache-manager/revisium-cache.module.ts
@@ -1,16 +1,12 @@
 import { DynamicModule, Logger, Module } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
+import { parseBool } from 'src/utils/utils/parse-bool';
 import { CacheBootstrapper } from './cache.bootstrapper';
 import { InMemoryAdapter } from './adapters/in-memory.adapter';
 import { RedisAdapter } from './adapters/redis.adapter';
 import { CacheService } from './services/cache.service';
 import { NoopCacheService } from './services/noop-cache.service';
 import { CACHE_SERVICE, CacheLike } from './services/cache.tokens';
-
-function parseBool(v?: string | null): boolean {
-  if (!v) return false;
-  return ['1', 'true', 'on', 'yes'].includes(String(v).toLowerCase());
-}
 
 @Module({})
 export class RevisiumCacheModule {

--- a/src/infrastructure/cache-manager/services/cache.service.ts
+++ b/src/infrastructure/cache-manager/services/cache.service.ts
@@ -1,0 +1,59 @@
+import { Injectable, Optional } from '@nestjs/common';
+import { CacheLike } from 'src/infrastructure/cache-manager/services/cache.tokens';
+import { CacheAdapter } from '../adapters/cache.adapter';
+import { InMemoryAdapter } from '../adapters/in-memory.adapter';
+
+@Injectable()
+export class CacheService implements CacheLike {
+  constructor(
+    private readonly l1: InMemoryAdapter,
+    @Optional() private readonly l2?: CacheAdapter,
+  ) {}
+
+  public async get<T>(key: string): Promise<T | undefined> {
+    const v1 = await this.l1.get<T>(key);
+
+    if (v1 !== undefined) {
+      return v1;
+    }
+
+    if (this.l2) {
+      const v2 = await this.l2.get<T>(key);
+
+      if (v2 !== undefined) {
+        await this.l1.set(key, v2);
+        return v2;
+      }
+    }
+
+    return undefined;
+  }
+
+  public async set<T>(
+    key: string,
+    value: T,
+    opts?: { ttlSec?: number; tags?: string[] },
+  ): Promise<void> {
+    await this.l1.set(key, value, opts);
+
+    if (this.l2) {
+      await this.l2.set(key, value, opts);
+    }
+  }
+
+  public async del(key: string) {
+    await this.l1.del(key);
+
+    if (this.l2) {
+      await this.l2.del(key);
+    }
+  }
+
+  public async delByTags(tags: string[]) {
+    await this.l1.delByTags(tags);
+
+    if (this.l2) {
+      await this.l2.delByTags(tags);
+    }
+  }
+}

--- a/src/infrastructure/cache-manager/services/cache.service.ts
+++ b/src/infrastructure/cache-manager/services/cache.service.ts
@@ -18,11 +18,21 @@ export class CacheService implements CacheLike {
     }
 
     if (this.l2) {
-      const v2 = await this.l2.get<T>(key);
-
-      if (v2 !== undefined) {
-        await this.l1.set(key, v2);
-        return v2;
+      const withMeta = this.l2.getWithMeta
+        ? await this.l2.getWithMeta<T>(key)
+        : undefined;
+      if (withMeta) {
+        await this.l1.set(key, withMeta.value, {
+          ttlSec: withMeta.ttlSec,
+          tags: withMeta.tags,
+        });
+        return withMeta.value;
+      } else {
+        const v2 = await this.l2.get<T>(key);
+        if (v2 !== undefined) {
+          await this.l1.set(key, v2);
+          return v2;
+        }
       }
     }
 

--- a/src/infrastructure/cache-manager/services/cache.tokens.ts
+++ b/src/infrastructure/cache-manager/services/cache.tokens.ts
@@ -1,0 +1,12 @@
+export const CACHE_SERVICE = 'CACHE_SERVICE';
+
+export interface CacheLike {
+  get<T>(key: string): Promise<T | undefined>;
+  set<T>(
+    key: string,
+    value: T,
+    opts?: { ttlSec?: number; tags?: string[] },
+  ): Promise<void>;
+  del(key: string): Promise<void>;
+  delByTags(tags: string[]): Promise<void>;
+}

--- a/src/infrastructure/cache-manager/services/noop-cache.service.ts
+++ b/src/infrastructure/cache-manager/services/noop-cache.service.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@nestjs/common';
+import { CacheLike } from 'src/infrastructure/cache-manager/services/cache.tokens';
+
+@Injectable()
+export class NoopCacheService implements CacheLike {
+  public async get<T>(_key: string): Promise<T | undefined> {
+    return undefined;
+  }
+
+  public async set<T>(
+    _key: string,
+    _value: T,
+    _opts?: { ttlSec?: number; tags?: string[] },
+  ): Promise<void> {}
+
+  public async del(_key: string): Promise<void> {}
+
+  public async delByTags(_tags: string[]): Promise<void> {}
+}

--- a/src/utils/utils/__tests__/parse-bool.spec.ts
+++ b/src/utils/utils/__tests__/parse-bool.spec.ts
@@ -1,0 +1,44 @@
+import { parseBool } from '../parse-bool';
+
+describe('parseBool', () => {
+  it('returns false for undefined', () => {
+    expect(parseBool(undefined)).toBe(false);
+  });
+
+  it('returns false for null', () => {
+    expect(parseBool(null as any)).toBe(false);
+  });
+
+  it('returns false for empty string', () => {
+    expect(parseBool('')).toBe(false);
+  });
+
+  it('returns true for "1"', () => {
+    expect(parseBool('1')).toBe(true);
+  });
+
+  it('returns true for "true"', () => {
+    expect(parseBool('true')).toBe(true);
+  });
+
+  it('returns true for "on"', () => {
+    expect(parseBool('on')).toBe(true);
+  });
+
+  it('returns true for "yes"', () => {
+    expect(parseBool('yes')).toBe(true);
+  });
+
+  it('is case-insensitive', () => {
+    expect(parseBool('TRUE')).toBe(true);
+    expect(parseBool('On')).toBe(true);
+    expect(parseBool('YeS')).toBe(true);
+  });
+
+  it('returns false for unrelated strings', () => {
+    expect(parseBool('0')).toBe(false);
+    expect(parseBool('false')).toBe(false);
+    expect(parseBool('no')).toBe(false);
+    expect(parseBool('random')).toBe(false);
+  });
+});

--- a/src/utils/utils/parse-bool.ts
+++ b/src/utils/utils/parse-bool.ts
@@ -1,0 +1,7 @@
+export function parseBool(value?: string | null): boolean {
+  if (!value) {
+    return false;
+  }
+
+  return ['1', 'true', 'on', 'yes'].includes(String(value).toLowerCase());
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Experimental two-tier caching (in-memory L1 with optional Redis L2), method-level caching decorator, global cache module and bootstrapper, and cache service locator.
  * Permission lookups now use cached method support to reduce repeated queries.

* **Chores**
  * Added sample env variable to toggle caching.
  * Added runtime dependencies for caching (LRU and Redis clients).

* **Tests**
  * Comprehensive tests for adapters, service, decorator, module modes, and TTL/tag behavior; parseBool utility tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->