### PR TITLE
refactor: make TransactionPrismaService.run private, add runReadCommitted

### DIFF
--- a/src/features/draft-revision/commands/handlers/__tests__/draft-revision-commit.handler.spec.ts
+++ b/src/features/draft-revision/commands/handlers/__tests__/draft-revision-commit.handler.spec.ts
@@ -29,11 +29,13 @@ describe('DraftRevisionCommitHandler', () => {
   function runInTransaction(
     command: DraftRevisionCommitCommand,
   ): Promise<DraftRevisionCommitCommandReturnType> {
-    return transactionService.run(() => commandBus.execute(command));
+    return transactionService.runSerializable(() =>
+      commandBus.execute(command),
+    );
   }
 
   async function createChange(draftRevisionId: string, tableId: string) {
-    return transactionService.run(() =>
+    return transactionService.runSerializable(() =>
       commandBus.execute(
         new DraftRevisionCreateTableCommand({
           revisionId: draftRevisionId,

--- a/src/features/draft-revision/commands/handlers/__tests__/draft-revision-create-rows.handler.spec.ts
+++ b/src/features/draft-revision/commands/handlers/__tests__/draft-revision-create-rows.handler.spec.ts
@@ -34,7 +34,7 @@ describe('DraftRevisionCreateRowsHandler', () => {
     revisionId: string,
     tableId: string,
   ): Promise<DraftRevisionCreateTableCommandReturnType> {
-    return transactionService.run(() =>
+    return transactionService.runSerializable(() =>
       commandBus.execute(
         new DraftRevisionCreateTableCommand({ revisionId, tableId }),
       ),
@@ -44,7 +44,9 @@ describe('DraftRevisionCreateRowsHandler', () => {
   function runInTransaction(
     command: DraftRevisionCreateRowsCommand,
   ): Promise<DraftRevisionCreateRowsCommandReturnType> {
-    return transactionService.run(() => commandBus.execute(command));
+    return transactionService.runSerializable(() =>
+      commandBus.execute(command),
+    );
   }
 
   describe('validation', () => {

--- a/src/features/draft-revision/commands/handlers/__tests__/draft-revision-create-table.handler.spec.ts
+++ b/src/features/draft-revision/commands/handlers/__tests__/draft-revision-create-table.handler.spec.ts
@@ -28,7 +28,9 @@ describe('DraftRevisionCreateTableHandler', () => {
   function runInTransaction(
     command: DraftRevisionCreateTableCommand,
   ): Promise<DraftRevisionCreateTableCommandReturnType> {
-    return transactionService.run(() => commandBus.execute(command));
+    return transactionService.runSerializable(() =>
+      commandBus.execute(command),
+    );
   }
 
   describe('validation', () => {

--- a/src/features/draft-revision/commands/handlers/__tests__/draft-revision-get-or-create-draft-row.handler.spec.ts
+++ b/src/features/draft-revision/commands/handlers/__tests__/draft-revision-get-or-create-draft-row.handler.spec.ts
@@ -40,7 +40,7 @@ describe('DraftRevisionGetOrCreateDraftRowHandler', () => {
     tableResult: DraftRevisionCreateTableCommandReturnType;
     rowsResult: DraftRevisionCreateRowsCommandReturnType;
   }> {
-    return transactionService.run(async () => {
+    return transactionService.runSerializable(async () => {
       const tableResult: DraftRevisionCreateTableCommandReturnType =
         await commandBus.execute(
           new DraftRevisionCreateTableCommand({ revisionId, tableId }),
@@ -60,7 +60,9 @@ describe('DraftRevisionGetOrCreateDraftRowHandler', () => {
   function runInTransaction(
     command: DraftRevisionGetOrCreateDraftRowCommand,
   ): Promise<DraftRevisionGetOrCreateDraftRowCommandReturnType> {
-    return transactionService.run(() => commandBus.execute(command));
+    return transactionService.runSerializable(() =>
+      commandBus.execute(command),
+    );
   }
 
   describe('validation', () => {

--- a/src/features/draft-revision/commands/handlers/__tests__/draft-revision-get-or-create-draft-table.handler.spec.ts
+++ b/src/features/draft-revision/commands/handlers/__tests__/draft-revision-get-or-create-draft-table.handler.spec.ts
@@ -34,7 +34,7 @@ describe('DraftRevisionGetOrCreateDraftTableHandler', () => {
     tableId: string,
     options?: { system?: boolean },
   ): Promise<DraftRevisionCreateTableCommandReturnType> {
-    return transactionService.run(() =>
+    return transactionService.runSerializable(() =>
       commandBus.execute(
         new DraftRevisionCreateTableCommand({
           revisionId,
@@ -48,7 +48,9 @@ describe('DraftRevisionGetOrCreateDraftTableHandler', () => {
   function runInTransaction(
     command: DraftRevisionGetOrCreateDraftTableCommand,
   ): Promise<DraftRevisionGetOrCreateDraftTableCommandReturnType> {
-    return transactionService.run(() => commandBus.execute(command));
+    return transactionService.runSerializable(() =>
+      commandBus.execute(command),
+    );
   }
 
   describe('validation', () => {

--- a/src/features/draft-revision/commands/handlers/__tests__/draft-revision-recompute-has-changes.handler.spec.ts
+++ b/src/features/draft-revision/commands/handlers/__tests__/draft-revision-recompute-has-changes.handler.spec.ts
@@ -420,7 +420,9 @@ describe('DraftRevisionRecomputeHasChangesHandler', () => {
   async function runInTransaction(
     command: DraftRevisionRecomputeHasChangesCommand,
   ): Promise<void> {
-    return transactionService.run(async () => commandBus.execute(command));
+    return transactionService.runSerializable(async () =>
+      commandBus.execute(command),
+    );
   }
 
   let prismaService: PrismaService;

--- a/src/features/draft-revision/commands/handlers/__tests__/draft-revision-remove-rows.handler.spec.ts
+++ b/src/features/draft-revision/commands/handlers/__tests__/draft-revision-remove-rows.handler.spec.ts
@@ -35,7 +35,7 @@ describe('DraftRevisionRemoveRowsHandler', () => {
     revisionId: string,
     tableId: string,
   ): Promise<DraftRevisionCreateTableCommandReturnType> {
-    return transactionService.run(() =>
+    return transactionService.runSerializable(() =>
       commandBus.execute(
         new DraftRevisionCreateTableCommand({ revisionId, tableId }),
       ),
@@ -50,7 +50,7 @@ describe('DraftRevisionRemoveRowsHandler', () => {
     tableResult: DraftRevisionCreateTableCommandReturnType;
     rowsResult: DraftRevisionCreateRowsCommandReturnType;
   }> {
-    return transactionService.run(async () => {
+    return transactionService.runSerializable(async () => {
       const tableResult: DraftRevisionCreateTableCommandReturnType =
         await commandBus.execute(
           new DraftRevisionCreateTableCommand({ revisionId, tableId }),
@@ -70,7 +70,9 @@ describe('DraftRevisionRemoveRowsHandler', () => {
   function runInTransaction(
     command: DraftRevisionRemoveRowsCommand,
   ): Promise<DraftRevisionRemoveRowsCommandReturnType> {
-    return transactionService.run(() => commandBus.execute(command));
+    return transactionService.runSerializable(() =>
+      commandBus.execute(command),
+    );
   }
 
   describe('validation', () => {

--- a/src/features/draft-revision/commands/handlers/__tests__/draft-revision-remove-table.handler.spec.ts
+++ b/src/features/draft-revision/commands/handlers/__tests__/draft-revision-remove-table.handler.spec.ts
@@ -41,7 +41,7 @@ describe('DraftRevisionRemoveTableHandler', () => {
     revisionId: string,
     tableId: string,
   ): Promise<DraftRevisionCreateTableCommandReturnType> {
-    return transactionService.run(() =>
+    return transactionService.runSerializable(() =>
       commandBus.execute(
         new DraftRevisionCreateTableCommand({ revisionId, tableId }),
       ),
@@ -53,7 +53,7 @@ describe('DraftRevisionRemoveTableHandler', () => {
     tableId: string,
     rowId: string,
   ): Promise<DraftRevisionCreateTableCommandReturnType> {
-    return transactionService.run(async () => {
+    return transactionService.runSerializable(async () => {
       const tableResult: DraftRevisionCreateTableCommandReturnType =
         await commandBus.execute(
           new DraftRevisionCreateTableCommand({ revisionId, tableId }),
@@ -72,7 +72,9 @@ describe('DraftRevisionRemoveTableHandler', () => {
   function runInTransaction(
     command: DraftRevisionRemoveTableCommand,
   ): Promise<DraftRevisionRemoveTableCommandReturnType> {
-    return transactionService.run(() => commandBus.execute(command));
+    return transactionService.runSerializable(() =>
+      commandBus.execute(command),
+    );
   }
 
   describe('validation', () => {

--- a/src/features/draft-revision/commands/handlers/__tests__/draft-revision-rename-rows.handler.spec.ts
+++ b/src/features/draft-revision/commands/handlers/__tests__/draft-revision-rename-rows.handler.spec.ts
@@ -39,7 +39,7 @@ describe('DraftRevisionRenameRowsHandler', () => {
     tableResult: DraftRevisionCreateTableCommandReturnType;
     rowsResult: DraftRevisionCreateRowsCommandReturnType;
   }> {
-    return transactionService.run(async () => {
+    return transactionService.runSerializable(async () => {
       const tableResult: DraftRevisionCreateTableCommandReturnType =
         await commandBus.execute(
           new DraftRevisionCreateTableCommand({ revisionId, tableId }),
@@ -59,13 +59,15 @@ describe('DraftRevisionRenameRowsHandler', () => {
   function runInTransaction(
     command: DraftRevisionRenameRowsCommand,
   ): Promise<DraftRevisionRenameRowsCommandReturnType> {
-    return transactionService.run(() => commandBus.execute(command));
+    return transactionService.runSerializable(() =>
+      commandBus.execute(command),
+    );
   }
 
   describe('validation', () => {
     it('should throw an error if row does not exist', async () => {
       const { draftRevisionId } = await prepareDraftRevisionTest(prismaService);
-      await transactionService.run(() =>
+      await transactionService.runSerializable(() =>
         commandBus.execute(
           new DraftRevisionCreateTableCommand({
             revisionId: draftRevisionId,

--- a/src/features/draft-revision/commands/handlers/__tests__/draft-revision-rename-table.handler.spec.ts
+++ b/src/features/draft-revision/commands/handlers/__tests__/draft-revision-rename-table.handler.spec.ts
@@ -33,7 +33,7 @@ describe('DraftRevisionRenameTableHandler', () => {
     revisionId: string,
     tableId: string,
   ): Promise<DraftRevisionCreateTableCommandReturnType> {
-    return transactionService.run(() =>
+    return transactionService.runSerializable(() =>
       commandBus.execute(
         new DraftRevisionCreateTableCommand({ revisionId, tableId }),
       ),
@@ -43,7 +43,9 @@ describe('DraftRevisionRenameTableHandler', () => {
   function runInTransaction(
     command: DraftRevisionRenameTableCommand,
   ): Promise<DraftRevisionRenameTableCommandReturnType> {
-    return transactionService.run(() => commandBus.execute(command));
+    return transactionService.runSerializable(() =>
+      commandBus.execute(command),
+    );
   }
 
   describe('validation', () => {

--- a/src/features/draft-revision/commands/handlers/__tests__/draft-revision-revert.handler.spec.ts
+++ b/src/features/draft-revision/commands/handlers/__tests__/draft-revision-revert.handler.spec.ts
@@ -29,11 +29,13 @@ describe('DraftRevisionRevertHandler', () => {
   function runInTransaction(
     command: DraftRevisionRevertCommand,
   ): Promise<DraftRevisionRevertCommandReturnType> {
-    return transactionService.run(() => commandBus.execute(command));
+    return transactionService.runSerializable(() =>
+      commandBus.execute(command),
+    );
   }
 
   async function createChange(draftRevisionId: string, tableId: string) {
-    return transactionService.run(() =>
+    return transactionService.runSerializable(() =>
       commandBus.execute(
         new DraftRevisionCreateTableCommand({
           revisionId: draftRevisionId,

--- a/src/features/draft-revision/commands/handlers/__tests__/draft-revision-update-rows.handler.spec.ts
+++ b/src/features/draft-revision/commands/handlers/__tests__/draft-revision-update-rows.handler.spec.ts
@@ -40,7 +40,7 @@ describe('DraftRevisionUpdateRowsHandler', () => {
     tableResult: DraftRevisionCreateTableCommandReturnType;
     rowsResult: DraftRevisionCreateRowsCommandReturnType;
   }> {
-    return transactionService.run(async () => {
+    return transactionService.runSerializable(async () => {
       const tableResult: DraftRevisionCreateTableCommandReturnType =
         await commandBus.execute(
           new DraftRevisionCreateTableCommand({ revisionId, tableId }),
@@ -60,7 +60,9 @@ describe('DraftRevisionUpdateRowsHandler', () => {
   function runInTransaction(
     command: DraftRevisionUpdateRowsCommand,
   ): Promise<DraftRevisionUpdateRowsCommandReturnType> {
-    return transactionService.run(() => commandBus.execute(command));
+    return transactionService.runSerializable(() =>
+      commandBus.execute(command),
+    );
   }
 
   describe('validation', () => {

--- a/src/features/endpoint/queries/handlers/__tests__/get-endpoint-relatives.handler.spec.ts
+++ b/src/features/endpoint/queries/handlers/__tests__/get-endpoint-relatives.handler.spec.ts
@@ -110,7 +110,9 @@ describe('GetEndpointRelativesHandler', () => {
   function runTransaction(
     query: GetEndpointRelativesQuery,
   ): Promise<GetEndpointRelativesQueryReturnType> {
-    return transactionService.run(async () => queryBus.execute(query));
+    return transactionService.runSerializable(async () =>
+      queryBus.execute(query),
+    );
   }
 
   let prismaService: PrismaService;

--- a/src/features/endpoint/queries/handlers/__tests__/get-project-endpoints.handler.spec.ts
+++ b/src/features/endpoint/queries/handlers/__tests__/get-project-endpoints.handler.spec.ts
@@ -209,7 +209,9 @@ describe('GetProjectEndpointsHandler', () => {
   function runTransaction(
     query: GetProjectEndpointsQuery,
   ): Promise<GetProjectEndpointsReturnType> {
-    return transactionService.run(async () => queryBus.execute(query));
+    return transactionService.runSerializable(async () =>
+      queryBus.execute(query),
+    );
   }
 
   let prismaService: PrismaService;

--- a/src/features/project/commands/handlers/create-project.handler.ts
+++ b/src/features/project/commands/handlers/create-project.handler.ts
@@ -87,9 +87,9 @@ export class CreateProjectHandler implements ICommandHandler<
       throw new LimitExceededException(limitResult);
     }
 
-    return this.transactionService.run(() => this.transactionHandler(command), {
-      isolationLevel: Prisma.TransactionIsolationLevel.ReadCommitted,
-    });
+    return this.transactionService.runReadCommitted(() =>
+      this.transactionHandler(command),
+    );
   }
 
   private async transactionHandler(

--- a/src/features/share/__tests__/foreign-keys.service.spec.ts
+++ b/src/features/share/__tests__/foreign-keys.service.spec.ts
@@ -33,15 +33,17 @@ describe('ForeignKeysService', () => {
     it('should find rows by key-value in JSON data', async () => {
       const tableVersionId = await createTableWithRows();
 
-      const results = await transactionPrismaService.run(async () => {
-        return service.findRowsByKeyValueInData(
-          tableVersionId,
-          'title',
-          'Test Title 1',
-          10,
-          0,
-        );
-      });
+      const results = await transactionPrismaService.runSerializable(
+        async () => {
+          return service.findRowsByKeyValueInData(
+            tableVersionId,
+            'title',
+            'Test Title 1',
+            10,
+            0,
+          );
+        },
+      );
 
       expect(results).toHaveLength(1);
       expect(results[0].data).toEqual({ title: 'Test Title 1', count: 10 });
@@ -50,15 +52,17 @@ describe('ForeignKeysService', () => {
     it('should return empty array when no matches found', async () => {
       const tableVersionId = await createTableWithRows();
 
-      const results = await transactionPrismaService.run(async () => {
-        return service.findRowsByKeyValueInData(
-          tableVersionId,
-          'title',
-          'Non-existent Title',
-          10,
-          0,
-        );
-      });
+      const results = await transactionPrismaService.runSerializable(
+        async () => {
+          return service.findRowsByKeyValueInData(
+            tableVersionId,
+            'title',
+            'Non-existent Title',
+            10,
+            0,
+          );
+        },
+      );
 
       expect(results).toHaveLength(0);
     });
@@ -66,15 +70,17 @@ describe('ForeignKeysService', () => {
     it('should respect limit and offset parameters', async () => {
       const tableVersionId = await createTableWithManyRows();
 
-      const results = await transactionPrismaService.run(async () => {
-        return service.findRowsByKeyValueInData(
-          tableVersionId,
-          'category',
-          'test',
-          2,
-          1,
-        );
-      });
+      const results = await transactionPrismaService.runSerializable(
+        async () => {
+          return service.findRowsByKeyValueInData(
+            tableVersionId,
+            'category',
+            'test',
+            2,
+            1,
+          );
+        },
+      );
 
       expect(results).toHaveLength(2);
     });
@@ -84,7 +90,7 @@ describe('ForeignKeysService', () => {
     it('should count rows by key-value in JSON data', async () => {
       const tableVersionId = await createTableWithRows();
 
-      const count = await transactionPrismaService.run(async () => {
+      const count = await transactionPrismaService.runSerializable(async () => {
         return service.countRowsByKeyValueInData(
           tableVersionId,
           'title',
@@ -98,7 +104,7 @@ describe('ForeignKeysService', () => {
     it('should return 0 when no matches found', async () => {
       const tableVersionId = await createTableWithRows();
 
-      const count = await transactionPrismaService.run(async () => {
+      const count = await transactionPrismaService.runSerializable(async () => {
         return service.countRowsByKeyValueInData(
           tableVersionId,
           'title',
@@ -114,15 +120,17 @@ describe('ForeignKeysService', () => {
     it('should find rows by JSON paths and value', async () => {
       const tableVersionId = await createTableWithNestedData();
 
-      const results = await transactionPrismaService.run(async () => {
-        return service.findRowsByPathsAndValueInData(
-          tableVersionId,
-          ['$.user.id', '$.metadata.userId'],
-          'user123',
-          10,
-          0,
-        );
-      });
+      const results = await transactionPrismaService.runSerializable(
+        async () => {
+          return service.findRowsByPathsAndValueInData(
+            tableVersionId,
+            ['$.user.id', '$.metadata.userId'],
+            'user123',
+            10,
+            0,
+          );
+        },
+      );
 
       expect(results).toHaveLength(2);
     });
@@ -130,15 +138,17 @@ describe('ForeignKeysService', () => {
     it('should return empty array when jsonPaths is empty', async () => {
       const tableVersionId = await createTableWithRows();
 
-      const results = await transactionPrismaService.run(async () => {
-        return service.findRowsByPathsAndValueInData(
-          tableVersionId,
-          [],
-          'any-value',
-          10,
-          0,
-        );
-      });
+      const results = await transactionPrismaService.runSerializable(
+        async () => {
+          return service.findRowsByPathsAndValueInData(
+            tableVersionId,
+            [],
+            'any-value',
+            10,
+            0,
+          );
+        },
+      );
 
       expect(results).toHaveLength(0);
     });
@@ -146,15 +156,17 @@ describe('ForeignKeysService', () => {
     it('should handle multiple paths with OR logic', async () => {
       const tableVersionId = await createTableWithMultipleFields();
 
-      const results = await transactionPrismaService.run(async () => {
-        return service.findRowsByPathsAndValueInData(
-          tableVersionId,
-          ['$.author', '$.editor'],
-          'john',
-          10,
-          0,
-        );
-      });
+      const results = await transactionPrismaService.runSerializable(
+        async () => {
+          return service.findRowsByPathsAndValueInData(
+            tableVersionId,
+            ['$.author', '$.editor'],
+            'john',
+            10,
+            0,
+          );
+        },
+      );
 
       expect(results).toHaveLength(3); // 2 with author=john, 1 with editor=john
     });
@@ -162,15 +174,17 @@ describe('ForeignKeysService', () => {
     it('should respect limit and offset', async () => {
       const tableVersionId = await createTableWithManyRows();
 
-      const results = await transactionPrismaService.run(async () => {
-        return service.findRowsByPathsAndValueInData(
-          tableVersionId,
-          ['$.category'],
-          'test',
-          2,
-          2,
-        );
-      });
+      const results = await transactionPrismaService.runSerializable(
+        async () => {
+          return service.findRowsByPathsAndValueInData(
+            tableVersionId,
+            ['$.category'],
+            'test',
+            2,
+            2,
+          );
+        },
+      );
 
       expect(results).toHaveLength(2);
     });
@@ -180,7 +194,7 @@ describe('ForeignKeysService', () => {
     it('should count rows by JSON paths and value', async () => {
       const tableVersionId = await createTableWithNestedData();
 
-      const count = await transactionPrismaService.run(async () => {
+      const count = await transactionPrismaService.runSerializable(async () => {
         return service.countRowsByPathsAndValueInData(
           tableVersionId,
           ['$.user.id', '$.metadata.userId'],
@@ -194,7 +208,7 @@ describe('ForeignKeysService', () => {
     it('should return 0 when jsonPaths is empty', async () => {
       const tableVersionId = await createTableWithRows();
 
-      const count = await transactionPrismaService.run(async () => {
+      const count = await transactionPrismaService.runSerializable(async () => {
         return service.countRowsByPathsAndValueInData(
           tableVersionId,
           [],
@@ -208,7 +222,7 @@ describe('ForeignKeysService', () => {
     it('should handle multiple paths with OR logic', async () => {
       const tableVersionId = await createTableWithMultipleFields();
 
-      const count = await transactionPrismaService.run(async () => {
+      const count = await transactionPrismaService.runSerializable(async () => {
         return service.countRowsByPathsAndValueInData(
           tableVersionId,
           ['$.author', '$.editor'],
@@ -224,7 +238,7 @@ describe('ForeignKeysService', () => {
     it('should count rows matching any of multiple values', async () => {
       const tableVersionId = await createTableWithMultipleFields();
 
-      const count = await transactionPrismaService.run(async () => {
+      const count = await transactionPrismaService.runSerializable(async () => {
         return service.countRowsByPathsAndValuesInData(
           tableVersionId,
           ['$.author'],
@@ -238,7 +252,7 @@ describe('ForeignKeysService', () => {
     it('should count rows matching any path and any value', async () => {
       const tableVersionId = await createTableWithMultipleFields();
 
-      const count = await transactionPrismaService.run(async () => {
+      const count = await transactionPrismaService.runSerializable(async () => {
         return service.countRowsByPathsAndValuesInData(
           tableVersionId,
           ['$.author', '$.editor'],
@@ -255,7 +269,7 @@ describe('ForeignKeysService', () => {
     it('should return 0 when jsonPaths is empty', async () => {
       const tableVersionId = await createTableWithRows();
 
-      const count = await transactionPrismaService.run(async () => {
+      const count = await transactionPrismaService.runSerializable(async () => {
         return service.countRowsByPathsAndValuesInData(
           tableVersionId,
           [],
@@ -269,7 +283,7 @@ describe('ForeignKeysService', () => {
     it('should return 0 when values is empty', async () => {
       const tableVersionId = await createTableWithRows();
 
-      const count = await transactionPrismaService.run(async () => {
+      const count = await transactionPrismaService.runSerializable(async () => {
         return service.countRowsByPathsAndValuesInData(
           tableVersionId,
           ['$.title'],
@@ -283,7 +297,7 @@ describe('ForeignKeysService', () => {
     it('should return 0 when no matches found', async () => {
       const tableVersionId = await createTableWithRows();
 
-      const count = await transactionPrismaService.run(async () => {
+      const count = await transactionPrismaService.runSerializable(async () => {
         return service.countRowsByPathsAndValuesInData(
           tableVersionId,
           ['$.title'],
@@ -297,7 +311,7 @@ describe('ForeignKeysService', () => {
     it('should handle nested paths with multiple values', async () => {
       const tableVersionId = await createTableWithNestedData();
 
-      const count = await transactionPrismaService.run(async () => {
+      const count = await transactionPrismaService.runSerializable(async () => {
         return service.countRowsByPathsAndValuesInData(
           tableVersionId,
           ['$.user.id', '$.metadata.userId'],
@@ -314,24 +328,28 @@ describe('ForeignKeysService', () => {
       const values = ['john', 'jane'];
 
       // Batch call
-      const batchCount = await transactionPrismaService.run(async () => {
-        return service.countRowsByPathsAndValuesInData(
-          tableVersionId,
-          paths,
-          values,
-        );
-      });
+      const batchCount = await transactionPrismaService.runSerializable(
+        async () => {
+          return service.countRowsByPathsAndValuesInData(
+            tableVersionId,
+            paths,
+            values,
+          );
+        },
+      );
 
       // Individual calls
       let individualSum = 0;
       for (const value of values) {
-        const count = await transactionPrismaService.run(async () => {
-          return service.countRowsByPathsAndValueInData(
-            tableVersionId,
-            paths,
-            value,
-          );
-        });
+        const count = await transactionPrismaService.runSerializable(
+          async () => {
+            return service.countRowsByPathsAndValueInData(
+              tableVersionId,
+              paths,
+              value,
+            );
+          },
+        );
         individualSum += count;
       }
 
@@ -345,45 +363,53 @@ describe('ForeignKeysService', () => {
       const tableVersionId = await createTableWithSpecialKeys();
 
       // These should all work now
-      const results1 = await transactionPrismaService.run(async () => {
-        return service.findRowsByKeyValueInData(
-          tableVersionId,
-          '123numerickey',
-          'value1',
-          10,
-          0,
-        );
-      });
+      const results1 = await transactionPrismaService.runSerializable(
+        async () => {
+          return service.findRowsByKeyValueInData(
+            tableVersionId,
+            '123numerickey',
+            'value1',
+            10,
+            0,
+          );
+        },
+      );
 
-      const results2 = await transactionPrismaService.run(async () => {
-        return service.findRowsByKeyValueInData(
-          tableVersionId,
-          'key-with-hyphens',
-          'value2',
-          10,
-          0,
-        );
-      });
+      const results2 = await transactionPrismaService.runSerializable(
+        async () => {
+          return service.findRowsByKeyValueInData(
+            tableVersionId,
+            'key-with-hyphens',
+            'value2',
+            10,
+            0,
+          );
+        },
+      );
 
-      const results3 = await transactionPrismaService.run(async () => {
-        return service.findRowsByKeyValueInData(
-          tableVersionId,
-          'key.with.dots',
-          'value3',
-          10,
-          0,
-        );
-      });
+      const results3 = await transactionPrismaService.runSerializable(
+        async () => {
+          return service.findRowsByKeyValueInData(
+            tableVersionId,
+            'key.with.dots',
+            'value3',
+            10,
+            0,
+          );
+        },
+      );
 
-      const results4 = await transactionPrismaService.run(async () => {
-        return service.findRowsByKeyValueInData(
-          tableVersionId,
-          'key with spaces',
-          'value4',
-          10,
-          0,
-        );
-      });
+      const results4 = await transactionPrismaService.runSerializable(
+        async () => {
+          return service.findRowsByKeyValueInData(
+            tableVersionId,
+            'key with spaces',
+            'value4',
+            10,
+            0,
+          );
+        },
+      );
 
       expect(results1).toHaveLength(1);
       expect(results2).toHaveLength(1);
@@ -395,7 +421,7 @@ describe('ForeignKeysService', () => {
       const tableVersionId = await createTableWithRows();
 
       await expect(
-        transactionPrismaService.run(async () => {
+        transactionPrismaService.runSerializable(async () => {
           return service.findRowsByKeyValueInData(
             tableVersionId,
             'key\0withnull',
@@ -412,7 +438,7 @@ describe('ForeignKeysService', () => {
       const longKey = 'a'.repeat(1001);
 
       await expect(
-        transactionPrismaService.run(async () => {
+        transactionPrismaService.runSerializable(async () => {
           return service.findRowsByKeyValueInData(
             tableVersionId,
             longKey,
@@ -428,15 +454,17 @@ describe('ForeignKeysService', () => {
       const tableVersionId = await createTableWithSpecialChars();
 
       // Values with special characters should work fine with parameterized queries
-      const results = await transactionPrismaService.run(async () => {
-        return service.findRowsByKeyValueInData(
-          tableVersionId,
-          'title',
-          'Title with \'quotes\' and "double quotes"',
-          10,
-          0,
-        );
-      });
+      const results = await transactionPrismaService.runSerializable(
+        async () => {
+          return service.findRowsByKeyValueInData(
+            tableVersionId,
+            'title',
+            'Title with \'quotes\' and "double quotes"',
+            10,
+            0,
+          );
+        },
+      );
 
       // Should find the matching row
       expect(results).toHaveLength(1);
@@ -446,15 +474,17 @@ describe('ForeignKeysService', () => {
       const tableVersionId = await createTableWithBackslashes();
 
       // Values with backslashes should work fine with parameterized queries
-      const results = await transactionPrismaService.run(async () => {
-        return service.findRowsByKeyValueInData(
-          tableVersionId,
-          'path',
-          'C:\\Windows\\System32\\file.exe',
-          10,
-          0,
-        );
-      });
+      const results = await transactionPrismaService.runSerializable(
+        async () => {
+          return service.findRowsByKeyValueInData(
+            tableVersionId,
+            'path',
+            'C:\\Windows\\System32\\file.exe',
+            10,
+            0,
+          );
+        },
+      );
 
       // Should find the matching row
       expect(results).toHaveLength(1);
@@ -464,15 +494,17 @@ describe('ForeignKeysService', () => {
       const tableVersionId = await createTableWithRows();
 
       // Malicious values should be treated as literal strings, not SQL
-      const results = await transactionPrismaService.run(async () => {
-        return service.findRowsByKeyValueInData(
-          tableVersionId,
-          'title',
-          'test\'; DROP TABLE "Row"; --',
-          10,
-          0,
-        );
-      });
+      const results = await transactionPrismaService.runSerializable(
+        async () => {
+          return service.findRowsByKeyValueInData(
+            tableVersionId,
+            'title',
+            'test\'; DROP TABLE "Row"; --',
+            10,
+            0,
+          );
+        },
+      );
 
       // Should return no results (treated as literal string match)
       expect(results).toHaveLength(0);
@@ -482,37 +514,43 @@ describe('ForeignKeysService', () => {
       const tableVersionId = await createTableWithSpecialKeys();
 
       // Test finding data with $ in field name
-      const results1 = await transactionPrismaService.run(async () => {
-        return service.findRowsByPathsAndValueInData(
-          tableVersionId,
-          ['$."field$with$dollars"'],
-          'value9',
-          10,
-          0,
-        );
-      });
+      const results1 = await transactionPrismaService.runSerializable(
+        async () => {
+          return service.findRowsByPathsAndValueInData(
+            tableVersionId,
+            ['$."field$with$dollars"'],
+            'value9',
+            10,
+            0,
+          );
+        },
+      );
 
       // Test finding data with ; in field name
-      const results2 = await transactionPrismaService.run(async () => {
-        return service.findRowsByPathsAndValueInData(
-          tableVersionId,
-          ['$."field;with;semicolons"'],
-          'value10',
-          10,
-          0,
-        );
-      });
+      const results2 = await transactionPrismaService.runSerializable(
+        async () => {
+          return service.findRowsByPathsAndValueInData(
+            tableVersionId,
+            ['$."field;with;semicolons"'],
+            'value10',
+            10,
+            0,
+          );
+        },
+      );
 
       // Test finding data with " in field name (escaped in JSON)
-      const results3 = await transactionPrismaService.run(async () => {
-        return service.findRowsByPathsAndValueInData(
-          tableVersionId,
-          ['$."field\\"with\\"quotes"'],
-          'value11',
-          10,
-          0,
-        );
-      });
+      const results3 = await transactionPrismaService.runSerializable(
+        async () => {
+          return service.findRowsByPathsAndValueInData(
+            tableVersionId,
+            ['$."field\\"with\\"quotes"'],
+            'value11',
+            10,
+            0,
+          );
+        },
+      );
 
       // Should find the matching rows
       expect(results1).toHaveLength(1);
@@ -531,7 +569,7 @@ describe('ForeignKeysService', () => {
       const tableVersionId = await createTableWithRows();
 
       await expect(
-        transactionPrismaService.run(async () => {
+        transactionPrismaService.runSerializable(async () => {
           return service.findRowsByPathsAndValueInData(
             tableVersionId,
             ['$.field\0withnull'],
@@ -547,7 +585,7 @@ describe('ForeignKeysService', () => {
       const tableVersionId = await createTableWithRows();
 
       await expect(
-        transactionPrismaService.run(async () => {
+        transactionPrismaService.runSerializable(async () => {
           return service.findRowsByPathsAndValueInData(
             tableVersionId,
             ['invalid.path'],
@@ -563,15 +601,17 @@ describe('ForeignKeysService', () => {
       const tableVersionId = await createTableWithLegitimateFieldNames();
 
       // Test that legitimate field names containing SQL keywords work correctly
-      const results = await transactionPrismaService.run(async () => {
-        return service.findRowsByKeyValueInData(
-          tableVersionId,
-          'fieldDROP', // Legitimate field name containing DROP
-          'some value',
-          10,
-          0,
-        );
-      });
+      const results = await transactionPrismaService.runSerializable(
+        async () => {
+          return service.findRowsByKeyValueInData(
+            tableVersionId,
+            'fieldDROP', // Legitimate field name containing DROP
+            'some value',
+            10,
+            0,
+          );
+        },
+      );
 
       expect(results).toHaveLength(1);
       expect(results[0].data).toEqual({

--- a/src/infrastructure/database/transaction-prisma.service.ts
+++ b/src/infrastructure/database/transaction-prisma.service.ts
@@ -186,7 +186,19 @@ export class TransactionPrismaService implements OnModuleInit {
     return this.getTransactionUnsafe() ?? this.prismaService;
   }
 
-  public async run<T>(
+  public runReadCommitted<T>(
+    handler: (...rest: unknown[]) => Promise<T>,
+    options?: Omit<Partial<TransactionOptions>, 'isolationLevel'>,
+  ): Promise<T> {
+    return this.run(handler, {
+      maxWait: options?.maxWait ?? this.serializableOptions.maxWait,
+      timeout: options?.timeout ?? this.serializableOptions.timeout,
+      isolationLevel: Prisma.TransactionIsolationLevel.ReadCommitted,
+      retry: options?.retry ?? this.serializableOptions.retry,
+    });
+  }
+
+  private async run<T>(
     handler: (...rest: unknown[]) => Promise<T>,
     options?: TransactionOptions,
   ): Promise<T> {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make transaction isolation explicit and reduce flakiness by making `TransactionPrismaService.run` private, adding `runReadCommitted`, and switching tests to `runSerializable`. This clarifies isolation intent and stabilizes transactional tests.

- **Refactors**
  - Added `runReadCommitted(handler, options?)` with ReadCommitted isolation and default retry/timeouts.
  - Made `run` private; public API is `runSerializable` and `runReadCommitted`.
  - Updated create-project handler to use `runReadCommitted`.

- **Migration**
  - Replace `transactionService.run(...)` with `transactionService.runSerializable(...)` in most cases.
  - Use `transactionService.runReadCommitted(...)` only when ReadCommitted is intentional.

<sup>Written for commit 01ffd0c37664df69599070a19753f13d112a6d4b. Summary will update on new commits. <a href="https://cubic.dev/pr/revisium/revisium-core/pull/491">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

