### PR TITLE
Add manage-api-key CASL permission

### DIFF
--- a/prisma/seed/permissions/manage-api-key.json
+++ b/prisma/seed/permissions/manage-api-key.json
@@ -1,0 +1,5 @@
+{
+  "action": "manage",
+  "subject": "ApiKey",
+  "condition": {}
+}

--- a/prisma/seed/roles/developer.json
+++ b/prisma/seed/roles/developer.json
@@ -17,6 +17,7 @@
     "delete-endpoint",
     "read-user",
     "read-project-private",
-    "read-project-public"
+    "read-project-public",
+    "manage-api-key"
   ]
 }

--- a/prisma/seed/roles/organizationAdmin.json
+++ b/prisma/seed/roles/organizationAdmin.json
@@ -23,6 +23,7 @@
     "delete-user",
     "read-user",
     "read-project-private",
-    "read-project-public"
+    "read-project-public",
+    "manage-api-key"
   ]
 }

--- a/prisma/seed/roles/organizationOwner.json
+++ b/prisma/seed/roles/organizationOwner.json
@@ -25,6 +25,7 @@
     "delete-user",
     "read-user",
     "read-project-private",
-    "read-project-public"
+    "read-project-public",
+    "manage-api-key"
   ]
 }

--- a/prisma/seed/roles/systemAdmin.json
+++ b/prisma/seed/roles/systemAdmin.json
@@ -26,6 +26,7 @@
     "delete-user",
     "read-user",
     "read-project-private",
-    "read-project-public"
+    "read-project-public",
+    "manage-api-key"
   ]
 }

--- a/src/api/graphql-api/api-key/__tests__/service-api-key.e2e.spec.ts
+++ b/src/api/graphql-api/api-key/__tests__/service-api-key.e2e.spec.ts
@@ -156,13 +156,13 @@ describe('Service API Key Management (e2e)', () => {
       expect(apiKey.readOnly).toBe(true);
     });
 
-    it('should reject service key creation by non-admin', async () => {
+    it('should allow service key creation by developer (has manage-api-key)', async () => {
       const response = await graphqlRequest(preparedData.developer.token)
         .send({
           query: CREATE_SERVICE_API_KEY,
           variables: {
             data: {
-              name: 'Unauthorized Key',
+              name: 'Developer Key',
               organizationId: preparedData.project.organizationId,
               permissions: {
                 rules: [{ action: ['read'], subject: ['Row'] }],
@@ -172,10 +172,9 @@ describe('Service API Key Management (e2e)', () => {
         })
         .expect(200);
 
-      expect(response.body.errors).toBeDefined();
-      expect(response.body.errors[0].message).toContain(
-        'Only organization admins',
-      );
+      const result = response.body.data.createServiceApiKey;
+      expect(result.secret).toMatch(/^rev_[A-Za-z0-9_-]{22}$/);
+      expect(result.apiKey.type).toBe('SERVICE');
     });
 
     it('should reject service key creation by admin of another org', async () => {
@@ -196,7 +195,7 @@ describe('Service API Key Management (e2e)', () => {
 
       expect(response.body.errors).toBeDefined();
       expect(response.body.errors[0].message).toContain(
-        'Only organization admins',
+        'do not have permission to manage API keys',
       );
     });
 
@@ -280,7 +279,7 @@ describe('Service API Key Management (e2e)', () => {
       expect(names).toContain('Service Key Alpha');
     });
 
-    it('should reject listing by non-admin', async () => {
+    it('should reject listing by reader (no manage-api-key)', async () => {
       const response = await graphqlRequest(preparedData.reader.token)
         .send({
           query: SERVICE_API_KEYS,
@@ -292,7 +291,7 @@ describe('Service API Key Management (e2e)', () => {
 
       expect(response.body.errors).toBeDefined();
       expect(response.body.errors[0].message).toContain(
-        'Only organization admins',
+        'do not have permission to manage API keys',
       );
     });
   });
@@ -332,7 +331,7 @@ describe('Service API Key Management (e2e)', () => {
       expect(revokeResponse.body.data.revokeApiKey.revokedAt).not.toBeNull();
     });
 
-    it('should reject revoke by non-admin', async () => {
+    it('should reject revoke by reader (no manage-api-key)', async () => {
       const createResponse = await graphqlRequest(preparedData.owner.token)
         .send({
           query: CREATE_SERVICE_API_KEY,
@@ -350,7 +349,7 @@ describe('Service API Key Management (e2e)', () => {
 
       const keyId = createResponse.body.data.createServiceApiKey.apiKey.id;
 
-      const revokeResponse = await graphqlRequest(preparedData.developer.token)
+      const revokeResponse = await graphqlRequest(preparedData.reader.token)
         .send({
           query: REVOKE_API_KEY,
           variables: { id: keyId },

--- a/src/api/graphql-api/api-key/__tests__/service-api-key.resolver.spec.ts
+++ b/src/api/graphql-api/api-key/__tests__/service-api-key.resolver.spec.ts
@@ -11,8 +11,14 @@ import { RevokeApiKeyHandler } from 'src/features/api-key/commands/handlers';
 import { RotateApiKeyHandler } from 'src/features/api-key/commands/handlers';
 import { GetApiKeyByIdHandler } from 'src/features/api-key/queries/handlers';
 import { GetApiKeysHandler } from 'src/features/api-key/queries/handlers';
+import { CaslAbilityFactory } from 'src/features/auth/casl-ability.factory';
+import {
+  CheckOrganizationPermissionHandler,
+  CheckProjectPermissionHandler,
+} from 'src/features/auth/commands/handlers';
 import {
   UserOrganizationRoles,
+  UserProjectRoles,
   UserSystemRoles,
 } from 'src/features/auth/consts';
 import { RevisiumCacheModule } from 'src/infrastructure/cache';
@@ -33,6 +39,9 @@ describe('ApiKeyApiService - Service Keys', () => {
         RotateApiKeyHandler,
         GetApiKeyByIdHandler,
         GetApiKeysHandler,
+        CheckOrganizationPermissionHandler,
+        CheckProjectPermissionHandler,
+        CaslAbilityFactory,
         PrismaService,
         { provide: ConfigService, useValue: { get: () => undefined } },
       ],
@@ -42,6 +51,8 @@ describe('ApiKeyApiService - Service Keys', () => {
 
     service = module.get(ApiKeyApiService);
     prisma = module.get(PrismaService);
+
+    await seedManageApiKeyPermission(prisma);
   });
 
   afterAll(async () => {
@@ -72,6 +83,33 @@ describe('ApiKeyApiService - Service Keys', () => {
       },
     });
     return userId;
+  };
+
+  const createProject = async (orgId: string, name?: string) => {
+    const projectName = name ?? `project-${nanoid(6)}`;
+    const project = await prisma.project.create({
+      data: {
+        id: nanoid(),
+        name: projectName,
+        organizationId: orgId,
+      },
+    });
+    return project;
+  };
+
+  const assignProjectRole = async (
+    projectId: string,
+    userId: string,
+    roleId: string,
+  ) => {
+    await prisma.userProject.create({
+      data: {
+        id: nanoid(),
+        projectId,
+        userId,
+        roleId,
+      },
+    });
   };
 
   const validPermissions = {
@@ -140,18 +178,18 @@ describe('ApiKeyApiService - Service Keys', () => {
       expect(result.id).toBeDefined();
     });
 
-    it('should reject when user is a regular developer', async () => {
+    it('should allow developer with org membership to create org-wide service key', async () => {
       const orgId = await createOrg();
       const devId = await createOrgUser(orgId, UserOrganizationRoles.developer);
 
-      await expect(
-        service.createServiceApiKey({
-          name: 'Unauthorized Key',
-          userId: devId,
-          organizationId: orgId,
-          permissions: validPermissions,
-        }),
-      ).rejects.toThrow(ForbiddenException);
+      const result = await service.createServiceApiKey({
+        name: 'Developer Org Key',
+        userId: devId,
+        organizationId: orgId,
+        permissions: validPermissions,
+      });
+
+      expect(result.id).toBeDefined();
     });
 
     it('should reject when user is not a member of the org', async () => {
@@ -170,6 +208,98 @@ describe('ApiKeyApiService - Service Keys', () => {
           permissions: validPermissions,
         }),
       ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('should allow developer to create project-scoped service key', async () => {
+      const orgId = await createOrg();
+      const devId = await createOrgUser(orgId, UserOrganizationRoles.developer);
+      const project = await createProject(orgId);
+      await assignProjectRole(project.id, devId, UserProjectRoles.developer);
+
+      const result = await service.createServiceApiKey({
+        name: 'Project Scoped Key',
+        userId: devId,
+        organizationId: orgId,
+        projectIds: [project.id],
+        permissions: validPermissions,
+      });
+
+      expect(result.id).toBeDefined();
+
+      const stored = await prisma.apiKey.findUnique({
+        where: { id: result.id },
+      });
+      expect(stored!.projectIds).toEqual([project.id]);
+    });
+
+    it('should reject editor creating project-scoped key (no manage-api-key)', async () => {
+      const orgId = await createOrg();
+      const editorId = await createOrgUser(orgId, UserOrganizationRoles.editor);
+      const project = await createProject(orgId);
+      await assignProjectRole(project.id, editorId, UserProjectRoles.editor);
+
+      await expect(
+        service.createServiceApiKey({
+          name: 'Unauthorized Project Key',
+          userId: editorId,
+          organizationId: orgId,
+          projectIds: [project.id],
+          permissions: validPermissions,
+        }),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('should reject editor creating project-scoped service key', async () => {
+      const orgId = await createOrg();
+      const editorId = await createOrgUser(orgId, UserOrganizationRoles.editor);
+      const project = await createProject(orgId);
+      await assignProjectRole(project.id, editorId, UserProjectRoles.editor);
+
+      await expect(
+        service.createServiceApiKey({
+          name: 'Editor Key',
+          userId: editorId,
+          organizationId: orgId,
+          projectIds: [project.id],
+          permissions: validPermissions,
+        }),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('should reject reader creating project-scoped service key', async () => {
+      const orgId = await createOrg();
+      const readerId = await createOrgUser(orgId, UserOrganizationRoles.reader);
+      const project = await createProject(orgId);
+      await assignProjectRole(project.id, readerId, UserProjectRoles.reader);
+
+      await expect(
+        service.createServiceApiKey({
+          name: 'Reader Key',
+          userId: readerId,
+          organizationId: orgId,
+          projectIds: [project.id],
+          permissions: validPermissions,
+        }),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('should allow org admin to create project-scoped service key', async () => {
+      const orgId = await createOrg();
+      const adminId = await createOrgUser(
+        orgId,
+        UserOrganizationRoles.organizationAdmin,
+      );
+      const project = await createProject(orgId);
+
+      const result = await service.createServiceApiKey({
+        name: 'Admin Project Key',
+        userId: adminId,
+        organizationId: orgId,
+        projectIds: [project.id],
+        permissions: validPermissions,
+      });
+
+      expect(result.id).toBeDefined();
     });
   });
 
@@ -210,6 +340,14 @@ describe('ApiKeyApiService - Service Keys', () => {
         ForbiddenException,
       );
     });
+
+    it('should allow listing for developer with org membership', async () => {
+      const orgId = await createOrg();
+      const devId = await createOrgUser(orgId, UserOrganizationRoles.developer);
+
+      const keys = await service.getServiceApiKeys(orgId, devId);
+      expect(keys).toBeDefined();
+    });
   });
 
   describe('revokeApiKey - service keys', () => {
@@ -235,13 +373,13 @@ describe('ApiKeyApiService - Service Keys', () => {
       expect(stored!.revokedAt).not.toBeNull();
     });
 
-    it('should reject revoke by non-admin of org', async () => {
+    it('should reject revoke by reader (no manage-api-key)', async () => {
       const orgId = await createOrg();
       const ownerId = await createOrgUser(
         orgId,
         UserOrganizationRoles.organizationOwner,
       );
-      const devId = await createOrgUser(orgId, UserOrganizationRoles.developer);
+      const readerId = await createOrgUser(orgId, UserOrganizationRoles.reader);
 
       const created = await service.createServiceApiKey({
         name: 'Not Yours',
@@ -250,7 +388,7 @@ describe('ApiKeyApiService - Service Keys', () => {
         permissions: validPermissions,
       });
 
-      await expect(service.revokeApiKey(created.id, devId)).rejects.toThrow(
+      await expect(service.revokeApiKey(created.id, readerId)).rejects.toThrow(
         NotFoundException,
       );
     });
@@ -277,6 +415,28 @@ describe('ApiKeyApiService - Service Keys', () => {
       await expect(service.revokeApiKey(created.id, ownerB)).rejects.toThrow(
         NotFoundException,
       );
+    });
+
+    it('should allow developer to revoke project-scoped key they created', async () => {
+      const orgId = await createOrg();
+      const devId = await createOrgUser(orgId, UserOrganizationRoles.developer);
+      const project = await createProject(orgId);
+      await assignProjectRole(project.id, devId, UserProjectRoles.developer);
+
+      const created = await service.createServiceApiKey({
+        name: 'Dev Project Key',
+        userId: devId,
+        organizationId: orgId,
+        projectIds: [project.id],
+        permissions: validPermissions,
+      });
+
+      await service.revokeApiKey(created.id, devId);
+
+      const stored = await prisma.apiKey.findUnique({
+        where: { id: created.id },
+      });
+      expect(stored!.revokedAt).not.toBeNull();
     });
   });
 
@@ -342,13 +502,13 @@ describe('ApiKeyApiService - Service Keys', () => {
       expect(key.name).toBe('Get Me');
     });
 
-    it('should reject access by non-admin', async () => {
+    it('should reject access by reader (no manage-api-key)', async () => {
       const orgId = await createOrg();
       const ownerId = await createOrgUser(
         orgId,
         UserOrganizationRoles.organizationOwner,
       );
-      const devId = await createOrgUser(orgId, UserOrganizationRoles.developer);
+      const readerId = await createOrgUser(orgId, UserOrganizationRoles.reader);
 
       const created = await service.createServiceApiKey({
         name: 'Not Yours',
@@ -357,9 +517,75 @@ describe('ApiKeyApiService - Service Keys', () => {
         permissions: validPermissions,
       });
 
-      await expect(service.getApiKeyById(created.id, devId)).rejects.toThrow(
+      await expect(service.getApiKeyById(created.id, readerId)).rejects.toThrow(
         NotFoundException,
       );
     });
+
+    it('should allow developer to access project-scoped key', async () => {
+      const orgId = await createOrg();
+      const devId = await createOrgUser(orgId, UserOrganizationRoles.developer);
+      const project = await createProject(orgId);
+      await assignProjectRole(project.id, devId, UserProjectRoles.developer);
+
+      const created = await service.createServiceApiKey({
+        name: 'Dev Accessible Key',
+        userId: devId,
+        organizationId: orgId,
+        projectIds: [project.id],
+        permissions: validPermissions,
+      });
+
+      const key = await service.getApiKeyById(created.id, devId);
+      expect(key.id).toBe(created.id);
+    });
   });
 });
+
+async function seedManageApiKeyPermission(prisma: PrismaService) {
+  await prisma.permission.upsert({
+    where: { id: 'manage-api-key' },
+    create: {
+      id: 'manage-api-key',
+      action: 'manage',
+      subject: 'ApiKey',
+      condition: {},
+    },
+    update: { action: 'manage', subject: 'ApiKey' },
+  });
+
+  const rolesWithPermission = [
+    'organizationOwner',
+    'organizationAdmin',
+    'developer',
+    'systemAdmin',
+  ];
+
+  const rolesWithoutPermission = ['editor', 'reader'];
+
+  for (const roleId of rolesWithPermission) {
+    await prisma.role
+      .update({
+        where: { id: roleId },
+        data: {
+          permissions: { connect: { id: 'manage-api-key' } },
+        },
+      })
+      .catch(() => {
+        // Role may not exist in test DB — skip
+      });
+  }
+
+  for (const roleId of rolesWithoutPermission) {
+    await prisma.role
+      .update({
+        where: { id: roleId },
+        data: {
+          permissions: { disconnect: { id: 'manage-api-key' } },
+        },
+      })
+      .catch(() => {
+        // Role may not exist in test DB — skip
+      });
+  }
+}

--- a/src/features/api-key/api-key-api.service.ts
+++ b/src/features/api-key/api-key-api.service.ts
@@ -3,6 +3,7 @@ import {
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
+import { ForbiddenError } from '@casl/ability';
 import { CommandBus, QueryBus } from '@nestjs/cqrs';
 import { nanoid } from 'nanoid';
 import { ApiKeyType, Prisma } from 'src/__generated__/client';
@@ -21,17 +22,21 @@ import {
   GetApiKeysQueryReturnType,
 } from 'src/features/api-key/queries/impl';
 import {
-  UserOrganizationRoles,
-  UserSystemRoles,
-} from 'src/features/auth/consts';
-import { PrismaService } from 'src/infrastructure/database/prisma.service';
+  CheckOrganizationPermissionCommand,
+  CheckProjectPermissionCommand,
+} from 'src/features/auth/commands/impl';
+import { PermissionAction, PermissionSubject } from 'src/features/auth/consts';
+
+const MANAGE_API_KEY_PERMISSION = {
+  action: PermissionAction.manage,
+  subject: PermissionSubject.ApiKey,
+};
 
 @Injectable()
 export class ApiKeyApiService {
   constructor(
     private readonly commandBus: CommandBus,
     private readonly queryBus: QueryBus,
-    private readonly prisma: PrismaService,
   ) {}
 
   async createPersonalApiKey(data: {
@@ -73,7 +78,11 @@ export class ApiKeyApiService {
     expiresAt?: Date;
     permissions: Prisma.InputJsonValue;
   }): Promise<CreateApiKeyCommandReturnType> {
-    await this.assertOrgAdmin(data.userId, data.organizationId);
+    await this.assertManageApiKeyPermission(
+      data.userId,
+      data.organizationId,
+      data.projectIds,
+    );
 
     const serviceId = `svc_${nanoid(12)}`;
 
@@ -118,7 +127,7 @@ export class ApiKeyApiService {
     organizationId: string,
     userId: string,
   ): Promise<GetApiKeysQueryReturnType> {
-    await this.assertOrgAdmin(userId, organizationId);
+    await this.assertManageApiKeyPermission(userId, organizationId);
 
     return this.queryBus.execute(
       new GetApiKeysQuery({
@@ -148,7 +157,11 @@ export class ApiKeyApiService {
         throw new NotFoundException('API key not found');
       }
       try {
-        await this.assertOrgAdmin(userId, apiKey.organizationId);
+        await this.assertManageApiKeyPermission(
+          userId,
+          apiKey.organizationId,
+          apiKey.projectIds.length > 0 ? apiKey.projectIds : undefined,
+        );
       } catch (error) {
         if (error instanceof ForbiddenException) {
           throw new NotFoundException('API key not found');
@@ -165,32 +178,38 @@ export class ApiKeyApiService {
     return apiKey;
   }
 
-  private async assertOrgAdmin(
+  private async assertManageApiKeyPermission(
     userId: string,
     organizationId: string,
+    projectIds?: string[],
   ): Promise<void> {
-    const user = await this.prisma.user.findUnique({
-      where: { id: userId },
-      select: { roleId: true },
-    });
-
-    if (user?.roleId === UserSystemRoles.systemAdmin) {
-      return;
-    }
-
-    const membership = await this.prisma.userOrganization.findFirst({
-      where: { userId, organizationId },
-      select: { roleId: true },
-    });
-
-    if (
-      !membership ||
-      (membership.roleId !== UserOrganizationRoles.organizationOwner &&
-        membership.roleId !== UserOrganizationRoles.organizationAdmin)
-    ) {
-      throw new ForbiddenException(
-        'Only organization admins can manage service API keys',
-      );
+    try {
+      if (projectIds && projectIds.length > 0) {
+        for (const projectId of projectIds) {
+          await this.commandBus.execute(
+            new CheckProjectPermissionCommand({
+              permissions: [MANAGE_API_KEY_PERMISSION],
+              projectId,
+              userId,
+            }),
+          );
+        }
+      } else {
+        await this.commandBus.execute(
+          new CheckOrganizationPermissionCommand({
+            permissions: [MANAGE_API_KEY_PERMISSION],
+            organizationId,
+            userId,
+          }),
+        );
+      }
+    } catch (error) {
+      if (error instanceof ForbiddenError) {
+        throw new ForbiddenException(
+          'You do not have permission to manage API keys',
+        );
+      }
+      throw error;
     }
   }
 }

--- a/src/features/auth/consts.ts
+++ b/src/features/auth/consts.ts
@@ -57,6 +57,7 @@ export enum PermissionAction {
   revert = 'revert',
   update = 'update',
   add = 'add',
+  manage = 'manage',
 }
 
 export enum PermissionSubject {
@@ -68,4 +69,5 @@ export enum PermissionSubject {
   Row = 'Row',
   Endpoint = 'Endpoint',
   User = 'User',
+  ApiKey = 'ApiKey',
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a CASL permission to manage API keys and replace role-based checks with permission guards. This lets developers and admins manage service API keys at org or project scope, while editors/readers remain blocked.

- New Features
  - Added a `manage` permission for the ApiKey subject and wired checks through `CheckOrganizationPermissionCommand` and `CheckProjectPermissionCommand` using `@casl/ability`.
  - Updated role seeds: organizationOwner, organizationAdmin, developer, and systemAdmin can manage API keys; editor and reader cannot.
  - Api key operations (create, list, get, revoke, rotate) now validate org or project-scoped permissions and return a clearer “You do not have permission to manage API keys” error when blocked.

- Migration
  - Rerun role/permission seeds to add the manage-api-key permission and update role mappings.

<sup>Written for commit 551880e05fb0c9410a653337ba553f8c96f83028. Summary will update on new commits. <a href="https://cubic.dev/pr/revisium/revisium-core/pull/484">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

