### PR TITLE
feat(auth): add issueAccessToken GraphQL query

### DIFF
--- a/src/api/graphql-api/__tests__/auth/issue-access-token.spec.ts
+++ b/src/api/graphql-api/__tests__/auth/issue-access-token.spec.ts
@@ -1,0 +1,109 @@
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import request from 'supertest';
+import {
+  prepareData,
+  PrepareDataReturnType,
+} from 'src/__tests__/utils/prepareProject';
+import { gql } from 'src/__tests__/utils/gql';
+import { graphqlQuery, graphqlQueryError } from 'src/__tests__/utils/queryTest';
+import { CoreModule } from 'src/core/core.module';
+import { registerGraphqlEnums } from 'src/api/graphql-api/registerGraphqlEnums';
+
+const ISSUE_ACCESS_TOKEN = gql`
+  query issueAccessToken {
+    issueAccessToken {
+      accessToken
+    }
+  }
+`;
+
+const CREATE_PERSONAL_API_KEY = gql`
+  mutation CreatePersonalApiKey($data: CreatePersonalApiKeyInput!) {
+    createPersonalApiKey(data: $data) {
+      apiKey {
+        id
+      }
+      secret
+    }
+  }
+`;
+
+describe('graphql - issueAccessToken', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    registerGraphqlEnums();
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [CoreModule.forRoot({ mode: 'monolith' })],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(new ValidationPipe({ transform: true }));
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  let preparedData: PrepareDataReturnType;
+
+  beforeEach(async () => {
+    preparedData = await prepareData(app);
+  });
+
+  it('returns access token for JWT-authenticated user', async () => {
+    const result = await graphqlQuery({
+      query: ISSUE_ACCESS_TOKEN,
+      app,
+      token: preparedData.owner.token,
+    });
+
+    expect(result.issueAccessToken).toBeDefined();
+    expect(typeof result.issueAccessToken.accessToken).toBe('string');
+    expect(result.issueAccessToken.accessToken.length).toBeGreaterThan(0);
+  });
+
+  it('rejects unauthenticated request', async () => {
+    return graphqlQueryError({
+      query: ISSUE_ACCESS_TOKEN,
+      app,
+      token: undefined,
+      error: /Unauthorized/,
+    });
+  });
+
+  it('rejects API key authentication with 403', async () => {
+    const createResult = await request(app.getHttpServer())
+      .post('/graphql')
+      .set('Authorization', `Bearer ${preparedData.owner.token}`)
+      .send({
+        query: CREATE_PERSONAL_API_KEY,
+        variables: { data: { name: 'test-issue-token' } },
+      })
+      .expect(200);
+
+    const apiKey = (
+      createResult.body as {
+        data: { createPersonalApiKey: { secret: string } };
+      }
+    ).data.createPersonalApiKey.secret;
+
+    const res = await request(app.getHttpServer())
+      .post('/graphql')
+      .set('X-Api-Key', apiKey)
+      .send({ query: ISSUE_ACCESS_TOKEN })
+      .expect(200);
+
+    const body = res.body as {
+      errors?: Array<{ message: string }>;
+    };
+
+    expect(body.errors).toBeDefined();
+    expect(body.errors[0].message).toMatch(
+      /Access token can only be issued for JWT-authenticated sessions/,
+    );
+  });
+});

--- a/src/api/graphql-api/__tests__/auth/issue-access-token.spec.ts
+++ b/src/api/graphql-api/__tests__/auth/issue-access-token.spec.ts
@@ -102,7 +102,7 @@ describe('graphql - issueAccessToken', () => {
     };
 
     expect(body.errors).toBeDefined();
-    expect(body.errors[0].message).toMatch(
+    expect(body.errors![0].message).toMatch(
       /Access token can only be issued for JWT-authenticated sessions/,
     );
   });

--- a/src/api/graphql-api/auth/auth.resolver.ts
+++ b/src/api/graphql-api/auth/auth.resolver.ts
@@ -1,5 +1,5 @@
-import { UseGuards } from '@nestjs/common';
-import { Args, Context, Mutation, Resolver } from '@nestjs/graphql';
+import { ForbiddenException, UseGuards } from '@nestjs/common';
+import { Args, Context, Mutation, Query, Resolver } from '@nestjs/graphql';
 import { Request as ExpressRequest, Response } from 'express';
 import { AuthApiService } from 'src/features/auth/commands/auth-api.service';
 import { PermissionAction, PermissionSubject } from 'src/features/auth/consts';
@@ -7,6 +7,8 @@ import { GqlJwtAuthGuard } from 'src/features/auth/guards/jwt/gql-jwt-auth-guard
 import { PermissionParams } from 'src/features/auth/guards/permission-params';
 import { GQLSystemGuard } from 'src/features/auth/guards/system.guard';
 import { CookieService } from 'src/features/auth/services/cookie.service';
+import { IAuthUser } from 'src/features/auth/types';
+import { CurrentUser } from 'src/api/graphql-api/current-user.decorator';
 import {
   ConfirmEmailCodeInput,
   CreateUserInput,
@@ -32,6 +34,19 @@ export class AuthResolver {
     private readonly authApiService: AuthApiService,
     private readonly cookieService: CookieService,
   ) {}
+
+  @UseGuards(GqlJwtAuthGuard)
+  @Query(() => LoginModel)
+  public async issueAccessToken(
+    @CurrentUser() user: IAuthUser,
+  ): Promise<LoginModel> {
+    if (user.authMethod !== 'jwt') {
+      throw new ForbiddenException(
+        'Access token can only be issued for JWT-authenticated sessions',
+      );
+    }
+    return this.authApiService.issueAccessTokenForUserId(user.userId);
+  }
 
   @Mutation(() => LoginModel)
   public async login(

--- a/src/api/graphql-api/schema.graphql
+++ b/src/api/graphql-api/schema.graphql
@@ -888,6 +888,7 @@ type Query {
   branches(data: GetBranchesInput!): BranchesConnection!
   configuration: ConfigurationModel!
   getRowCountForeignKeysTo(data: GetRowCountForeignKeysByInput!): Int! @deprecated(reason: "use RowModel.rowForeignKeysBy.totalCount")
+  issueAccessToken: LoginModel!
   me: MeModel!
   meProjects(data: GetMeProjectsInput!): ProjectsConnection!
   myApiKeys: [ApiKeyModel!]!


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a GraphQL query to issue a fresh access token for cookie-authenticated sessions. Restores the `/get-token` page after JWT 2.0 moved tokens to httpOnly cookies.

- **New Features**
  - Added issueAccessToken: LoginModel! query to the schema.
  - Protected with GqlJwtAuthGuard; allowed only for JWT sessions, otherwise Forbidden.
  - Issues tokens via AuthApiService.issueAccessTokenForUserId using CurrentUser.
  - Added e2e tests for JWT success, unauthenticated rejection, and API key 403; updated with a non-null assertion for strict tsc.

<sup>Written for commit 3ef802bbef2f9967a639779fe4a74b8689627230. Summary will update on new commits. <a href="https://cubic.dev/pr/revisium/revisium-core/pull/489">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

