### PR TITLE
fix: invalidate auth cache when project visibility changes

### DIFF
--- a/src/features/project/commands/handlers/__tests__/update-project.handler.spec.ts
+++ b/src/features/project/commands/handlers/__tests__/update-project.handler.spec.ts
@@ -1,0 +1,70 @@
+import { CommandBus } from '@nestjs/cqrs';
+import { prepareProject } from 'src/__tests__/utils/prepareProject';
+import { createTestingModule } from 'src/features/project/commands/handlers/__tests__/utils';
+import {
+  UpdateProjectCommand,
+  UpdateProjectCommandReturnType,
+} from 'src/features/project/commands/impl';
+import { AuthCacheService } from 'src/infrastructure/cache/services/auth-cache.service';
+import { PrismaService } from 'src/infrastructure/database/prisma.service';
+
+describe('UpdateProjectHandler', () => {
+  it('should update isPublic', async () => {
+    const { organizationId, projectName, projectId } =
+      await prepareProject(prismaService);
+
+    const command = new UpdateProjectCommand({
+      organizationId,
+      projectName,
+      isPublic: true,
+    });
+
+    const result = await execute(command);
+
+    const project = await prismaService.project.findUnique({
+      where: { id: projectId },
+    });
+
+    expect(result).toBe(true);
+    expect(project?.isPublic).toBe(true);
+  });
+
+  it('should invalidate project permissions cache after update', async () => {
+    const { organizationId, projectName } = await prepareProject(prismaService);
+
+    const spy = jest.spyOn(authCacheService, 'invalidateProjectPermissions');
+
+    const command = new UpdateProjectCommand({
+      organizationId,
+      projectName,
+      isPublic: true,
+    });
+
+    await execute(command);
+
+    expect(spy).toHaveBeenCalledWith(organizationId, projectName);
+
+    spy.mockRestore();
+  });
+
+  let prismaService: PrismaService;
+  let commandBus: CommandBus;
+  let authCacheService: AuthCacheService;
+
+  function execute(
+    command: UpdateProjectCommand,
+  ): Promise<UpdateProjectCommandReturnType> {
+    return commandBus.execute(command);
+  }
+
+  beforeAll(async () => {
+    const result = await createTestingModule();
+    prismaService = result.prismaService;
+    commandBus = result.commandBus;
+    authCacheService = result.module.get(AuthCacheService);
+  });
+
+  afterAll(async () => {
+    await prismaService.$disconnect();
+  });
+});

--- a/src/features/project/commands/handlers/__tests__/utils.ts
+++ b/src/features/project/commands/handlers/__tests__/utils.ts
@@ -9,6 +9,7 @@ import { PROJECT_QUERIES } from 'src/features/project/queries/handlers';
 import { ShareModule } from 'src/features/share/share.module';
 import { ShareTransactionalQueries } from 'src/features/share/share.transactional.queries';
 import { SystemTables } from 'src/features/share/system-tables.consts';
+import { RevisiumCacheModule } from 'src/infrastructure/cache';
 import { DatabaseModule } from 'src/infrastructure/database/database.module';
 import { PrismaService } from 'src/infrastructure/database/prisma.service';
 import { TransactionPrismaService } from 'src/infrastructure/database/transaction-prisma.service';
@@ -24,6 +25,7 @@ export const createTestingModule = async () => {
       AppOptionsModule.forRoot({ mode: 'monolith' }),
       BillingModule,
       NotificationModule,
+      RevisiumCacheModule.forRootAsync(),
     ],
     providers: [
       {

--- a/src/features/project/commands/handlers/update-project.handler.ts
+++ b/src/features/project/commands/handlers/update-project.handler.ts
@@ -1,4 +1,5 @@
 import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+import { AuthCacheService } from 'src/infrastructure/cache/services/auth-cache.service';
 import { TransactionPrismaService } from 'src/infrastructure/database/transaction-prisma.service';
 import { UpdateProjectCommand } from 'src/features/project/commands/impl';
 import { ShareTransactionalQueries } from 'src/features/share/share.transactional.queries';
@@ -11,6 +12,7 @@ export class UpdateProjectHandler implements ICommandHandler<
   constructor(
     private readonly transactionPrisma: TransactionPrismaService,
     private readonly shareTransactionalQueries: ShareTransactionalQueries,
+    private readonly authCache: AuthCacheService,
   ) {}
 
   private get transaction() {
@@ -18,9 +20,16 @@ export class UpdateProjectHandler implements ICommandHandler<
   }
 
   public async execute({ data }: UpdateProjectCommand): Promise<boolean> {
-    return this.transactionPrisma.runSerializable(() =>
+    const result = await this.transactionPrisma.runSerializable(() =>
       this.transactionHandler(data),
     );
+
+    await this.authCache.invalidateProjectPermissions(
+      data.organizationId,
+      data.projectName,
+    );
+
+    return result;
   }
 
   private async transactionHandler(data: UpdateProjectCommand['data']) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Invalidate project permissions cache when a project's `isPublic` flag changes to prevent stale permissions and unauthorized access.

- **Bug Fixes**
  - In `UpdateProjectHandler`, call `invalidateProjectPermissions` after the transactional update.
  - Added tests to verify visibility is updated and cache invalidation is triggered.

<sup>Written for commit ff65e9b4e2bda29441d189799c51e06212c61fee. Summary will update on new commits. <a href="https://cubic.dev/pr/revisium/revisium-core/pull/483">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

