### PR TITLE
chore: bump nodemailer to 8.0.5 (GHSA-vvjj-xcjg-gr5g)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12901,9 +12901,9 @@
       "license": "MIT"
     },
     "node_modules/nodemailer": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.4.tgz",
-      "integrity": "sha512-k+jf6N8PfQJ0Fe8ZhJlgqU5qJU44Lpvp2yvidH3vp1lPnVQMgi4yEEMPXg5eJS1gFIJTVq1NHBk7Ia9ARdSBdQ==",
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.5.tgz",
+      "integrity": "sha512-0PF8Yb1yZuQfQbq+5/pZJrtF6WQcjTd5/S4JOHs9PGFxuTqoB/icwuB44pOdURHJbRKX1PPoJZtY7R4VUoCC8w==",
       "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Upgrade `nodemailer` to 8.0.5 to address security advisory GHSA-vvjj-xcjg-gr5g and pull in the latest patch. Lockfile updated only; no code changes.

<sup>Written for commit 2685219d8f40220c1157d7cd0a58e41a007dba77. Summary will update on new commits. <a href="https://cubic.dev/pr/revisium/revisium-core/pull/488">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

