### PR TITLE
feat: admin cache management with stats and reset

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.816.0",
+        "@bentocache/plugin-prometheus": "^0.2.0",
         "@casl/ability": "^6.7.5",
         "@graphql-yoga/nestjs": "^3.8.0",
         "@modelcontextprotocol/sdk": "^1.25.3",
@@ -1693,6 +1694,16 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@bentocache/plugin-prometheus": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@bentocache/plugin-prometheus/-/plugin-prometheus-0.2.0.tgz",
+      "integrity": "sha512-ZaWtexpwDf6cSy2dZaRl36BAZi1eSM8QDnGeJQ0qN7rJ6TEvrP3v0egH70Gxc5mdHY7xhh0Zppf+kAoTgJZx3A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "bentocache": "^1.0.0",
+        "prom-client": "^15.0.0"
+      }
     },
     "node_modules/@biomejs/js-api": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.816.0",
+    "@bentocache/plugin-prometheus": "^0.2.0",
     "@casl/ability": "^6.7.5",
     "@graphql-yoga/nestjs": "^3.8.0",
     "@modelcontextprotocol/sdk": "^1.25.3",
@@ -207,7 +208,8 @@
     "moduleNameMapper": {
       "^bentocache$": "<rootDir>/src/infrastructure/cache/__mocks__/bentocache.js",
       "^bentocache/drivers/memory$": "<rootDir>/src/infrastructure/cache/__mocks__/bentocache-memory.js",
-      "^bentocache/drivers/redis$": "<rootDir>/src/infrastructure/cache/__mocks__/bentocache-redis.js"
+      "^bentocache/drivers/redis$": "<rootDir>/src/infrastructure/cache/__mocks__/bentocache-redis.js",
+      "^@bentocache/plugin-prometheus$": "<rootDir>/src/infrastructure/cache/__mocks__/bentocache-plugin-prometheus.js"
     }
   }
 }

--- a/prisma/seed/permissions/manage-cache.json
+++ b/prisma/seed/permissions/manage-cache.json
@@ -1,0 +1,5 @@
+{
+  "action": "manage",
+  "subject": "Cache",
+  "condition": {}
+}

--- a/prisma/seed/permissions/read-cache.json
+++ b/prisma/seed/permissions/read-cache.json
@@ -1,0 +1,5 @@
+{
+  "action": "read",
+  "subject": "Cache",
+  "condition": {}
+}

--- a/prisma/seed/roles/systemAdmin.json
+++ b/prisma/seed/roles/systemAdmin.json
@@ -27,6 +27,8 @@
     "read-user",
     "read-project-private",
     "read-project-public",
-    "manage-api-key"
+    "manage-api-key",
+    "read-cache",
+    "manage-cache"
   ]
 }

--- a/src/__tests__/e2e/graphql/readonly/admin-cache.spec.ts
+++ b/src/__tests__/e2e/graphql/readonly/admin-cache.spec.ts
@@ -1,0 +1,207 @@
+import { INestApplication } from '@nestjs/common';
+import { nanoid } from 'nanoid';
+import { testCreateUser } from 'src/__tests__/create-models';
+import { gql } from 'src/__tests__/utils/gql';
+import { UserSystemRoles } from 'src/features/auth/consts';
+import { AuthService } from 'src/features/auth/auth.service';
+import { PrismaService } from 'src/infrastructure/database/prisma.service';
+import {
+  getTestApp,
+  closeTestApp,
+  getReadonlyFixture,
+  gqlQuery,
+  gqlQueryRaw,
+  type PrepareDataReturnType,
+} from 'src/__tests__/e2e/shared';
+
+describe('graphql - admin cache (readonly)', () => {
+  let app: INestApplication;
+  let fixture: PrepareDataReturnType;
+  let prismaService: PrismaService;
+  let authService: AuthService;
+
+  beforeAll(async () => {
+    app = await getTestApp();
+    fixture = await getReadonlyFixture(app);
+    prismaService = app.get(PrismaService);
+    authService = app.get(AuthService);
+  });
+
+  afterAll(async () => {
+    await closeTestApp();
+  });
+
+  const createAdminUser = async () => {
+    const userId = nanoid();
+    const user = await testCreateUser(prismaService, {
+      id: userId,
+      email: `admin-cache-${userId}@example.com`,
+      username: `admin-cache-${userId}`,
+      roleId: UserSystemRoles.systemAdmin,
+    });
+    const token = authService.login({
+      username: user.username ?? '',
+      sub: user.id,
+    });
+    return { user, token };
+  };
+
+  describe('adminCacheStats query', () => {
+    const getQuery = () => ({
+      query: gql`
+        query adminCacheStats {
+          adminCacheStats {
+            totalHits
+            totalMisses
+            totalWrites
+            totalDeletes
+            totalClears
+            overallHitRate
+            byCategory {
+              key
+              hits
+              misses
+              writes
+              deletes
+              hitRate
+            }
+          }
+        }
+      `,
+    });
+
+    it('admin can get cache stats', async () => {
+      const admin = await createAdminUser();
+
+      const result = await gqlQuery({
+        app,
+        token: admin.token,
+        ...getQuery(),
+      });
+
+      expect(result.adminCacheStats).toBeDefined();
+      expect(typeof result.adminCacheStats.totalHits).toBe('number');
+      expect(typeof result.adminCacheStats.totalMisses).toBe('number');
+      expect(typeof result.adminCacheStats.totalWrites).toBe('number');
+      expect(typeof result.adminCacheStats.totalDeletes).toBe('number');
+      expect(typeof result.adminCacheStats.totalClears).toBe('number');
+      expect(typeof result.adminCacheStats.overallHitRate).toBe('number');
+      expect(Array.isArray(result.adminCacheStats.byCategory)).toBe(true);
+    });
+
+    it('returns consistent stats across calls', async () => {
+      const admin = await createAdminUser();
+
+      const first = await gqlQuery({
+        app,
+        token: admin.token,
+        ...getQuery(),
+      });
+
+      const second = await gqlQuery({
+        app,
+        token: admin.token,
+        ...getQuery(),
+      });
+
+      expect(second.adminCacheStats.totalHits).toBeGreaterThanOrEqual(
+        first.adminCacheStats.totalHits,
+      );
+      expect(second.adminCacheStats.totalWrites).toBeGreaterThanOrEqual(
+        first.adminCacheStats.totalWrites,
+      );
+    });
+
+    it('regular user cannot access adminCacheStats', async () => {
+      const result = await gqlQueryRaw({
+        app,
+        token: fixture.owner.token,
+        ...getQuery(),
+      });
+
+      expect(result.errors).toBeDefined();
+      expect(result.errors?.[0].message).toMatch(/not allowed/i);
+    });
+
+    it('unauthenticated cannot access adminCacheStats', async () => {
+      const result = await gqlQueryRaw({
+        app,
+        ...getQuery(),
+      });
+
+      expect(result.errors).toBeDefined();
+      expect(result.errors?.[0].message).toMatch(/Unauthorized/i);
+    });
+  });
+
+  describe('adminResetAllCache mutation', () => {
+    const getMutation = () => ({
+      query: gql`
+        mutation adminResetAllCache {
+          adminResetAllCache
+        }
+      `,
+    });
+
+    it('admin can reset all cache', async () => {
+      const admin = await createAdminUser();
+
+      const result = await gqlQuery({
+        app,
+        token: admin.token,
+        ...getMutation(),
+      });
+
+      expect(result.adminResetAllCache).toBe(true);
+    });
+
+    it('stats reset after clearing cache', async () => {
+      const admin = await createAdminUser();
+
+      const statsQuery = {
+        query: gql`
+          query adminCacheStats {
+            adminCacheStats {
+              totalHits
+              totalMisses
+            }
+          }
+        `,
+      };
+
+      await gqlQuery({ app, token: admin.token, ...statsQuery });
+      await gqlQuery({ app, token: admin.token, ...statsQuery });
+
+      await gqlQuery({ app, token: admin.token, ...getMutation() });
+
+      const after = await gqlQuery({
+        app,
+        token: admin.token,
+        ...statsQuery,
+      });
+
+      expect(after.adminCacheStats.totalHits).toBeLessThanOrEqual(2);
+    });
+
+    it('regular user cannot reset cache', async () => {
+      const result = await gqlQueryRaw({
+        app,
+        token: fixture.owner.token,
+        ...getMutation(),
+      });
+
+      expect(result.errors).toBeDefined();
+      expect(result.errors?.[0].message).toMatch(/not allowed/i);
+    });
+
+    it('unauthenticated cannot reset cache', async () => {
+      const result = await gqlQueryRaw({
+        app,
+        ...getMutation(),
+      });
+
+      expect(result.errors).toBeDefined();
+      expect(result.errors?.[0].message).toMatch(/Unauthorized/i);
+    });
+  });
+});

--- a/src/api/graphql-api/cache/cache.resolver.ts
+++ b/src/api/graphql-api/cache/cache.resolver.ts
@@ -1,0 +1,34 @@
+import { UseGuards } from '@nestjs/common';
+import { Mutation, Query, Resolver } from '@nestjs/graphql';
+import { PermissionAction, PermissionSubject } from 'src/features/auth/consts';
+import { GqlJwtAuthGuard } from 'src/features/auth/guards/jwt/gql-jwt-auth-guard.service';
+import { PermissionParams } from 'src/features/auth/guards/permission-params';
+import { GQLSystemGuard } from 'src/features/auth/guards/system.guard';
+import { CacheManagementService } from 'src/infrastructure/cache/services/cache-management.service';
+import { CacheStatsModel } from 'src/api/graphql-api/cache/model/cache-stats.model';
+
+@UseGuards(GqlJwtAuthGuard, GQLSystemGuard)
+@Resolver()
+export class CacheResolver {
+  constructor(
+    private readonly cacheManagementService: CacheManagementService,
+  ) {}
+
+  @PermissionParams({
+    action: PermissionAction.read,
+    subject: PermissionSubject.Cache,
+  })
+  @Query(() => CacheStatsModel)
+  async adminCacheStats(): Promise<CacheStatsModel> {
+    return this.cacheManagementService.getStats();
+  }
+
+  @PermissionParams({
+    action: PermissionAction.manage,
+    subject: PermissionSubject.Cache,
+  })
+  @Mutation(() => Boolean)
+  async adminResetAllCache(): Promise<boolean> {
+    return this.cacheManagementService.clearAll();
+  }
+}

--- a/src/api/graphql-api/cache/model/cache-stats.model.ts
+++ b/src/api/graphql-api/cache/model/cache-stats.model.ts
@@ -1,0 +1,46 @@
+import { Field, Float, Int, ObjectType } from '@nestjs/graphql';
+
+@ObjectType()
+export class CacheMetricModel {
+  @Field()
+  key: string;
+
+  @Field(() => Int)
+  hits: number;
+
+  @Field(() => Int)
+  misses: number;
+
+  @Field(() => Int)
+  writes: number;
+
+  @Field(() => Int)
+  deletes: number;
+
+  @Field(() => Float)
+  hitRate: number;
+}
+
+@ObjectType()
+export class CacheStatsModel {
+  @Field(() => Int)
+  totalHits: number;
+
+  @Field(() => Int)
+  totalMisses: number;
+
+  @Field(() => Int)
+  totalWrites: number;
+
+  @Field(() => Int)
+  totalDeletes: number;
+
+  @Field(() => Int)
+  totalClears: number;
+
+  @Field(() => Float)
+  overallHitRate: number;
+
+  @Field(() => [CacheMetricModel])
+  byCategory: CacheMetricModel[];
+}

--- a/src/api/graphql-api/configuration/model/configuration.model.ts
+++ b/src/api/graphql-api/configuration/model/configuration.model.ts
@@ -19,6 +19,12 @@ export class GithubOauth {
 }
 
 @ObjectType()
+export class CacheConfigModel {
+  @Field(() => Boolean)
+  enabled: boolean;
+}
+
+@ObjectType()
 export class PluginsModel {
   @Field(() => Boolean)
   file: boolean;
@@ -37,6 +43,9 @@ export class ConfigurationModel {
 
   @Field(() => GithubOauth)
   github: GithubOauth;
+
+  @Field(() => CacheConfigModel)
+  cache: CacheConfigModel;
 
   @Field(() => PluginsModel)
   plugins: PluginsModel;

--- a/src/api/graphql-api/graphql-api.module.ts
+++ b/src/api/graphql-api/graphql-api.module.ts
@@ -46,6 +46,7 @@ import { RevisionChangesModule } from 'src/features/revision-changes/revision-ch
 import { ApiKeyModule } from 'src/features/api-key/api-key.module';
 import { SubSchemaModule } from 'src/features/sub-schema';
 import { ApiKeyResolver } from 'src/api/graphql-api/api-key/api-key.resolver';
+import { CacheResolver } from 'src/api/graphql-api/cache/cache.resolver';
 import { SubSchemaResolver } from 'src/api/graphql-api/sub-schema/sub-schema.resolver';
 
 @Module({
@@ -109,6 +110,7 @@ import { SubSchemaResolver } from 'src/api/graphql-api/sub-schema/sub-schema.res
     ViewsResolver,
     SubSchemaResolver,
     ApiKeyResolver,
+    CacheResolver,
   ],
 })
 export class GraphqlApiModule {}

--- a/src/api/graphql-api/schema.graphql
+++ b/src/api/graphql-api/schema.graphql
@@ -118,6 +118,29 @@ type BranchesConnection {
   totalCount: Int!
 }
 
+type CacheConfigModel {
+  enabled: Boolean!
+}
+
+type CacheMetricModel {
+  deletes: Int!
+  hitRate: Float!
+  hits: Int!
+  key: String!
+  misses: Int!
+  writes: Int!
+}
+
+type CacheStatsModel {
+  byCategory: [CacheMetricModel!]!
+  overallHitRate: Float!
+  totalClears: Int!
+  totalDeletes: Int!
+  totalHits: Int!
+  totalMisses: Int!
+  totalWrites: Int!
+}
+
 input CancelSubscriptionInput {
   cancelAtPeriodEnd: Boolean
   organizationId: ID!
@@ -155,6 +178,7 @@ type ChildBranchModel {
 type ConfigurationModel {
   availableEmailSignUp: Boolean!
   billing: BillingConfigurationModel!
+  cache: CacheConfigModel!
   github: GithubOauth!
   google: GoogleOauth!
   noAuth: Boolean!
@@ -648,6 +672,7 @@ type Mutation {
   activateEarlyAccess(data: ActivateEarlyAccessInput!): SubscriptionModel!
   addUserToOrganization(data: AddUserToOrganizationInput!): Boolean!
   addUserToProject(data: AddUserToProjectInput!): Boolean!
+  adminResetAllCache: Boolean!
   applyMigrations(data: ApplyMigrationsInput!): [ApplyMigrationResultModel!]!
   cancelSubscription(data: CancelSubscriptionInput!): Boolean!
   confirmEmailCode(data: ConfirmEmailCodeInput!): LoginModel!
@@ -853,6 +878,7 @@ type ProjectsConnection {
 }
 
 type Query {
+  adminCacheStats: CacheStatsModel!
   adminUser(data: AdminUserInput!): UserModel
   adminUsers(data: SearchUsersInput!): UsersConnection!
   apiKeyById(id: ID!): ApiKeyModel!

--- a/src/features/auth/consts.ts
+++ b/src/features/auth/consts.ts
@@ -70,4 +70,5 @@ export enum PermissionSubject {
   Endpoint = 'Endpoint',
   User = 'User',
   ApiKey = 'ApiKey',
+  Cache = 'Cache',
 }

--- a/src/features/auth/guards/base-persmission.guard.ts
+++ b/src/features/auth/guards/base-persmission.guard.ts
@@ -44,7 +44,7 @@ export abstract class BasePermissionGuard<
 
     return {
       user,
-      params: args.data,
+      params: args.data ?? ({} as T),
     };
   }
 

--- a/src/infrastructure/cache/__mocks__/bentocache-plugin-prometheus.js
+++ b/src/infrastructure/cache/__mocks__/bentocache-plugin-prometheus.js
@@ -1,0 +1,3 @@
+module.exports = {
+  prometheusPlugin: () => ({}),
+};

--- a/src/infrastructure/cache/revisium-cache.module.ts
+++ b/src/infrastructure/cache/revisium-cache.module.ts
@@ -3,6 +3,7 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
 import { CqrsModule } from '@nestjs/cqrs';
 import { pgBusDriver } from 'src/infrastructure/cache/pg-bus/pg-bus.driver';
 import { AuthCacheService } from 'src/infrastructure/cache/services/auth-cache.service';
+import { CacheManagementService } from 'src/infrastructure/cache/services/cache-management.service';
 import { CacheService } from 'src/infrastructure/cache/services/cache.service';
 import { RevisionCacheService } from 'src/infrastructure/cache/services/revision-cache.service';
 import { RowCacheService } from 'src/infrastructure/cache/services/row-cache.service';
@@ -15,18 +16,180 @@ import { NoopCacheService } from 'src/infrastructure/cache/services/noop-cache.s
 import { CACHE_SERVICE } from './services/cache.tokens';
 import { CACHE_EVENT_HANDLERS } from './handlers';
 import Redis from 'ioredis';
+import * as promClient from 'prom-client';
+
+// Dedicated registry for bentocache metrics — avoids "already registered" on double module init
+export const bentocacheRegistry = new promClient.Registry();
+
+// Singleton guard — forRootAsync factory runs per import, but we only create BentoCache once
+let bentoCachePromise: Promise<any> | null = null;
+
+const CACHE_KEY_GROUPS: [RegExp, string][] = [
+  // Data keys
+  [/^revision:get-rows:/, 'row-queries'],
+  [/^revision:revision:/, 'revisions'],
+  [/^revision:/, 'row-data'],
+  [/^auth:role:permissions:/, 'auth-roles'],
+  [/^auth:check-/, 'auth-checks'],
+  [/^auth:api-key:/, 'auth-api-keys'],
+  [/^billing:sub:/, 'billing-subscriptions'],
+  [/^billing:usage:/, 'billing-usage'],
+  [/^billing:rev-org:/, 'billing-lookups'],
+  // Internal tag keys (___bc:t:*) — aggregate to avoid unbounded cardinality
+  [/^___bc:t:auth-relatives$/, 'tag:auth'],
+  [/^___bc:t:dictionaries$/, 'tag:auth'],
+  [/^___bc:t:user-permissions-/, 'tag:user-permissions'],
+  [/^___bc:t:org-permissions-/, 'tag:org-permissions'],
+  [/^___bc:t:project-permissions-/, 'tag:project-permissions'],
+  [/^___bc:t:revision-relatives-/, 'tag:revision-relatives'],
+  [/^___bc:t:table-relatives-/, 'tag:table-relatives'],
+  [/^___bc:t:table-get-rows-/, 'tag:table-get-rows'],
+  [/^___bc:t:revision-/, 'tag:revisions'],
+  [/^___bc:t:billing-org-/, 'tag:billing'],
+  [/^___bc:t:billing-usage-/, 'tag:billing'],
+  [/^___bc:t:/, 'tag:other'],
+];
 
 // Dynamic imports for ESM compatibility (requires --experimental-require-module in Node.js 22+)
 async function loadBentoCacheCore() {
   const { BentoCache, bentostore } = await import('bentocache');
   const { memoryDriver } = await import('bentocache/drivers/memory');
-  return { BentoCache, bentostore, memoryDriver };
+  const { prometheusPlugin } = await import('@bentocache/plugin-prometheus');
+  return { BentoCache, bentostore, memoryDriver, prometheusPlugin };
 }
 
 async function loadBentoCacheRedis() {
   const { redisBusDriver, redisDriver } =
     await import('bentocache/drivers/redis');
   return { redisBusDriver, redisDriver };
+}
+
+async function createBentoCache(cfg: ConfigService): Promise<any> {
+  const logger = new Logger('RevisiumCacheModule');
+  const enabled = parseBool(getEnvWithDeprecation(cfg, 'CACHE_ENABLED'));
+
+  if (!enabled) {
+    logger.warn(
+      'Cache disabled (NoopBentoCache). Set CACHE_ENABLED=1 to enable.',
+    );
+    return new NoopCacheService() as any;
+  }
+
+  const l1MaxSize = getEnvWithDeprecation(cfg, 'CACHE_L1_MAX_SIZE');
+
+  if (l1MaxSize) {
+    logger.log(`L1_MAX_SIZE: ${l1MaxSize}`);
+  }
+
+  const redisUrl = getEnvWithDeprecation(cfg, 'CACHE_L2_REDIS_URL') || null;
+
+  try {
+    let bento: any;
+
+    if (redisUrl) {
+      const redisBusHost = getEnvWithDeprecationOrThrow<string>(
+        cfg,
+        'CACHE_BUS_HOST',
+      );
+
+      if (redisBusHost) {
+        logger.log(`CACHE_BUS_HOST: ${redisBusHost}`);
+      }
+
+      const redisBusPort = getEnvWithDeprecationOrThrow<string>(
+        cfg,
+        'CACHE_BUS_PORT',
+      );
+
+      if (redisBusPort) {
+        logger.log(`CACHE_BUS_PORT: ${redisBusPort}`);
+      }
+
+      const { BentoCache, bentostore, memoryDriver, prometheusPlugin } =
+        await loadBentoCacheCore();
+      const { redisBusDriver, redisDriver } = await loadBentoCacheRedis();
+
+      bento = new BentoCache({
+        default: 'cache',
+        plugins: [
+          prometheusPlugin({
+            prefix: 'bentocache',
+            registry: bentocacheRegistry,
+            keyGroups: CACHE_KEY_GROUPS,
+          }),
+        ],
+        stores: {
+          cache: bentostore()
+            .useL1Layer(
+              memoryDriver({
+                maxSize: l1MaxSize,
+              }),
+            )
+            .useL2Layer(
+              redisDriver({
+                connection: new Redis(redisUrl),
+              }),
+            )
+            .useBus(
+              redisBusDriver({
+                connection: {
+                  host: redisBusHost,
+                  port: Number.parseInt(redisBusPort),
+                },
+                retryQueue: {
+                  enabled: true,
+                  maxSize: undefined,
+                },
+              }),
+            ),
+        },
+      });
+      logger.log(
+        `✅ Cache enabled: L1 + L2 (BentoCache + Redis @ ${redisUrl}).`,
+      );
+    } else {
+      const databaseUrl = cfg.getOrThrow<string>('DATABASE_URL');
+      const debug = parseBool(getEnvWithDeprecation(cfg, 'CACHE_DEBUG'));
+
+      const { BentoCache, bentostore, memoryDriver, prometheusPlugin } =
+        await loadBentoCacheCore();
+
+      bento = new BentoCache({
+        default: 'cache',
+        plugins: [
+          prometheusPlugin({
+            prefix: 'bentocache',
+            registry: bentocacheRegistry,
+            keyGroups: CACHE_KEY_GROUPS,
+          }),
+        ],
+        stores: {
+          cache: bentostore()
+            .useL1Layer(
+              memoryDriver({
+                maxSize: l1MaxSize,
+              }),
+            )
+            .useBus(
+              pgBusDriver({
+                connectionString: databaseUrl,
+                debug,
+              }),
+            ),
+        },
+      });
+      logger.log('✅ Cache enabled: L1 only (BentoCache memory).');
+    }
+
+    return bento;
+  } catch (e) {
+    const err = e as Error;
+    logger.error(
+      `❌ BentoCache setup failed (${redisUrl || 'memory'}), using noop fallback.`,
+      err?.stack ?? String(err),
+    );
+    return new NoopCacheService() as any;
+  }
 }
 
 @Module({})
@@ -39,130 +202,17 @@ export class RevisiumCacheModule {
       providers: [
         {
           provide: CACHE_SERVICE,
-          useFactory: async (cfg: ConfigService): Promise<any> => {
-            const logger = new Logger('RevisiumCacheModule');
-            const enabled = parseBool(
-              getEnvWithDeprecation(cfg, 'CACHE_ENABLED'),
-            );
-
-            if (!enabled) {
-              logger.warn(
-                'Cache disabled (NoopBentoCache). Set CACHE_ENABLED=1 to enable.',
-              );
-              return new NoopCacheService() as any;
+          useFactory: (cfg: ConfigService): Promise<any> => {
+            if (bentoCachePromise) {
+              return bentoCachePromise;
             }
-
-            const l1MaxSize = getEnvWithDeprecation(cfg, 'CACHE_L1_MAX_SIZE');
-
-            if (l1MaxSize) {
-              logger.log(`L1_MAX_SIZE: ${l1MaxSize}`);
-            }
-
-            const redisUrl =
-              getEnvWithDeprecation(cfg, 'CACHE_L2_REDIS_URL') || null;
-
-            try {
-              let bento: any;
-
-              if (redisUrl) {
-                const redisBusHost = getEnvWithDeprecationOrThrow<string>(
-                  cfg,
-                  'CACHE_BUS_HOST',
-                );
-
-                if (redisBusHost) {
-                  logger.log(`CACHE_BUS_HOST: ${redisBusHost}`);
-                }
-
-                const redisBusPort = getEnvWithDeprecationOrThrow<string>(
-                  cfg,
-                  'CACHE_BUS_PORT',
-                );
-
-                if (redisBusPort) {
-                  logger.log(`CACHE_BUS_PORT: ${redisBusPort}`);
-                }
-
-                const { BentoCache, bentostore, memoryDriver } =
-                  await loadBentoCacheCore();
-                const { redisBusDriver, redisDriver } =
-                  await loadBentoCacheRedis();
-
-                // L1 + L2 configuration
-                bento = new BentoCache({
-                  default: 'cache',
-                  stores: {
-                    cache: bentostore()
-                      .useL1Layer(
-                        memoryDriver({
-                          maxSize: l1MaxSize,
-                        }),
-                      )
-                      .useL2Layer(
-                        redisDriver({
-                          connection: new Redis(redisUrl),
-                        }),
-                      )
-                      .useBus(
-                        redisBusDriver({
-                          connection: {
-                            host: redisBusHost,
-                            port: Number.parseInt(redisBusPort),
-                          },
-                          retryQueue: {
-                            enabled: true,
-                            maxSize: undefined,
-                          },
-                        }),
-                      ),
-                  },
-                });
-                logger.log(
-                  `✅ Cache enabled: L1 + L2 (BentoCache + Redis @ ${redisUrl}).`,
-                );
-              } else {
-                const databaseUrl = cfg.getOrThrow<string>('DATABASE_URL');
-                const debug = parseBool(
-                  getEnvWithDeprecation(cfg, 'CACHE_DEBUG'),
-                );
-
-                const { BentoCache, bentostore, memoryDriver } =
-                  await loadBentoCacheCore();
-
-                // L1 only configuration
-                bento = new BentoCache({
-                  default: 'cache',
-                  stores: {
-                    cache: bentostore()
-                      .useL1Layer(
-                        memoryDriver({
-                          maxSize: l1MaxSize,
-                        }),
-                      )
-                      .useBus(
-                        pgBusDriver({
-                          connectionString: databaseUrl,
-                          debug,
-                        }),
-                      ),
-                  },
-                });
-                logger.log('✅ Cache enabled: L1 only (BentoCache memory).');
-              }
-
-              return bento;
-            } catch (e) {
-              const err = e as Error;
-              logger.error(
-                `❌ BentoCache setup failed (${redisUrl || 'memory'}), using noop fallback.`,
-                err?.stack ?? String(err),
-              );
-              return new NoopCacheService() as any;
-            }
+            bentoCachePromise = createBentoCache(cfg);
+            return bentoCachePromise;
           },
           inject: [ConfigService],
         },
         CacheService,
+        CacheManagementService,
         RowCacheService,
         RevisionCacheService,
         AuthCacheService,
@@ -173,6 +223,7 @@ export class RevisiumCacheModule {
         RevisionCacheService,
         AuthCacheService,
         CacheService,
+        CacheManagementService,
         CACHE_SERVICE,
       ],
     };

--- a/src/infrastructure/cache/services/__tests__/cache-management.service.spec.ts
+++ b/src/infrastructure/cache/services/__tests__/cache-management.service.spec.ts
@@ -1,0 +1,113 @@
+import * as promClient from 'prom-client';
+import { bentocacheRegistry } from 'src/infrastructure/cache/revisium-cache.module';
+import { CacheManagementService } from 'src/infrastructure/cache/services/cache-management.service';
+import { CacheService } from 'src/infrastructure/cache/services/cache.service';
+
+describe('CacheManagementService', () => {
+  let service: CacheManagementService;
+  let cacheService: CacheService;
+
+  beforeEach(() => {
+    bentocacheRegistry.clear();
+    cacheService = { clear: jest.fn().mockResolvedValue(undefined) } as any;
+    service = new CacheManagementService(cacheService);
+  });
+
+  afterEach(() => {
+    bentocacheRegistry.clear();
+  });
+
+  describe('getStats', () => {
+    it('returns zeros when no metrics registered', async () => {
+      const stats = await service.getStats();
+
+      expect(stats.totalHits).toBe(0);
+      expect(stats.totalMisses).toBe(0);
+      expect(stats.totalWrites).toBe(0);
+      expect(stats.totalDeletes).toBe(0);
+      expect(stats.totalClears).toBe(0);
+      expect(stats.overallHitRate).toBe(0);
+      expect(stats.byCategory).toEqual([]);
+    });
+
+    it('returns aggregated stats from prometheus counters', async () => {
+      const hits = new promClient.Counter({
+        name: 'bentocache_hits',
+        help: 'hits',
+        labelNames: ['store', 'key'],
+        registers: [bentocacheRegistry],
+      });
+      const misses = new promClient.Counter({
+        name: 'bentocache_misses',
+        help: 'misses',
+        labelNames: ['store', 'key'],
+        registers: [bentocacheRegistry],
+      });
+      const writes = new promClient.Counter({
+        name: 'bentocache_writes',
+        help: 'writes',
+        labelNames: ['store', 'key'],
+        registers: [bentocacheRegistry],
+      });
+      const deletes = new promClient.Counter({
+        name: 'bentocache_deletes',
+        help: 'deletes',
+        labelNames: ['store', 'key'],
+        registers: [bentocacheRegistry],
+      });
+      new promClient.Counter({
+        name: 'bentocache_clears',
+        help: 'clears',
+        labelNames: ['store'],
+        registers: [bentocacheRegistry],
+      });
+
+      hits.inc({ store: 'cache', key: 'auth-checks' }, 10);
+      hits.inc({ store: 'cache', key: 'row-data' }, 5);
+      misses.inc({ store: 'cache', key: 'auth-checks' }, 2);
+      misses.inc({ store: 'cache', key: 'row-data' }, 1);
+      writes.inc({ store: 'cache', key: 'auth-checks' }, 2);
+      deletes.inc({ store: 'cache', key: 'row-data' }, 1);
+
+      const stats = await service.getStats();
+
+      expect(stats.totalHits).toBe(15);
+      expect(stats.totalMisses).toBe(3);
+      expect(stats.totalWrites).toBe(2);
+      expect(stats.totalDeletes).toBe(1);
+      expect(stats.overallHitRate).toBeCloseTo(15 / 18);
+      expect(stats.byCategory).toHaveLength(2);
+
+      const authChecks = stats.byCategory.find((c) => c.key === 'auth-checks');
+      expect(authChecks).toBeDefined();
+      expect(authChecks!.hits).toBe(10);
+      expect(authChecks!.misses).toBe(2);
+      expect(authChecks!.hitRate).toBeCloseTo(10 / 12);
+
+      const rowData = stats.byCategory.find((c) => c.key === 'row-data');
+      expect(rowData).toBeDefined();
+      expect(rowData!.hits).toBe(5);
+      expect(rowData!.deletes).toBe(1);
+    });
+  });
+
+  describe('clearAll', () => {
+    it('clears cache and resets metrics', async () => {
+      const hits = new promClient.Counter({
+        name: 'bentocache_hits',
+        help: 'hits',
+        labelNames: ['store', 'key'],
+        registers: [bentocacheRegistry],
+      });
+      hits.inc({ store: 'cache', key: 'test' }, 5);
+
+      const result = await service.clearAll();
+
+      expect(result).toBe(true);
+      expect(cacheService.clear).toHaveBeenCalled();
+
+      const stats = await service.getStats();
+      expect(stats.totalHits).toBe(0);
+    });
+  });
+});

--- a/src/infrastructure/cache/services/cache-management.service.ts
+++ b/src/infrastructure/cache/services/cache-management.service.ts
@@ -1,0 +1,132 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { bentocacheRegistry } from 'src/infrastructure/cache/revisium-cache.module';
+import { CacheService } from 'src/infrastructure/cache/services/cache.service';
+
+interface MetricByKey {
+  key: string;
+  hits: number;
+  misses: number;
+  writes: number;
+  deletes: number;
+  hitRate: number;
+}
+
+interface CacheStats {
+  totalHits: number;
+  totalMisses: number;
+  totalWrites: number;
+  totalDeletes: number;
+  totalClears: number;
+  overallHitRate: number;
+  byCategory: MetricByKey[];
+}
+
+interface MetricJSON {
+  name: string;
+  values: Array<{
+    value: number;
+    labels: Record<string, string>;
+  }>;
+}
+
+@Injectable()
+export class CacheManagementService {
+  private readonly logger = new Logger(CacheManagementService.name);
+
+  constructor(private readonly cacheService: CacheService) {}
+
+  async getStats(): Promise<CacheStats> {
+    const metrics =
+      (await bentocacheRegistry.getMetricsAsJSON()) as MetricJSON[];
+
+    const hitsMetric = metrics.find((m) => m.name === 'bentocache_hits');
+    const missesMetric = metrics.find((m) => m.name === 'bentocache_misses');
+    const writesMetric = metrics.find((m) => m.name === 'bentocache_writes');
+    const deletesMetric = metrics.find((m) => m.name === 'bentocache_deletes');
+    const clearsMetric = metrics.find((m) => m.name === 'bentocache_clears');
+
+    const totalHits = this.sumMetricValues(hitsMetric);
+    const totalMisses = this.sumMetricValues(missesMetric);
+    const totalWrites = this.sumMetricValues(writesMetric);
+    const totalDeletes = this.sumMetricValues(deletesMetric);
+    const totalClears = this.sumMetricValues(clearsMetric);
+
+    const total = totalHits + totalMisses;
+    const overallHitRate = total > 0 ? totalHits / total : 0;
+
+    const byCategory = this.aggregateByKey(
+      hitsMetric,
+      missesMetric,
+      writesMetric,
+      deletesMetric,
+    );
+
+    return {
+      totalHits,
+      totalMisses,
+      totalWrites,
+      totalDeletes,
+      totalClears,
+      overallHitRate,
+      byCategory,
+    };
+  }
+
+  async clearAll(): Promise<boolean> {
+    this.logger.warn('Clearing all cache (admin action)');
+    await this.cacheService.clear();
+    bentocacheRegistry.resetMetrics();
+    return true;
+  }
+
+  private sumMetricValues(metric: MetricJSON | undefined): number {
+    if (!metric?.values) {
+      return 0;
+    }
+
+    return metric.values.reduce((sum, v) => sum + (v.value || 0), 0);
+  }
+
+  private aggregateByKey(
+    hitsMetric: MetricJSON | undefined,
+    missesMetric: MetricJSON | undefined,
+    writesMetric: MetricJSON | undefined,
+    deletesMetric: MetricJSON | undefined,
+  ): MetricByKey[] {
+    const keyMap = new Map<
+      string,
+      { hits: number; misses: number; writes: number; deletes: number }
+    >();
+
+    const addValues = (
+      metric: MetricJSON | undefined,
+      field: 'hits' | 'misses' | 'writes' | 'deletes',
+    ) => {
+      if (!metric?.values) {
+        return;
+      }
+
+      for (const v of metric.values) {
+        const key = v.labels?.key || 'unknown';
+        if (!keyMap.has(key)) {
+          keyMap.set(key, { hits: 0, misses: 0, writes: 0, deletes: 0 });
+        }
+        keyMap.get(key)![field] += v.value || 0;
+      }
+    };
+
+    addValues(hitsMetric, 'hits');
+    addValues(missesMetric, 'misses');
+    addValues(writesMetric, 'writes');
+    addValues(deletesMetric, 'deletes');
+
+    return Array.from(keyMap.entries()).map(([key, data]) => {
+      const total = data.hits + data.misses;
+      return {
+        key,
+        ...data,
+        hitRate: total > 0 ? data.hits / total : 0,
+      };
+    });
+  }
+}

--- a/src/infrastructure/cache/services/cache.service.ts
+++ b/src/infrastructure/cache/services/cache.service.ts
@@ -37,4 +37,8 @@ export class CacheService {
   public delete(options: DeleteOptions) {
     return this.bento.delete(options);
   }
+
+  public clear() {
+    return this.bento.clear();
+  }
 }

--- a/src/infrastructure/cache/services/noop-cache.service.ts
+++ b/src/infrastructure/cache/services/noop-cache.service.ts
@@ -21,6 +21,10 @@ export class NoopCacheService {
   public delete(_: DeleteOptions) {
     return false;
   }
+
+  public clear() {
+    return false;
+  }
 }
 
 const noopGetSetFactory: GetSetFactoryContext = {

--- a/src/infrastructure/configuration/queries/handlers/get-configuration.handler.ts
+++ b/src/infrastructure/configuration/queries/handlers/get-configuration.handler.ts
@@ -1,4 +1,5 @@
 import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
+import { ConfigService } from '@nestjs/config';
 import { GitHubAuthService } from 'src/features/auth/github-oauth.service';
 import { GoogleOauthService } from 'src/features/auth/google-oauth.service';
 import { NoAuthService } from 'src/features/auth/no-auth.service';
@@ -8,6 +9,8 @@ import {
   GetConfigurationQueryReturnType,
 } from 'src/infrastructure/configuration/queries/impl';
 import { EmailService } from 'src/infrastructure/email/email.service';
+import { getEnvWithDeprecation } from 'src/utils/env';
+import { parseBool } from 'src/utils/utils/parse-bool';
 
 @QueryHandler(GetConfigurationQuery)
 export class GetConfigurationHandler implements IQueryHandler<
@@ -15,6 +18,7 @@ export class GetConfigurationHandler implements IQueryHandler<
   GetConfigurationQueryReturnType
 > {
   constructor(
+    private readonly configService: ConfigService,
     private readonly emailService: EmailService,
     private readonly googleOauthService: GoogleOauthService,
     private readonly githubOauthService: GitHubAuthService,
@@ -33,6 +37,11 @@ export class GetConfigurationHandler implements IQueryHandler<
       github: {
         available: this.githubOauthService.isAvailable,
         clientId: this.githubOauthService.clientId,
+      },
+      cache: {
+        enabled: parseBool(
+          getEnvWithDeprecation(this.configService, 'CACHE_ENABLED'),
+        ),
       },
       plugins: {
         file: this.filePlugin.isAvailable,

--- a/src/infrastructure/configuration/queries/impl/get-configuration.query.ts
+++ b/src/infrastructure/configuration/queries/impl/get-configuration.query.ts
@@ -5,6 +5,9 @@ export type GetConfigurationQueryReturnType = {
   noAuth: boolean;
   google: { available: boolean; clientId?: string };
   github: { available: boolean; clientId?: string };
+  cache: {
+    enabled: boolean;
+  };
   plugins: {
     file: boolean;
   };

--- a/src/infrastructure/metrics-api/metrics.controller.ts
+++ b/src/infrastructure/metrics-api/metrics.controller.ts
@@ -3,6 +3,7 @@ import { ApiExcludeController } from '@nestjs/swagger';
 import { Response } from 'express';
 import * as client from 'prom-client';
 import { PrismaService } from 'src/infrastructure/database/prisma.service';
+import { bentocacheRegistry } from 'src/infrastructure/cache/revisium-cache.module';
 import { MetricsEnabledGuard } from 'src/infrastructure/metrics-api/metrics-enabled.guard';
 
 @ApiExcludeController()
@@ -13,7 +14,8 @@ export class MetricsController {
 
   @Get()
   async getMetrics(@Res() response: Response) {
-    const metrics = await client.register.metrics();
+    const merged = client.Registry.merge([client.register, bentocacheRegistry]);
+    const metrics = await merged.metrics();
 
     response.set('Content-Type', client.register.contentType);
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds admin-only cache management with GraphQL stats and a reset action, plus Prometheus metrics for better observability. Also exposes a `cache.enabled` flag in configuration.

- New Features
  - GraphQL: `adminCacheStats` returns totals (hits, misses, writes, deletes, clears, overall hit rate) and per-category metrics.
  - GraphQL: `adminResetAllCache` clears all cache and resets metrics.
  - Permissions: new `Cache` subject with `read-cache` and `manage-cache`; `systemAdmin` seeded with both.
  - Configuration: `cache.enabled` added to `ConfigurationModel`.
  - Metrics: instrumented BentoCache via Prometheus with a dedicated registry; `/metrics` now includes cache metrics.
  - Stability: singleton BentoCache init; safe clear support in cache services; unit tests for `CacheManagementService`.

- Dependencies
  - Added `@bentocache/plugin-prometheus`; updated Jest `moduleNameMapper` for tests.

<sup>Written for commit bbd697b06d51c661a482ea766a208fdeaf8a57e9. Summary will update on new commits. <a href="https://cubic.dev/pr/revisium/revisium-core/pull/485">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

