### PR TITLE
feat: add API key count limits and X-Api-Key auth to Swagger

### DIFF
--- a/ENV.md
+++ b/ENV.md
@@ -113,6 +113,15 @@ cp .env.example .env
 
 ---
 
+## API Key Limits
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `API_KEY_MAX_PER_USER` | `10` | Maximum number of personal API keys per user |
+| `API_KEY_MAX_SERVICE_PER_ORG` | `100` | Maximum number of service API keys per organization |
+
+---
+
 ## Internal API Keys (Microservice Mode Only)
 
 In monolith/standalone mode, internal keys are derived automatically from `JWT_SECRET`. These env vars are ignored (a warning is logged if set). For multi-replica monolith deployments, ensure `JWT_SECRET` is explicitly set.

--- a/src/api/graphql-api/api-key/__tests__/api-key.resolver.spec.ts
+++ b/src/api/graphql-api/api-key/__tests__/api-key.resolver.spec.ts
@@ -1,4 +1,5 @@
 import { NotFoundException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { CqrsModule } from '@nestjs/cqrs';
 import { Test, TestingModule } from '@nestjs/testing';
 import { nanoid } from 'nanoid';
@@ -29,6 +30,7 @@ describe('ApiKeyApiService', () => {
         GetApiKeyByIdHandler,
         GetApiKeysHandler,
         PrismaService,
+        { provide: ConfigService, useValue: { get: () => undefined } },
       ],
     }).compile();
 

--- a/src/api/graphql-api/api-key/__tests__/service-api-key.resolver.spec.ts
+++ b/src/api/graphql-api/api-key/__tests__/service-api-key.resolver.spec.ts
@@ -1,4 +1,5 @@
 import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { CqrsModule } from '@nestjs/cqrs';
 import { Test, TestingModule } from '@nestjs/testing';
 import { nanoid } from 'nanoid';
@@ -33,6 +34,7 @@ describe('ApiKeyApiService - Service Keys', () => {
         GetApiKeyByIdHandler,
         GetApiKeysHandler,
         PrismaService,
+        { provide: ConfigService, useValue: { get: () => undefined } },
       ],
     }).compile();
 

--- a/src/api/rest-api/auth/auth.controller.ts
+++ b/src/api/rest-api/auth/auth.controller.ts
@@ -11,6 +11,7 @@ import {
   ApiBearerAuth,
   ApiOkResponse,
   ApiOperation,
+  ApiSecurity,
   ApiTags,
 } from '@nestjs/swagger';
 import { ApiCommonErrors } from 'src/api/rest-api/share/decorators';
@@ -30,6 +31,7 @@ import { SuccessModelDto } from 'src/api/rest-api/share/model/success.model';
 @UseInterceptors(RestMetricsInterceptor)
 @ApiTags('Auth')
 @ApiBearerAuth('access-token')
+@ApiSecurity('api-key')
 @Controller('auth')
 export class AuthController {
   constructor(

--- a/src/api/rest-api/branch/branch-by-name.controller.ts
+++ b/src/api/rest-api/branch/branch-by-name.controller.ts
@@ -14,6 +14,7 @@ import {
   ApiBody,
   ApiOkResponse,
   ApiOperation,
+  ApiSecurity,
   ApiTags,
 } from '@nestjs/swagger';
 import {
@@ -59,6 +60,7 @@ import {
   'organization/:organizationId/projects/:projectName/branches/:branchName',
 )
 @ApiBearerAuth('access-token')
+@ApiSecurity('api-key')
 @ApiTags('Branch')
 export class BranchByNameController {
   constructor(

--- a/src/api/rest-api/endpoint/endpoint-by-id.controller.ts
+++ b/src/api/rest-api/endpoint/endpoint-by-id.controller.ts
@@ -10,6 +10,7 @@ import {
   ApiBearerAuth,
   ApiOkResponse,
   ApiOperation,
+  ApiSecurity,
   ApiTags,
 } from '@nestjs/swagger';
 import {
@@ -34,6 +35,7 @@ import { RestMetricsInterceptor } from 'src/infrastructure/metrics/rest/rest-met
 })
 @Controller('/endpoints/:endpointId')
 @ApiBearerAuth('access-token')
+@ApiSecurity('api-key')
 @ApiTags('Endpoint')
 export class EndpointByIdController {
   constructor(private readonly endpointApi: EndpointApiService) {}

--- a/src/api/rest-api/init-swagger.ts
+++ b/src/api/rest-api/init-swagger.ts
@@ -14,6 +14,16 @@ export function initSwagger(app: INestApplication<any>) {
       },
       'access-token',
     )
+    .addApiKey(
+      {
+        type: 'apiKey',
+        in: 'header',
+        name: 'X-Api-Key',
+        description:
+          'API Key (rev_...) for programmatic access. Query param ?api_key=rev_... is also supported for webhooks.',
+      },
+      'api-key',
+    )
     .addTag('Configuration', 'System configuration and feature flags')
     .addTag(
       'Auth',

--- a/src/api/rest-api/openapi.json
+++ b/src/api/rest-api/openapi.json
@@ -59,6 +59,9 @@
         },
         "security": [
           {
+            "api-key": []
+          },
+          {
             "access-token": []
           }
         ],
@@ -125,6 +128,9 @@
           }
         },
         "security": [
+          {
+            "api-key": []
+          },
           {
             "access-token": []
           }
@@ -193,6 +199,9 @@
         },
         "security": [
           {
+            "api-key": []
+          },
+          {
             "access-token": []
           }
         ],
@@ -249,6 +258,9 @@
           }
         },
         "security": [
+          {
+            "api-key": []
+          },
           {
             "access-token": []
           }
@@ -344,6 +356,9 @@
         },
         "security": [
           {
+            "api-key": []
+          },
+          {
             "access-token": []
           }
         ],
@@ -437,6 +452,9 @@
           }
         },
         "security": [
+          {
+            "api-key": []
+          },
           {
             "access-token": []
           }
@@ -532,6 +550,9 @@
         },
         "security": [
           {
+            "api-key": []
+          },
+          {
             "access-token": []
           }
         ],
@@ -617,6 +638,9 @@
         },
         "security": [
           {
+            "api-key": []
+          },
+          {
             "access-token": []
           }
         ],
@@ -701,6 +725,9 @@
           }
         },
         "security": [
+          {
+            "api-key": []
+          },
           {
             "access-token": []
           }
@@ -788,6 +815,9 @@
         },
         "security": [
           {
+            "api-key": []
+          },
+          {
             "access-token": []
           }
         ],
@@ -871,6 +901,9 @@
           }
         },
         "security": [
+          {
+            "api-key": []
+          },
           {
             "access-token": []
           }
@@ -966,6 +999,9 @@
         },
         "security": [
           {
+            "api-key": []
+          },
+          {
             "access-token": []
           }
         ],
@@ -1051,6 +1087,9 @@
           }
         },
         "security": [
+          {
+            "api-key": []
+          },
           {
             "access-token": []
           }
@@ -1155,6 +1194,9 @@
         },
         "security": [
           {
+            "api-key": []
+          },
+          {
             "access-token": []
           }
         ],
@@ -1258,6 +1300,9 @@
         },
         "security": [
           {
+            "api-key": []
+          },
+          {
             "access-token": []
           }
         ],
@@ -1351,6 +1396,9 @@
           }
         },
         "security": [
+          {
+            "api-key": []
+          },
           {
             "access-token": []
           }
@@ -1447,6 +1495,9 @@
         },
         "security": [
           {
+            "api-key": []
+          },
+          {
             "access-token": []
           }
         ],
@@ -1542,6 +1593,9 @@
         },
         "security": [
           {
+            "api-key": []
+          },
+          {
             "access-token": []
           }
         ],
@@ -1634,6 +1688,9 @@
           }
         },
         "security": [
+          {
+            "api-key": []
+          },
           {
             "access-token": []
           }
@@ -1730,6 +1787,9 @@
         },
         "security": [
           {
+            "api-key": []
+          },
+          {
             "access-token": []
           }
         ],
@@ -1824,6 +1884,9 @@
           }
         },
         "security": [
+          {
+            "api-key": []
+          },
           {
             "access-token": []
           }
@@ -1920,6 +1983,9 @@
         },
         "security": [
           {
+            "api-key": []
+          },
+          {
             "access-token": []
           }
         ],
@@ -2015,6 +2081,9 @@
         },
         "security": [
           {
+            "api-key": []
+          },
+          {
             "access-token": []
           }
         ],
@@ -2109,6 +2178,9 @@
           }
         },
         "security": [
+          {
+            "api-key": []
+          },
           {
             "access-token": []
           }
@@ -2251,6 +2323,9 @@
         },
         "security": [
           {
+            "api-key": []
+          },
+          {
             "access-token": []
           }
         ],
@@ -2356,6 +2431,9 @@
         },
         "security": [
           {
+            "api-key": []
+          },
+          {
             "access-token": []
           }
         ],
@@ -2451,6 +2529,9 @@
         },
         "security": [
           {
+            "api-key": []
+          },
+          {
             "access-token": []
           }
         ],
@@ -2527,6 +2608,9 @@
           }
         },
         "security": [
+          {
+            "api-key": []
+          },
           {
             "access-token": []
           }
@@ -2605,6 +2689,9 @@
         },
         "security": [
           {
+            "api-key": []
+          },
+          {
             "access-token": []
           }
         ],
@@ -2681,6 +2768,9 @@
           }
         },
         "security": [
+          {
+            "api-key": []
+          },
           {
             "access-token": []
           }
@@ -2761,6 +2851,9 @@
           }
         },
         "security": [
+          {
+            "api-key": []
+          },
           {
             "access-token": []
           }
@@ -2846,6 +2939,9 @@
           }
         },
         "security": [
+          {
+            "api-key": []
+          },
           {
             "access-token": []
           }
@@ -2941,6 +3037,9 @@
         },
         "security": [
           {
+            "api-key": []
+          },
+          {
             "access-token": []
           }
         ],
@@ -3026,6 +3125,9 @@
         },
         "security": [
           {
+            "api-key": []
+          },
+          {
             "access-token": []
           }
         ],
@@ -3105,6 +3207,9 @@
           }
         },
         "security": [
+          {
+            "api-key": []
+          },
           {
             "access-token": []
           }
@@ -3190,6 +3295,9 @@
           }
         },
         "security": [
+          {
+            "api-key": []
+          },
           {
             "access-token": []
           }
@@ -3284,6 +3392,9 @@
         },
         "security": [
           {
+            "api-key": []
+          },
+          {
             "access-token": []
           }
         ],
@@ -3377,6 +3488,9 @@
           }
         },
         "security": [
+          {
+            "api-key": []
+          },
           {
             "access-token": []
           }
@@ -3523,6 +3637,9 @@
         },
         "security": [
           {
+            "api-key": []
+          },
+          {
             "access-token": []
           }
         ],
@@ -3668,6 +3785,9 @@
         },
         "security": [
           {
+            "api-key": []
+          },
+          {
             "access-token": []
           }
         ],
@@ -3775,6 +3895,9 @@
         },
         "security": [
           {
+            "api-key": []
+          },
+          {
             "access-token": []
           }
         ],
@@ -3861,6 +3984,9 @@
         },
         "security": [
           {
+            "api-key": []
+          },
+          {
             "access-token": []
           }
         ],
@@ -3944,6 +4070,9 @@
           }
         },
         "security": [
+          {
+            "api-key": []
+          },
           {
             "access-token": []
           }
@@ -4039,6 +4168,9 @@
         },
         "security": [
           {
+            "api-key": []
+          },
+          {
             "access-token": []
           }
         ],
@@ -4124,6 +4256,9 @@
           }
         },
         "security": [
+          {
+            "api-key": []
+          },
           {
             "access-token": []
           }
@@ -4221,6 +4356,9 @@
         },
         "security": [
           {
+            "api-key": []
+          },
+          {
             "access-token": []
           }
         ],
@@ -4314,6 +4452,9 @@
           }
         },
         "security": [
+          {
+            "api-key": []
+          },
           {
             "access-token": []
           }
@@ -4411,6 +4552,9 @@
         },
         "security": [
           {
+            "api-key": []
+          },
+          {
             "access-token": []
           }
         ],
@@ -4506,6 +4650,9 @@
           }
         },
         "security": [
+          {
+            "api-key": []
+          },
           {
             "access-token": []
           }
@@ -4603,6 +4750,9 @@
         },
         "security": [
           {
+            "api-key": []
+          },
+          {
             "access-token": []
           }
         ],
@@ -4699,6 +4849,9 @@
         },
         "security": [
           {
+            "api-key": []
+          },
+          {
             "access-token": []
           }
         ],
@@ -4785,6 +4938,9 @@
         },
         "security": [
           {
+            "api-key": []
+          },
+          {
             "access-token": []
           }
         ],
@@ -4870,6 +5026,9 @@
           }
         },
         "security": [
+          {
+            "api-key": []
+          },
           {
             "access-token": []
           }
@@ -4974,6 +5133,9 @@
         },
         "security": [
           {
+            "api-key": []
+          },
+          {
             "access-token": []
           }
         ],
@@ -5059,6 +5221,9 @@
           }
         },
         "security": [
+          {
+            "api-key": []
+          },
           {
             "access-token": []
           }
@@ -5163,6 +5328,9 @@
         },
         "security": [
           {
+            "api-key": []
+          },
+          {
             "access-token": []
           }
         ],
@@ -5259,6 +5427,9 @@
         },
         "security": [
           {
+            "api-key": []
+          },
+          {
             "access-token": []
           }
         ],
@@ -5354,6 +5525,9 @@
         },
         "security": [
           {
+            "api-key": []
+          },
+          {
             "access-token": []
           }
         ],
@@ -5446,6 +5620,9 @@
           }
         },
         "security": [
+          {
+            "api-key": []
+          },
           {
             "access-token": []
           }
@@ -5550,6 +5727,9 @@
         },
         "security": [
           {
+            "api-key": []
+          },
+          {
             "access-token": []
           }
         ],
@@ -5653,6 +5833,9 @@
         },
         "security": [
           {
+            "api-key": []
+          },
+          {
             "access-token": []
           }
         ],
@@ -5747,6 +5930,9 @@
           }
         },
         "security": [
+          {
+            "api-key": []
+          },
           {
             "access-token": []
           }
@@ -5868,6 +6054,9 @@
         },
         "security": [
           {
+            "api-key": []
+          },
+          {
             "access-token": []
           }
         ],
@@ -5962,6 +6151,9 @@
           }
         },
         "security": [
+          {
+            "api-key": []
+          },
           {
             "access-token": []
           }
@@ -6083,6 +6275,9 @@
         },
         "security": [
           {
+            "api-key": []
+          },
+          {
             "access-token": []
           }
         ],
@@ -6187,6 +6382,9 @@
           }
         },
         "security": [
+          {
+            "api-key": []
+          },
           {
             "access-token": []
           }
@@ -6312,6 +6510,9 @@
         },
         "security": [
           {
+            "api-key": []
+          },
+          {
             "access-token": []
           }
         ],
@@ -6389,6 +6590,9 @@
         },
         "security": [
           {
+            "api-key": []
+          },
+          {
             "access-token": []
           }
         ],
@@ -6465,6 +6669,9 @@
           }
         },
         "security": [
+          {
+            "api-key": []
+          },
           {
             "access-token": []
           }
@@ -6945,6 +7152,12 @@
         "scheme": "bearer",
         "bearerFormat": "JWT",
         "type": "http"
+      },
+      "api-key": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-Api-Key",
+        "description": "API Key (rev_...) for programmatic access. Query param ?api_key=rev_... is also supported for webhooks."
       }
     },
     "schemas": {

--- a/src/api/rest-api/organization/organization.controller.ts
+++ b/src/api/rest-api/organization/organization.controller.ts
@@ -15,6 +15,7 @@ import {
   ApiOkResponse,
   ApiOperation,
   ApiQuery,
+  ApiSecurity,
   ApiTags,
 } from '@nestjs/swagger';
 import {
@@ -53,6 +54,7 @@ import { transformFromPaginatedPrismaToUserOrganizationModel } from 'src/api/res
 })
 @Controller('organization')
 @ApiBearerAuth('access-token')
+@ApiSecurity('api-key')
 @ApiTags('Organization')
 export class OrganizationController {
   constructor(

--- a/src/api/rest-api/project/project.controller.ts
+++ b/src/api/rest-api/project/project.controller.ts
@@ -14,6 +14,7 @@ import {
   ApiBearerAuth,
   ApiOkResponse,
   ApiOperation,
+  ApiSecurity,
   ApiTags,
 } from '@nestjs/swagger';
 import {
@@ -49,6 +50,7 @@ import { transformFromPaginatedPrismaToUserProjectModel } from 'src/api/rest-api
 @Controller('organization/:organizationId/projects')
 @ApiTags('Project')
 @ApiBearerAuth('access-token')
+@ApiSecurity('api-key')
 export class ProjectController {
   constructor(private readonly projectApi: ProjectApiService) {}
 

--- a/src/api/rest-api/revision/revision-by-id.controller.ts
+++ b/src/api/rest-api/revision/revision-by-id.controller.ts
@@ -14,6 +14,7 @@ import {
   ApiExtraModels,
   ApiOkResponse,
   ApiOperation,
+  ApiSecurity,
   ApiTags,
   getSchemaPath,
 } from '@nestjs/swagger';
@@ -79,6 +80,7 @@ import { TablesConnection } from 'src/api/rest-api/table/model/table.model';
 })
 @Controller('revision/:revisionId')
 @ApiBearerAuth('access-token')
+@ApiSecurity('api-key')
 @ApiTags('Revision')
 @ApiExtraModels(InitMigrationDto)
 @ApiExtraModels(UpdateMigrationDto)

--- a/src/api/rest-api/row/row-by-id.controller.ts
+++ b/src/api/rest-api/row/row-by-id.controller.ts
@@ -22,6 +22,7 @@ import {
   ApiConsumes,
   ApiOkResponse,
   ApiOperation,
+  ApiSecurity,
   ApiTags,
 } from '@nestjs/swagger';
 import {
@@ -69,6 +70,7 @@ import { transformFromPrismaToTableModel } from 'src/api/rest-api/share/utils/tr
 })
 @Controller('revision/:revisionId/tables/:tableId/rows/:rowId')
 @ApiBearerAuth('access-token')
+@ApiSecurity('api-key')
 @ApiTags('Row')
 export class RowByIdController {
   constructor(private readonly rows: RowApiService) {}

--- a/src/api/rest-api/table/table-by-id.controller.ts
+++ b/src/api/rest-api/table/table-by-id.controller.ts
@@ -20,6 +20,7 @@ import {
   ApiBody,
   ApiOkResponse,
   ApiOperation,
+  ApiSecurity,
   ApiTags,
 } from '@nestjs/swagger';
 import {
@@ -83,6 +84,7 @@ import { Table } from 'src/__generated__/client';
 })
 @Controller('revision/:revisionId/tables/:tableId')
 @ApiBearerAuth('access-token')
+@ApiSecurity('api-key')
 @ApiTags('Table')
 export class TableByIdController {
   constructor(

--- a/src/api/rest-api/user/user.controller.ts
+++ b/src/api/rest-api/user/user.controller.ts
@@ -9,6 +9,7 @@ import {
   ApiBearerAuth,
   ApiOkResponse,
   ApiOperation,
+  ApiSecurity,
   ApiTags,
 } from '@nestjs/swagger';
 import { ApiCommonErrors } from 'src/api/rest-api/share/decorators';
@@ -21,6 +22,7 @@ import { MeModel } from 'src/api/rest-api/user/model';
 @UseInterceptors(RestMetricsInterceptor)
 @ApiTags('User')
 @ApiBearerAuth('access-token')
+@ApiSecurity('api-key')
 @Controller('user')
 export class UserController {
   constructor(private readonly userApiService: UserApiService) {}

--- a/src/features/api-key/commands/__tests__/create-api-key-limits.handler.spec.ts
+++ b/src/features/api-key/commands/__tests__/create-api-key-limits.handler.spec.ts
@@ -1,0 +1,186 @@
+import { BadRequestException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { CommandBus, CqrsModule } from '@nestjs/cqrs';
+import { Test, TestingModule } from '@nestjs/testing';
+import { nanoid } from 'nanoid';
+import { ApiKeyType } from 'src/__generated__/client';
+import { testCreateUser } from 'src/__tests__/create-models';
+import { ApiKeyService } from 'src/features/api-key/api-key.service';
+import { CreateApiKeyHandler } from 'src/features/api-key/commands/handlers';
+import { CreateApiKeyCommand } from 'src/features/api-key/commands/impl';
+import { RevisiumCacheModule } from 'src/infrastructure/cache';
+import { PrismaService } from 'src/infrastructure/database/prisma.service';
+
+describe('CreateApiKeyHandler — key limits', () => {
+  let commandBus: CommandBus;
+  let prisma: PrismaService;
+
+  const TEST_PERSONAL_LIMIT = 3;
+  const TEST_SERVICE_LIMIT = 3;
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [CqrsModule, RevisiumCacheModule.forRootAsync()],
+      providers: [
+        CreateApiKeyHandler,
+        ApiKeyService,
+        PrismaService,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: (key: string) => {
+              if (key === 'API_KEY_MAX_PER_USER') return TEST_PERSONAL_LIMIT;
+              if (key === 'API_KEY_MAX_SERVICE_PER_ORG')
+                return TEST_SERVICE_LIMIT;
+              return undefined;
+            },
+          },
+        },
+      ],
+    }).compile();
+
+    await module.init();
+
+    commandBus = module.get(CommandBus);
+    prisma = module.get(PrismaService);
+  });
+
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  describe('personal key limit', () => {
+    it('should allow creating keys up to the limit', async () => {
+      const userId = nanoid();
+      await testCreateUser(prisma, { id: userId });
+
+      for (let i = 0; i < TEST_PERSONAL_LIMIT; i++) {
+        const result = await commandBus.execute(
+          new CreateApiKeyCommand({
+            type: ApiKeyType.PERSONAL,
+            name: `Key ${i}`,
+            userId,
+          }),
+        );
+        expect(result.id).toBeDefined();
+      }
+    });
+
+    it('should reject when personal key limit is reached', async () => {
+      const userId = nanoid();
+      await testCreateUser(prisma, { id: userId });
+
+      for (let i = 0; i < TEST_PERSONAL_LIMIT; i++) {
+        await commandBus.execute(
+          new CreateApiKeyCommand({
+            type: ApiKeyType.PERSONAL,
+            name: `Key ${i}`,
+            userId,
+          }),
+        );
+      }
+
+      await expect(
+        commandBus.execute(
+          new CreateApiKeyCommand({
+            type: ApiKeyType.PERSONAL,
+            name: 'One too many',
+            userId,
+          }),
+        ),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should allow creating after revoking a key', async () => {
+      const userId = nanoid();
+      await testCreateUser(prisma, { id: userId });
+
+      const keys: string[] = [];
+      for (let i = 0; i < TEST_PERSONAL_LIMIT; i++) {
+        const result = await commandBus.execute(
+          new CreateApiKeyCommand({
+            type: ApiKeyType.PERSONAL,
+            name: `Key ${i}`,
+            userId,
+          }),
+        );
+        keys.push(result.id);
+      }
+
+      await prisma.apiKey.update({
+        where: { id: keys[0] },
+        data: { revokedAt: new Date() },
+      });
+
+      const result = await commandBus.execute(
+        new CreateApiKeyCommand({
+          type: ApiKeyType.PERSONAL,
+          name: 'After revoke',
+          userId,
+        }),
+      );
+      expect(result.id).toBeDefined();
+    });
+  });
+
+  describe('service key limit', () => {
+    it('should reject when service key limit is reached', async () => {
+      const orgId = `org-${nanoid(8)}`;
+      await prisma.organization.create({
+        data: { id: orgId, createdId: nanoid() },
+      });
+
+      const permissions = { rules: [{ action: ['read'], subject: ['Row'] }] };
+
+      for (let i = 0; i < TEST_SERVICE_LIMIT; i++) {
+        await commandBus.execute(
+          new CreateApiKeyCommand({
+            type: ApiKeyType.SERVICE,
+            name: `Service ${i}`,
+            serviceId: `svc-${nanoid(8)}`,
+            organizationId: orgId,
+            permissions,
+          }),
+        );
+      }
+
+      await expect(
+        commandBus.execute(
+          new CreateApiKeyCommand({
+            type: ApiKeyType.SERVICE,
+            name: 'One too many',
+            serviceId: `svc-${nanoid(8)}`,
+            organizationId: orgId,
+            permissions,
+          }),
+        ),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('internal keys are not limited', () => {
+    it('should not count internal keys against limits', async () => {
+      const userId = nanoid();
+      await testCreateUser(prisma, { id: userId });
+
+      for (let i = 0; i < TEST_PERSONAL_LIMIT + 2; i++) {
+        await commandBus.execute(
+          new CreateApiKeyCommand({
+            type: ApiKeyType.INTERNAL,
+            name: `Internal ${i}`,
+            internalServiceName: `svc-${nanoid(8)}`,
+          }),
+        );
+      }
+
+      const result = await commandBus.execute(
+        new CreateApiKeyCommand({
+          type: ApiKeyType.PERSONAL,
+          name: 'Personal after internals',
+          userId,
+        }),
+      );
+      expect(result.id).toBeDefined();
+    });
+  });
+});

--- a/src/features/api-key/commands/__tests__/create-api-key.handler.spec.ts
+++ b/src/features/api-key/commands/__tests__/create-api-key.handler.spec.ts
@@ -3,6 +3,7 @@ import {
   ConflictException,
   NotFoundException,
 } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { CommandBus, CqrsModule } from '@nestjs/cqrs';
 import { Test, TestingModule } from '@nestjs/testing';
 import { nanoid } from 'nanoid';
@@ -21,7 +22,12 @@ describe('CreateApiKeyHandler', () => {
   beforeAll(async () => {
     const module: TestingModule = await Test.createTestingModule({
       imports: [CqrsModule, RevisiumCacheModule.forRootAsync()],
-      providers: [CreateApiKeyHandler, ApiKeyService, PrismaService],
+      providers: [
+        CreateApiKeyHandler,
+        ApiKeyService,
+        PrismaService,
+        { provide: ConfigService, useValue: { get: () => undefined } },
+      ],
     }).compile();
 
     await module.init();

--- a/src/features/api-key/commands/__tests__/revoke-api-key.handler.spec.ts
+++ b/src/features/api-key/commands/__tests__/revoke-api-key.handler.spec.ts
@@ -1,4 +1,5 @@
 import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { CommandBus, CqrsModule } from '@nestjs/cqrs';
 import { Test, TestingModule } from '@nestjs/testing';
 import { nanoid } from 'nanoid';
@@ -28,6 +29,7 @@ describe('RevokeApiKeyHandler', () => {
         CreateApiKeyHandler,
         ApiKeyService,
         PrismaService,
+        { provide: ConfigService, useValue: { get: () => undefined } },
       ],
     }).compile();
 

--- a/src/features/api-key/commands/__tests__/rotate-api-key.handler.spec.ts
+++ b/src/features/api-key/commands/__tests__/rotate-api-key.handler.spec.ts
@@ -1,4 +1,5 @@
 import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { CommandBus, CqrsModule } from '@nestjs/cqrs';
 import { Test, TestingModule } from '@nestjs/testing';
 import { nanoid } from 'nanoid';
@@ -31,6 +32,7 @@ describe('RotateApiKeyHandler', () => {
         CreateApiKeyHandler,
         ApiKeyService,
         PrismaService,
+        { provide: ConfigService, useValue: { get: () => undefined } },
       ],
     }).compile();
 

--- a/src/features/api-key/commands/handlers/create-api-key.handler.ts
+++ b/src/features/api-key/commands/handlers/create-api-key.handler.ts
@@ -3,6 +3,7 @@ import {
   ConflictException,
   NotFoundException,
 } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 import { ApiKeyType } from 'src/__generated__/client';
 import { ApiKeyService } from 'src/features/api-key/api-key.service';
@@ -16,6 +17,8 @@ import { PrismaService } from 'src/infrastructure/database/prisma.service';
 
 const MAX_NAME_LENGTH = 255;
 const MAX_INTERNAL_SERVICE_NAME_LENGTH = 50;
+const DEFAULT_MAX_PERSONAL_KEYS_PER_USER = 10;
+const DEFAULT_MAX_SERVICE_KEYS_PER_ORG = 100;
 
 const VALID_ACTIONS = new Set<string>([
   ...Object.values(PermissionAction),
@@ -34,6 +37,7 @@ export class CreateApiKeyHandler implements ICommandHandler<
   constructor(
     private readonly prisma: PrismaService,
     private readonly apiKeyService: ApiKeyService,
+    private readonly configService: ConfigService,
   ) {}
 
   async execute({
@@ -44,6 +48,7 @@ export class CreateApiKeyHandler implements ICommandHandler<
     this.validateCrossFields(data);
     this.validatePermissions(data);
     await this.validateReferences(data);
+    await this.validateKeyLimit(data);
 
     const { key, hash, prefix } = this.apiKeyService.generateKey();
 
@@ -239,6 +244,50 @@ export class CreateApiKeyHandler implements ICommandHandler<
       if (!org) {
         throw new NotFoundException(
           `Organization "${data.organizationId}" not found`,
+        );
+      }
+    }
+  }
+
+  private async validateKeyLimit(
+    data: CreateApiKeyCommand['data'],
+  ): Promise<void> {
+    if (data.type === ApiKeyType.PERSONAL) {
+      const max =
+        Number(this.configService.get('API_KEY_MAX_PER_USER')) ||
+        DEFAULT_MAX_PERSONAL_KEYS_PER_USER;
+
+      const count = await this.prisma.apiKey.count({
+        where: {
+          type: ApiKeyType.PERSONAL,
+          userId: data.userId,
+          revokedAt: null,
+        },
+      });
+
+      if (count >= max) {
+        throw new BadRequestException(
+          `Maximum number of personal API keys (${max}) reached. Revoke unused keys to create new ones.`,
+        );
+      }
+    }
+
+    if (data.type === ApiKeyType.SERVICE) {
+      const max =
+        Number(this.configService.get('API_KEY_MAX_SERVICE_PER_ORG')) ||
+        DEFAULT_MAX_SERVICE_KEYS_PER_ORG;
+
+      const count = await this.prisma.apiKey.count({
+        where: {
+          type: ApiKeyType.SERVICE,
+          organizationId: data.organizationId,
+          revokedAt: null,
+        },
+      });
+
+      if (count >= max) {
+        throw new BadRequestException(
+          `Maximum number of service API keys (${max}) reached for this organization. Revoke unused keys to create new ones.`,
         );
       }
     }

--- a/src/features/api-key/queries/__tests__/get-api-keys.handler.spec.ts
+++ b/src/features/api-key/queries/__tests__/get-api-keys.handler.spec.ts
@@ -1,3 +1,4 @@
+import { ConfigService } from '@nestjs/config';
 import { CommandBus, CqrsModule, QueryBus } from '@nestjs/cqrs';
 import { Test, TestingModule } from '@nestjs/testing';
 import { nanoid } from 'nanoid';
@@ -31,6 +32,7 @@ describe('GetApiKeysHandler', () => {
         RevokeApiKeyHandler,
         ApiKeyService,
         PrismaService,
+        { provide: ConfigService, useValue: { get: () => undefined } },
       ],
     }).compile();
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds configurable API key limits and documents API key auth in Swagger using the `X-Api-Key` header. Defaults to 10 personal keys per user and 100 service keys per org; revoking a key frees a slot and internal keys are not limited.

- **New Features**
  - Enforce limits: `API_KEY_MAX_PER_USER` (default 10) and `API_KEY_MAX_SERVICE_PER_ORG` (default 100); only counts non-revoked keys.
  - Add `X-Api-Key` security scheme to Swagger; also supports `?api_key=rev_...` for webhooks.
  - Annotate all REST controllers with `@ApiSecurity('api-key')` and regenerate `openapi.json`.
  - Add unit tests for limit enforcement.
  - Stabilize API key tests by injecting `ConfigService` across all API key test modules.

- **Migration**
  - Optionally set `API_KEY_MAX_PER_USER` and `API_KEY_MAX_SERVICE_PER_ORG` in your `.env`.
  - In Swagger, send API keys via the `X-Api-Key` header (or `?api_key=` for webhook calls).

<sup>Written for commit acd001f433a2d400540738425abc84ae2249ef7e. Summary will update on new commits. <a href="https://cubic.dev/pr/revisium/revisium-core/pull/482">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

