### PR TITLE
fix: skip usage cache for rare limit metrics

### DIFF
--- a/ee/billing/__tests__/limits.service.spec.ts
+++ b/ee/billing/__tests__/limits.service.spec.ts
@@ -336,7 +336,25 @@ describe('LimitsService (Ultra-Thin)', () => {
 
     await service.checkLimit('test-org', LimitMetric.ROW_VERSIONS, 1);
 
-    expect(cacheSpy).toHaveBeenCalled();
+    expect(cacheSpy).toHaveBeenCalledWith(
+      'test-org',
+      LimitMetric.ROW_VERSIONS,
+      expect.any(Function),
+    );
+  });
+
+  it('should use cache with context key for ROWS_PER_TABLE metric', async () => {
+    const cacheSpy = jest.spyOn(billingCache, 'usage');
+    mockBillingClient.getOrgLimits.mockResolvedValue(PRO_LIMITS);
+
+    const context = { revisionId: 'rev-1', tableId: 'tbl-1' };
+    await service.checkLimit('test-org', LimitMetric.ROWS_PER_TABLE, 1, context);
+
+    expect(cacheSpy).toHaveBeenCalledWith(
+      'test-org',
+      `${LimitMetric.ROWS_PER_TABLE}:r=rev-1:t=tbl-1:p=`,
+      expect.any(Function),
+    );
   });
 
   it('should deny when branches_per_project limit reached', async () => {

--- a/ee/billing/__tests__/limits.service.spec.ts
+++ b/ee/billing/__tests__/limits.service.spec.ts
@@ -48,6 +48,8 @@ describe('LimitsService (Ultra-Thin)', () => {
   let module: TestingModule;
   let service: LimitsService;
   let prisma: PrismaService;
+  let billingCache: BillingCacheService;
+  let usageService: UsageService;
   let mockBillingClient: jest.Mocked<IBillingClient>;
 
   beforeAll(async () => {
@@ -79,6 +81,8 @@ describe('LimitsService (Ultra-Thin)', () => {
 
     service = module.get(LimitsService);
     prisma = module.get(PrismaService);
+    billingCache = module.get(BillingCacheService);
+    usageService = module.get(UsageService);
   });
 
   beforeEach(() => {
@@ -302,6 +306,37 @@ describe('LimitsService (Ultra-Thin)', () => {
     expect(result.allowed).toBe(true);
     expect(result.current).toBe(2);
     expect(result.limit).toBe(10);
+  });
+
+  it('should bypass cache for PROJECTS metric', async () => {
+    const computeSpy = jest.spyOn(usageService, 'computeUsage');
+    const cacheSpy = jest.spyOn(billingCache, 'usage');
+    mockBillingClient.getOrgLimits.mockResolvedValue(PRO_LIMITS);
+
+    await service.checkLimit('test-org', LimitMetric.PROJECTS, 1);
+
+    expect(computeSpy).toHaveBeenCalledWith('test-org', LimitMetric.PROJECTS, undefined);
+    expect(cacheSpy).not.toHaveBeenCalled();
+  });
+
+  it('should bypass cache for SEATS metric', async () => {
+    const computeSpy = jest.spyOn(usageService, 'computeUsage');
+    const cacheSpy = jest.spyOn(billingCache, 'usage');
+    mockBillingClient.getOrgLimits.mockResolvedValue(PRO_LIMITS);
+
+    await service.checkLimit('test-org', LimitMetric.SEATS, 1);
+
+    expect(computeSpy).toHaveBeenCalledWith('test-org', LimitMetric.SEATS, undefined);
+    expect(cacheSpy).not.toHaveBeenCalled();
+  });
+
+  it('should use cache for ROW_VERSIONS metric', async () => {
+    const cacheSpy = jest.spyOn(billingCache, 'usage');
+    mockBillingClient.getOrgLimits.mockResolvedValue(PRO_LIMITS);
+
+    await service.checkLimit('test-org', LimitMetric.ROW_VERSIONS, 1);
+
+    expect(cacheSpy).toHaveBeenCalled();
   });
 
   it('should deny when branches_per_project limit reached', async () => {

--- a/ee/billing/limits/limits.service.ts
+++ b/ee/billing/limits/limits.service.ts
@@ -22,6 +22,13 @@ export class LimitsService implements ILimitsService {
     { data: OrgLimits; expiresAt: number }
   >();
 
+  private static readonly UNCACHED_METRICS: ReadonlySet<LimitMetric> = new Set([
+    LimitMetric.PROJECTS,
+    LimitMetric.SEATS,
+    LimitMetric.BRANCHES_PER_PROJECT,
+    LimitMetric.TABLES_PER_REVISION,
+  ]);
+
   constructor(
     @Inject(BILLING_CLIENT_TOKEN)
     private readonly billingClient: IBillingClient,
@@ -41,15 +48,7 @@ export class LimitsService implements ILimitsService {
     const limit = this.getLimitForMetric(orgLimits, metric);
     if (limit === null || limit === undefined) return { allowed: true };
 
-    const cacheKey =
-      context?.revisionId || context?.tableId || context?.projectId
-        ? `${metric}:r=${context?.revisionId ?? ''}:t=${context?.tableId ?? ''}:p=${context?.projectId ?? ''}`
-        : metric;
-    const current = await this.billingCache.usage(
-      organizationId,
-      cacheKey,
-      () => this.usageService.computeUsage(organizationId, metric, context),
-    );
+    const current = await this.getUsage(organizationId, metric, context);
     const projected = current + increment;
 
     if (projected > limit) {
@@ -64,6 +63,25 @@ export class LimitsService implements ILimitsService {
 
   invalidateCache(organizationId: string): void {
     this.limitsCache.delete(organizationId);
+  }
+
+  private async getUsage(
+    organizationId: string,
+    metric: LimitMetric,
+    context?: { revisionId?: string; tableId?: string; projectId?: string },
+  ): Promise<number> {
+    if (LimitsService.UNCACHED_METRICS.has(metric)) {
+      return this.usageService.computeUsage(organizationId, metric, context);
+    }
+
+    const cacheKey =
+      context?.revisionId || context?.tableId || context?.projectId
+        ? `${metric}:r=${context?.revisionId ?? ''}:t=${context?.tableId ?? ''}:p=${context?.projectId ?? ''}`
+        : metric;
+
+    return this.billingCache.usage(organizationId, cacheKey, () =>
+      this.usageService.computeUsage(organizationId, metric, context),
+    );
   }
 
   private getLimitForMetric(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Skip usage caching for rare limit metrics to enforce limits immediately and prevent temporary overages from the 2-minute TTL. Keep caching for expensive metrics that already have proper invalidation and support context-aware keys.

- **Bug Fixes**
  - Compute usage directly (no cache) for `PROJECTS`, `SEATS`, `BRANCHES_PER_PROJECT`, `TABLES_PER_REVISION`.
  - Centralized logic in `getUsage()`; keep context-keyed caching for other metrics. Tests cover bypass for `PROJECTS`/`SEATS`, cache usage for `ROW_VERSIONS`, and context-keyed cache for `ROWS_PER_TABLE`.

<sup>Written for commit ed8c2b9978fa66f6513a65a8187064154ed324a3. Summary will update on new commits. <a href="https://cubic.dev/pr/revisium/revisium-core/pull/490">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

