### PR TITLE
fix(oauth): support basic client authentication

### DIFF
--- a/docs/oauth.md
+++ b/docs/oauth.md
@@ -66,12 +66,13 @@ Revisium implements an OAuth 2.1 Authorization Code flow with PKCE to authentica
 
 ### Discovery (RFC 8414)
 
-| Method | Path | Description |
-|--------|------|-------------|
-| GET | `/.well-known/oauth-authorization-server` | OAuth server metadata |
-| GET | `/.well-known/oauth-protected-resource` | Resource server metadata |
+| Method | Path                                      | Description              |
+| ------ | ----------------------------------------- | ------------------------ |
+| GET    | `/.well-known/oauth-authorization-server` | OAuth server metadata    |
+| GET    | `/.well-known/oauth-protected-resource`   | Resource server metadata |
 
 **Authorization Server Metadata:**
+
 ```json
 {
   "issuer": "https://revisium.example.com",
@@ -81,14 +82,21 @@ Revisium implements an OAuth 2.1 Authorization Code flow with PKCE to authentica
   "response_types_supported": ["code"],
   "grant_types_supported": ["authorization_code", "refresh_token"],
   "code_challenge_methods_supported": ["S256"],
-  "token_endpoint_auth_methods_supported": ["client_secret_post"],
+  "token_endpoint_auth_methods_supported": [
+    "client_secret_post",
+    "client_secret_basic"
+  ],
   "revocation_endpoint": "https://revisium.example.com/oauth/revoke",
-  "revocation_endpoint_auth_methods_supported": ["client_secret_post"],
+  "revocation_endpoint_auth_methods_supported": [
+    "client_secret_post",
+    "client_secret_basic"
+  ],
   "scopes_supported": ["mcp"]
 }
 ```
 
 **Protected Resource Metadata:**
+
 ```json
 {
   "resource": "https://revisium.example.com",
@@ -100,11 +108,12 @@ Revisium implements an OAuth 2.1 Authorization Code flow with PKCE to authentica
 
 ### Client Registration
 
-| Method | Path | Auth | Description |
-|--------|------|------|-------------|
-| POST | `/oauth/register` | None | Dynamic Client Registration (RFC 7591) |
+| Method | Path              | Auth | Description                            |
+| ------ | ----------------- | ---- | -------------------------------------- |
+| POST   | `/oauth/register` | None | Dynamic Client Registration (RFC 7591) |
 
 **Request:**
+
 ```json
 {
   "client_name": "Claude Code",
@@ -114,40 +123,44 @@ Revisium implements an OAuth 2.1 Authorization Code flow with PKCE to authentica
 ```
 
 **Response:**
+
 ```json
 {
   "client_id": "abc123",
   "client_secret": "ocs_<72 hex chars>",
   "client_name": "Claude Code",
+  "token_endpoint_auth_method": "client_secret_post",
   "redirect_uris": ["http://127.0.0.1:3000/callback"],
   "grant_types": ["authorization_code", "refresh_token"]
 }
 ```
 
 The `client_secret` is returned **once** and stored as a SHA-256 hash in the database. It cannot be retrieved later.
+The registration response explicitly declares `token_endpoint_auth_method: "client_secret_post"` so dynamically registered MCP clients do not fall back to `client_secret_basic` by default.
 
 All `redirect_uris` must use `http:` or `https:` scheme. Other schemes (`javascript:`, `data:`, etc.) are rejected. `http:` is only allowed for `localhost`, `127.0.0.1`, and `[::1]` (IPv6 loopback).
 
 ### Authorization
 
-| Method | Path | Auth | Description |
-|--------|------|------|-------------|
-| GET | `/oauth/authorize` | None | Validate params and redirect to Admin UI |
-| POST | `/oauth/authorize` | Bearer JWT | Create auth code (called by Admin UI) |
+| Method | Path               | Auth       | Description                              |
+| ------ | ------------------ | ---------- | ---------------------------------------- |
+| GET    | `/oauth/authorize` | None       | Validate params and redirect to Admin UI |
+| POST   | `/oauth/authorize` | Bearer JWT | Create auth code (called by Admin UI)    |
 
 **GET /oauth/authorize** query parameters:
 
-| Parameter | Required | Description |
-|-----------|----------|-------------|
-| `client_id` | Yes | Registered client ID |
-| `redirect_uri` | Yes | Must match registered URI |
-| `code_challenge` | Yes | PKCE challenge (`base64url(sha256(verifier))`) |
-| `state` | Yes | Opaque value for CSRF protection |
-| `response_type` | Yes | Must be `code` |
-| `code_challenge_method` | Yes | Must be `S256` |
-| `scope` | No | Space-separated scopes (e.g. `mcp`) |
+| Parameter               | Required | Description                                    |
+| ----------------------- | -------- | ---------------------------------------------- |
+| `client_id`             | Yes      | Registered client ID                           |
+| `redirect_uri`          | Yes      | Must match registered URI                      |
+| `code_challenge`        | Yes      | PKCE challenge (`base64url(sha256(verifier))`) |
+| `state`                 | Yes      | Opaque value for CSRF protection               |
+| `response_type`         | Yes      | Must be `code`                                 |
+| `code_challenge_method` | Yes      | Must be `S256`                                 |
+| `scope`                 | No       | Space-separated scopes (e.g. `mcp`)            |
 
 Validates all parameters, then redirects `302` to Admin UI:
+
 ```text
 /authorize?client_id=...&client_name=...&redirect_uri=...&code_challenge=...&state=...&scope=mcp
 ```
@@ -171,6 +184,7 @@ Content-Type: application/json
 The `scope` field is optional. When present, it is stored with the authorization code and propagated to the access token on exchange.
 
 Response:
+
 ```json
 {
   "redirect_uri": "http://127.0.0.1:3000/callback?code=auth_<48 hex chars>&state=xyz789"
@@ -179,9 +193,9 @@ Response:
 
 ### Token Revocation (RFC 7009)
 
-| Method | Path | Auth | Description |
-|--------|------|------|-------------|
-| POST | `/oauth/revoke` | `client_secret_post` | Revoke an access or refresh token |
+| Method | Path            | Auth                                          | Description                       |
+| ------ | --------------- | --------------------------------------------- | --------------------------------- |
+| POST   | `/oauth/revoke` | `client_secret_post` or `client_secret_basic` | Revoke an access or refresh token |
 
 ```http
 POST /oauth/revoke
@@ -196,21 +210,24 @@ Content-Type: application/json
 ```
 
 **Behavior:**
+
 - Always returns `200 OK`, even for invalid or already-revoked tokens (per RFC 7009)
 - `token_type_hint` is optional; the server uses token prefix (`oat_`/`ort_`) as a fallback hint
 - Revoking a **refresh token** cascades: all access tokens for the same client+user pair are also revoked
 - Revoking an **access token** does not revoke the associated refresh token
 - Client authentication (`client_id` + `client_secret`) is required
+- Client authentication can be provided either in the JSON body (`client_secret_post`) or via `Authorization: Basic <base64(client_id:client_secret)>` (`client_secret_basic`)
 
 MCP clients discover this endpoint via `revocation_endpoint` in the authorization server metadata.
 
 ### Token Exchange
 
-| Method | Path | Auth | Description |
-|--------|------|------|-------------|
-| POST | `/oauth/token` | None | Exchange code or refresh token for tokens |
+| Method | Path           | Auth                                          | Description                               |
+| ------ | -------------- | --------------------------------------------- | ----------------------------------------- |
+| POST   | `/oauth/token` | `client_secret_post` or `client_secret_basic` | Exchange code or refresh token for tokens |
 
 **Authorization Code Grant:**
+
 ```http
 POST /oauth/token
 Content-Type: application/json
@@ -226,6 +243,7 @@ Content-Type: application/json
 ```
 
 **Refresh Token Grant:**
+
 ```http
 POST /oauth/token
 Content-Type: application/json
@@ -238,7 +256,23 @@ Content-Type: application/json
 }
 ```
 
+**Alternative client authentication (`client_secret_basic`):**
+
+```http
+POST /oauth/token
+Authorization: Basic base64(client_id:client_secret)
+Content-Type: application/json
+
+{
+  "grant_type": "authorization_code",
+  "code": "auth_<48 hex chars>",
+  "code_verifier": "<43-128 chars>",
+  "redirect_uri": "http://127.0.0.1:3000/callback"
+}
+```
+
 **Token Response (both grants):**
+
 ```json
 {
   "access_token": "oat_<72 hex chars>",
@@ -250,11 +284,11 @@ Content-Type: application/json
 
 ### MCP
 
-| Method | Path | Auth | Description |
-|--------|------|------|-------------|
-| POST | `/mcp` | Bearer | Stateless MCP request |
-| GET | `/mcp` | - | Returns 405 (SSE not supported) |
-| DELETE | `/mcp` | - | Returns 405 (sessions not supported) |
+| Method | Path   | Auth   | Description                          |
+| ------ | ------ | ------ | ------------------------------------ |
+| POST   | `/mcp` | Bearer | Stateless MCP request                |
+| GET    | `/mcp` | -      | Returns 405 (SSE not supported)      |
+| DELETE | `/mcp` | -      | Returns 405 (sessions not supported) |
 
 ```http
 POST /mcp
@@ -271,6 +305,7 @@ Accept: application/json, text/event-stream
 ```
 
 On `401`, the response includes a `WWW-Authenticate` header pointing to the resource metadata with the `mcp` scope:
+
 ```text
 WWW-Authenticate: Bearer resource_metadata="https://revisium.example.com/.well-known/oauth-protected-resource", scope="mcp"
 ```
@@ -279,12 +314,12 @@ The `scope="mcp"` parameter tells MCP clients to include this scope in the autho
 
 ## Token Types
 
-| Type | Prefix | Length | TTL | Storage |
-|------|--------|--------|-----|---------|
-| Client Secret | `ocs_` | 72 hex chars | Permanent | SHA-256 hash |
-| Authorization Code | `auth_` | 48 hex chars | 10 minutes | Plain text (single-use) |
-| Access Token | `oat_` | 72 hex chars | 1 hour (default) / 30 days (`scope=mcp`) | SHA-256 hash |
-| Refresh Token | `ort_` | 72 hex chars | 30 days (default) / 90 days (`scope=mcp`) | SHA-256 hash |
+| Type               | Prefix  | Length       | TTL                                       | Storage                 |
+| ------------------ | ------- | ------------ | ----------------------------------------- | ----------------------- |
+| Client Secret      | `ocs_`  | 72 hex chars | Permanent                                 | SHA-256 hash            |
+| Authorization Code | `auth_` | 48 hex chars | 10 minutes                                | Plain text (single-use) |
+| Access Token       | `oat_`  | 72 hex chars | 1 hour (default) / 30 days (`scope=mcp`)  | SHA-256 hash            |
+| Refresh Token      | `ort_`  | 72 hex chars | 30 days (default) / 90 days (`scope=mcp`) | SHA-256 hash            |
 
 All tokens are generated with `crypto.randomBytes()`. Client secrets and tokens are stored as SHA-256 hashes; only the authorization code is stored in plain text (it's single-use and short-lived).
 
@@ -294,10 +329,10 @@ The MCP access token TTL can be overridden via `MCP_ACCESS_TOKEN_EXPIRY_DAYS` en
 
 Revisium supports the `mcp` OAuth scope. When an MCP client (Claude Code, Cursor, etc.) connects, the server includes `scope="mcp"` in the `WWW-Authenticate` header on `401` responses. MCP clients pass this scope through the authorization flow, which results in longer-lived tokens:
 
-| Scope | Access Token TTL | Refresh Token TTL |
-|-------|-----------------|-------------------|
-| (none) | 1 hour | 30 days |
-| `mcp` | 30 days (configurable via `MCP_ACCESS_TOKEN_EXPIRY_DAYS`) | 90 days |
+| Scope  | Access Token TTL                                          | Refresh Token TTL |
+| ------ | --------------------------------------------------------- | ----------------- |
+| (none) | 1 hour                                                    | 30 days           |
+| `mcp`  | 30 days (configurable via `MCP_ACCESS_TOKEN_EXPIRY_DAYS`) | 90 days           |
 
 The scope is stored on the authorization code, access token, and refresh token. On token refresh, the scope is inherited from the refresh token being rotated.
 
@@ -597,25 +632,25 @@ In production, `PUBLIC_URL` matches the external domain (e.g. `https://revisium.
 
 ## Environment Variables
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `PUBLIC_URL` | `http://localhost:8080` | External URL used in OAuth discovery metadata and redirects |
-| `JWT_SECRET` | - | Secret for signing/verifying JWT tokens |
-| `REVISIUM_NO_AUTH` | `false` | Skip auth, treat all requests as admin |
-| `MCP_ACCESS_TOKEN_EXPIRY_DAYS` | `30` | Access token TTL (in days) for `scope=mcp` |
+| Variable                       | Default                 | Description                                                 |
+| ------------------------------ | ----------------------- | ----------------------------------------------------------- |
+| `PUBLIC_URL`                   | `http://localhost:8080` | External URL used in OAuth discovery metadata and redirects |
+| `JWT_SECRET`                   | -                       | Secret for signing/verifying JWT tokens                     |
+| `REVISIUM_NO_AUTH`             | `false`                 | Skip auth, treat all requests as admin                      |
+| `MCP_ACCESS_TOKEN_EXPIRY_DAYS` | `30`                    | Access token TTL (in days) for `scope=mcp`                  |
 
 ## Source Files
 
-| File | Description |
-|------|-------------|
-| [`src/features/oauth/oauth.module.ts`](../src/features/oauth/oauth.module.ts) | OAuth NestJS module |
-| [`src/features/oauth/oauth.controller.ts`](../src/features/oauth/oauth.controller.ts) | Discovery, registration, authorization, token endpoints |
-| [`src/features/oauth/oauth-client.service.ts`](../src/features/oauth/oauth-client.service.ts) | Client registration and secret validation |
-| [`src/features/oauth/oauth-authorization.service.ts`](../src/features/oauth/oauth-authorization.service.ts) | Authorization code creation and PKCE exchange |
-| [`src/features/oauth/oauth-token.service.ts`](../src/features/oauth/oauth-token.service.ts) | Access/refresh token lifecycle |
-| [`src/api/mcp-api/mcp.controller.ts`](../src/api/mcp-api/mcp.controller.ts) | Stateless MCP HTTP transport |
-| [`src/api/mcp-api/mcp-auth.service.ts`](../src/api/mcp-api/mcp-auth.service.ts) | Bearer token detection (JWT vs OAuth) |
-| [`prisma/schema.prisma`](../prisma/schema.prisma) | Database models (OAuthClient, OAuthAuthorizationCode, OAuthAccessToken, OAuthRefreshToken) |
+| File                                                                                                        | Description                                                                                |
+| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| [`src/features/oauth/oauth.module.ts`](../src/features/oauth/oauth.module.ts)                               | OAuth NestJS module                                                                        |
+| [`src/features/oauth/oauth.controller.ts`](../src/features/oauth/oauth.controller.ts)                       | Discovery, registration, authorization, token endpoints                                    |
+| [`src/features/oauth/oauth-client.service.ts`](../src/features/oauth/oauth-client.service.ts)               | Client registration and secret validation                                                  |
+| [`src/features/oauth/oauth-authorization.service.ts`](../src/features/oauth/oauth-authorization.service.ts) | Authorization code creation and PKCE exchange                                              |
+| [`src/features/oauth/oauth-token.service.ts`](../src/features/oauth/oauth-token.service.ts)                 | Access/refresh token lifecycle                                                             |
+| [`src/api/mcp-api/mcp.controller.ts`](../src/api/mcp-api/mcp.controller.ts)                                 | Stateless MCP HTTP transport                                                               |
+| [`src/api/mcp-api/mcp-auth.service.ts`](../src/api/mcp-api/mcp-auth.service.ts)                             | Bearer token detection (JWT vs OAuth)                                                      |
+| [`prisma/schema.prisma`](../prisma/schema.prisma)                                                           | Database models (OAuthClient, OAuthAuthorizationCode, OAuthAccessToken, OAuthRefreshToken) |
 
 ## Token Cleanup
 

--- a/docs/oauth.md
+++ b/docs/oauth.md
@@ -39,7 +39,7 @@ Revisium implements an OAuth 2.1 Authorization Code flow with PKCE to authentica
        |                       |       "Authorize"      |
        |                       |                        |
        |                       |  POST /oauth/authorize |
-       |                       |  Bearer JWT            |
+       |                       |  Session JWT           |
        |                       |<-----------------------|
        |                       |  { redirect_uri }      |
        |                       |----------------------->|
@@ -145,7 +145,7 @@ All `redirect_uris` must use `http:` or `https:` scheme. Other schemes (`javascr
 | Method | Path               | Auth       | Description                              |
 | ------ | ------------------ | ---------- | ---------------------------------------- |
 | GET    | `/oauth/authorize` | None       | Validate params and redirect to Admin UI |
-| POST   | `/oauth/authorize` | Bearer JWT | Create auth code (called by Admin UI)    |
+| POST   | `/oauth/authorize` | Session JWT | Create auth code (called by Admin UI)   |
 
 **GET /oauth/authorize** query parameters:
 
@@ -169,7 +169,6 @@ Validates all parameters, then redirects `302` to Admin UI:
 
 ```http
 POST /oauth/authorize
-Authorization: Bearer <user-jwt>
 Content-Type: application/json
 
 {
@@ -180,6 +179,10 @@ Content-Type: application/json
   "scope": "mcp"
 }
 ```
+
+The user session can be authenticated either by `Authorization: Bearer <user-jwt>`
+or by the browser's `rev_at` cookie. For the admin UI under JWT 2.0, the
+cookie-backed session is the normal path.
 
 The `scope` field is optional. When present, it is stored with the authorization code and propagated to the access token on exchange.
 
@@ -579,7 +582,7 @@ Browser opens /authorize?client_id=...&client_name=...
   |
   +-- User clicks Authorize -> approve()
   |   +-- POST /oauth/authorize
-  |       Authorization: Bearer <JWT from AuthService.token>
+  |       Cookie: rev_at=<httpOnly JWT> (or Authorization: Bearer <user-jwt>)
   |       Body: { client_id, redirect_uri, code_challenge, state }
   |
   +-- Response: { redirect_uri }

--- a/src/features/oauth/__tests__/oauth.controller.spec.ts
+++ b/src/features/oauth/__tests__/oauth.controller.spec.ts
@@ -92,7 +92,14 @@ describe('OAuth Controller', () => {
         response_types_supported: ['code'],
         grant_types_supported: ['authorization_code', 'refresh_token'],
         code_challenge_methods_supported: ['S256'],
-        revocation_endpoint_auth_methods_supported: ['client_secret_post'],
+        token_endpoint_auth_methods_supported: [
+          'client_secret_post',
+          'client_secret_basic',
+        ],
+        revocation_endpoint_auth_methods_supported: [
+          'client_secret_post',
+          'client_secret_basic',
+        ],
         scopes_supported: ['mcp'],
       });
     });
@@ -128,6 +135,7 @@ describe('OAuth Controller', () => {
         client_id: expect.any(String),
         client_secret: expect.stringMatching(/^ocs_/),
         client_name: 'test-app',
+        token_endpoint_auth_method: 'client_secret_post',
         redirect_uris: ['https://example.com/callback'],
       });
     });
@@ -379,6 +387,57 @@ describe('OAuth Controller', () => {
       });
     });
 
+    it('exchanges authorization code with client_secret_basic', async () => {
+      const codeVerifier = 'shared_test_code_verifier_that_is_long_enough';
+      const codeChallenge = createHash('sha256')
+        .update(codeVerifier)
+        .digest('base64url');
+
+      const regRes = await request(app.getHttpServer())
+        .post('/oauth/register')
+        .send({
+          client_name: 'basic-auth-test',
+          redirect_uris: ['https://example.com/callback'],
+        })
+        .expect(201);
+
+      const { client_id, client_secret } = regRes.body;
+
+      const authRes = await request(app.getHttpServer())
+        .post('/oauth/authorize')
+        .set('Authorization', `Bearer ${userToken}`)
+        .send({
+          client_id,
+          redirect_uri: 'https://example.com/callback',
+          code_challenge: codeChallenge,
+          state: 'test_state',
+        })
+        .expect(201);
+
+      const redirectUrl = new URL(authRes.body.redirect_uri);
+      const code = redirectUrl.searchParams.get('code');
+      const basicAuth = Buffer.from(`${client_id}:${client_secret}`).toString(
+        'base64',
+      );
+
+      const tokenRes = await request(app.getHttpServer())
+        .post('/oauth/token')
+        .set('Authorization', `Basic ${basicAuth}`)
+        .send({
+          grant_type: 'authorization_code',
+          code,
+          code_verifier: codeVerifier,
+          redirect_uri: 'https://example.com/callback',
+        })
+        .expect(201);
+
+      expect(tokenRes.body).toMatchObject({
+        access_token: expect.stringMatching(/^oat_/),
+        refresh_token: expect.stringMatching(/^ort_/),
+        token_type: 'Bearer',
+      });
+    });
+
     it('preserves mcp scope on refresh', async () => {
       const { client_id, client_secret, refresh_token } = await obtainTokens({
         scope: 'mcp',
@@ -469,6 +528,21 @@ describe('OAuth Controller', () => {
           token: access_token,
           client_id,
           client_secret,
+        })
+        .expect(200);
+    });
+
+    it('accepts client_secret_basic for revocation', async () => {
+      const { client_id, client_secret, access_token } = await obtainTokens();
+      const basicAuth = Buffer.from(`${client_id}:${client_secret}`).toString(
+        'base64',
+      );
+
+      await request(app.getHttpServer())
+        .post('/oauth/revoke')
+        .set('Authorization', `Basic ${basicAuth}`)
+        .send({
+          token: access_token,
         })
         .expect(200);
     });

--- a/src/features/oauth/__tests__/oauth.controller.spec.ts
+++ b/src/features/oauth/__tests__/oauth.controller.spec.ts
@@ -33,6 +33,7 @@ describe('OAuth Controller', () => {
   });
 
   afterAll(async () => {
+    await prisma.$disconnect();
     await app.close();
   });
 
@@ -65,6 +66,9 @@ describe('OAuth Controller', () => {
 
     const redirectUrl = new URL(authRes.body.redirect_uri);
     const code = redirectUrl.searchParams.get('code');
+    if (!code) {
+      throw new Error('missing authorization code from authorize response');
+    }
 
     const tokenRes = await request(app.getHttpServer())
       .post('/oauth/token')
@@ -115,6 +119,9 @@ describe('OAuth Controller', () => {
 
     const redirectUrl = new URL(authRes.body.redirect_uri);
     const code = redirectUrl.searchParams.get('code');
+    if (!code) {
+      throw new Error('missing authorization code from authorize response');
+    }
 
     return {
       client_id,
@@ -521,6 +528,30 @@ describe('OAuth Controller', () => {
       await request(app.getHttpServer())
         .post('/oauth/token')
         .set('Authorization', 'Basic !!!')
+        .send({
+          grant_type: 'authorization_code',
+          code,
+          client_id,
+          client_secret,
+          code_verifier,
+          redirect_uri,
+        })
+        .expect(400)
+        .expect(({ body }) => {
+          expect(body.message).toBe('Invalid client credentials');
+          expect(body).not.toHaveProperty('access_token');
+        });
+    });
+
+    it('rejects client_secret_basic with trailing invalid base64 characters', async () => {
+      const { client_id, client_secret, code, code_verifier, redirect_uri } =
+        await obtainAuthorizationCode();
+      const basicAuth =
+        Buffer.from(`${client_id}:${client_secret}`).toString('base64') + '!!!';
+
+      await request(app.getHttpServer())
+        .post('/oauth/token')
+        .set('Authorization', `Basic ${basicAuth}`)
         .send({
           grant_type: 'authorization_code',
           code,

--- a/src/features/oauth/__tests__/oauth.controller.spec.ts
+++ b/src/features/oauth/__tests__/oauth.controller.spec.ts
@@ -7,6 +7,7 @@ import {
 } from 'src/__tests__/utils/prepareProject';
 import { createFreshTestApp } from 'src/__tests__/e2e/shared';
 import { AuthService } from 'src/features/auth/auth.service';
+import { ACCESS_COOKIE_NAME } from 'src/features/auth/services/cookie.service';
 
 describe('OAuth Controller', () => {
   let app: INestApplication;
@@ -356,11 +357,34 @@ describe('OAuth Controller', () => {
       expect(res.body.redirect_uri).toContain('state=test_state');
     });
 
-    it('rejects without Bearer token', async () => {
+    it('accepts the rev_at cookie without an Authorization header', async () => {
       const regRes = await request(app.getHttpServer())
         .post('/oauth/register')
         .send({
-          client_name: 'no-bearer-test',
+          client_name: 'cookie-authorize-test',
+          redirect_uris: ['https://example.com/callback'],
+        });
+
+      const res = await request(app.getHttpServer())
+        .post('/oauth/authorize')
+        .set('Cookie', `${ACCESS_COOKIE_NAME}=${userToken}`)
+        .send({
+          client_id: regRes.body.client_id,
+          redirect_uri: 'https://example.com/callback',
+          code_challenge: 'test_challenge',
+          state: 'test_state',
+        })
+        .expect(201);
+
+      expect(res.body.redirect_uri).toContain('code=');
+      expect(res.body.redirect_uri).toContain('state=test_state');
+    });
+
+    it('rejects without an authenticated session', async () => {
+      const regRes = await request(app.getHttpServer())
+        .post('/oauth/register')
+        .send({
+          client_name: 'no-session-test',
           redirect_uris: ['https://example.com/callback'],
         });
 

--- a/src/features/oauth/__tests__/oauth.controller.spec.ts
+++ b/src/features/oauth/__tests__/oauth.controller.spec.ts
@@ -1,23 +1,30 @@
 import { INestApplication } from '@nestjs/common';
 import request from 'supertest';
 import { createHash } from 'node:crypto';
+import { ApiKeyType } from 'src/__generated__/client';
 import {
   prepareData,
   PrepareDataReturnType,
 } from 'src/__tests__/utils/prepareProject';
 import { createFreshTestApp } from 'src/__tests__/e2e/shared';
+import { ApiKeyService } from 'src/features/api-key/api-key.service';
 import { AuthService } from 'src/features/auth/auth.service';
 import { ACCESS_COOKIE_NAME } from 'src/features/auth/services/cookie.service';
+import { PrismaService } from 'src/infrastructure/database/prisma.service';
 
 describe('OAuth Controller', () => {
   let app: INestApplication;
   let authService: AuthService;
+  let apiKeyService: ApiKeyService;
+  let prisma: PrismaService;
   let fixture: PrepareDataReturnType;
   let userToken: string;
 
   beforeAll(async () => {
     app = await createFreshTestApp();
     authService = app.get(AuthService);
+    apiKeyService = app.get(ApiKeyService);
+    prisma = app.get(PrismaService);
     fixture = await prepareData(app);
     userToken = authService.login({
       username: fixture.owner.user.username,
@@ -397,6 +404,37 @@ describe('OAuth Controller', () => {
           state: 'state',
         })
         .expect(401);
+    });
+
+    it('rejects API-key authentication for authorization-code minting', async () => {
+      const regRes = await request(app.getHttpServer())
+        .post('/oauth/register')
+        .send({
+          client_name: 'api-key-authorize-test',
+          redirect_uris: ['https://example.com/callback'],
+        });
+
+      const { key, hash, prefix } = apiKeyService.generateKey();
+      await prisma.apiKey.create({
+        data: {
+          prefix,
+          keyHash: hash,
+          type: ApiKeyType.PERSONAL,
+          name: 'authorize-test-key',
+          userId: fixture.owner.user.id,
+        },
+      });
+
+      await request(app.getHttpServer())
+        .post('/oauth/authorize')
+        .set('x-api-key', key)
+        .send({
+          client_id: regRes.body.client_id,
+          redirect_uri: 'https://example.com/callback',
+          code_challenge: 'challenge',
+          state: 'state',
+        })
+        .expect(403);
     });
 
     it('rejects missing fields', async () => {

--- a/src/features/oauth/__tests__/oauth.controller.spec.ts
+++ b/src/features/oauth/__tests__/oauth.controller.spec.ts
@@ -77,6 +77,46 @@ describe('OAuth Controller', () => {
     };
   };
 
+  const obtainAuthorizationCode = async (options: { scope?: string } = {}) => {
+    const codeVerifier = 'shared_test_code_verifier_that_is_long_enough';
+    const codeChallenge = createHash('sha256')
+      .update(codeVerifier)
+      .digest('base64url');
+
+    const regRes = await request(app.getHttpServer())
+      .post('/oauth/register')
+      .send({
+        client_name: 'obtain-auth-code-test',
+        redirect_uris: ['https://example.com/callback'],
+      })
+      .expect(201);
+
+    const { client_id, client_secret } = regRes.body;
+
+    const authRes = await request(app.getHttpServer())
+      .post('/oauth/authorize')
+      .set('Authorization', `Bearer ${userToken}`)
+      .send({
+        client_id,
+        redirect_uri: 'https://example.com/callback',
+        code_challenge: codeChallenge,
+        state: 'test_state',
+        ...(options.scope ? { scope: options.scope } : {}),
+      })
+      .expect(201);
+
+    const redirectUrl = new URL(authRes.body.redirect_uri);
+    const code = redirectUrl.searchParams.get('code');
+
+    return {
+      client_id,
+      client_secret,
+      code,
+      code_verifier: codeVerifier,
+      redirect_uri: 'https://example.com/callback',
+    };
+  };
+
   describe('GET /.well-known/oauth-authorization-server', () => {
     it('returns authorization server metadata', async () => {
       const res = await request(app.getHttpServer())
@@ -388,34 +428,8 @@ describe('OAuth Controller', () => {
     });
 
     it('exchanges authorization code with client_secret_basic', async () => {
-      const codeVerifier = 'shared_test_code_verifier_that_is_long_enough';
-      const codeChallenge = createHash('sha256')
-        .update(codeVerifier)
-        .digest('base64url');
-
-      const regRes = await request(app.getHttpServer())
-        .post('/oauth/register')
-        .send({
-          client_name: 'basic-auth-test',
-          redirect_uris: ['https://example.com/callback'],
-        })
-        .expect(201);
-
-      const { client_id, client_secret } = regRes.body;
-
-      const authRes = await request(app.getHttpServer())
-        .post('/oauth/authorize')
-        .set('Authorization', `Bearer ${userToken}`)
-        .send({
-          client_id,
-          redirect_uri: 'https://example.com/callback',
-          code_challenge: codeChallenge,
-          state: 'test_state',
-        })
-        .expect(201);
-
-      const redirectUrl = new URL(authRes.body.redirect_uri);
-      const code = redirectUrl.searchParams.get('code');
+      const { client_id, client_secret, code, code_verifier, redirect_uri } =
+        await obtainAuthorizationCode();
       const basicAuth = Buffer.from(`${client_id}:${client_secret}`).toString(
         'base64',
       );
@@ -426,8 +440,8 @@ describe('OAuth Controller', () => {
         .send({
           grant_type: 'authorization_code',
           code,
-          code_verifier: codeVerifier,
-          redirect_uri: 'https://example.com/callback',
+          code_verifier,
+          redirect_uri,
         })
         .expect(201);
 
@@ -436,6 +450,74 @@ describe('OAuth Controller', () => {
         refresh_token: expect.stringMatching(/^ort_/),
         token_type: 'Bearer',
       });
+    });
+
+    it('rejects malformed base64 client_secret_basic without falling back to body credentials', async () => {
+      const { client_id, client_secret, code, code_verifier, redirect_uri } =
+        await obtainAuthorizationCode();
+
+      await request(app.getHttpServer())
+        .post('/oauth/token')
+        .set('Authorization', 'Basic !!!')
+        .send({
+          grant_type: 'authorization_code',
+          code,
+          client_id,
+          client_secret,
+          code_verifier,
+          redirect_uri,
+        })
+        .expect(400)
+        .expect(({ body }) => {
+          expect(body.message).toBe('Invalid client credentials');
+          expect(body).not.toHaveProperty('access_token');
+        });
+    });
+
+    it('rejects client_secret_basic without a colon', async () => {
+      const { client_id, client_secret, code, code_verifier, redirect_uri } =
+        await obtainAuthorizationCode();
+      const basicAuth = Buffer.from(client_id).toString('base64');
+
+      await request(app.getHttpServer())
+        .post('/oauth/token')
+        .set('Authorization', `Basic ${basicAuth}`)
+        .send({
+          grant_type: 'authorization_code',
+          code,
+          client_id,
+          client_secret,
+          code_verifier,
+          redirect_uri,
+        })
+        .expect(400)
+        .expect(({ body }) => {
+          expect(body.message).toBe('Invalid client credentials');
+          expect(body).not.toHaveProperty('access_token');
+        });
+    });
+
+    it('rejects client_secret_basic with an empty client id', async () => {
+      const { client_id, client_secret, code, code_verifier, redirect_uri } =
+        await obtainAuthorizationCode();
+      const basicAuth = Buffer.from(`:${client_secret}`).toString('base64');
+
+      await request(app.getHttpServer())
+        .post('/oauth/token')
+        .set('Authorization', `Basic ${basicAuth}`)
+        .send({
+          grant_type: 'authorization_code',
+          code,
+          client_id,
+          client_secret,
+          code_verifier,
+          redirect_uri,
+        })
+        .expect(400)
+        .expect(({ body }) => {
+          expect(body.message).toBe('Invalid client credentials');
+          expect(body).not.toHaveProperty('access_token');
+        });
     });
 
     it('preserves mcp scope on refresh', async () => {

--- a/src/features/oauth/oauth.controller.ts
+++ b/src/features/oauth/oauth.controller.ts
@@ -13,6 +13,7 @@ import {
 import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
 import { ApiExcludeController } from '@nestjs/swagger';
+import { Buffer } from 'node:buffer';
 import { Request, Response } from 'express';
 import { JwtSecretService } from 'src/features/auth/jwt-secret.service';
 import { OAuthClientService } from './oauth-client.service';
@@ -46,9 +47,15 @@ export class OAuthController {
       response_types_supported: ['code'],
       grant_types_supported: ['authorization_code', 'refresh_token'],
       code_challenge_methods_supported: ['S256'],
-      token_endpoint_auth_methods_supported: ['client_secret_post'],
+      token_endpoint_auth_methods_supported: [
+        'client_secret_post',
+        'client_secret_basic',
+      ],
       revocation_endpoint: `${this.publicUrl}/oauth/revoke`,
-      revocation_endpoint_auth_methods_supported: ['client_secret_post'],
+      revocation_endpoint_auth_methods_supported: [
+        'client_secret_post',
+        'client_secret_basic',
+      ],
       scopes_supported: ['mcp'],
     };
   }
@@ -89,6 +96,7 @@ export class OAuthController {
       client_id: result.clientId,
       client_secret: result.clientSecret,
       client_name: result.clientName,
+      token_endpoint_auth_method: 'client_secret_post',
       redirect_uris: body.redirect_uris,
       grant_types: body.grant_types ?? ['authorization_code', 'refresh_token'],
     };
@@ -207,6 +215,7 @@ export class OAuthController {
   @Post('oauth/revoke')
   @HttpCode(200)
   async revokeToken(
+    @Req() req: Request,
     @Body()
     body: {
       token: string;
@@ -215,31 +224,34 @@ export class OAuthController {
       client_secret?: string;
     },
   ) {
-    const { token, token_type_hint, client_id, client_secret } = body;
+    const { token, token_type_hint } = body;
 
     if (!token) {
       throw new BadRequestException('token is required');
     }
 
-    if (!client_id || !client_secret) {
+    const { clientId, clientSecret } = this.extractClientCredentials(req, body);
+
+    if (!clientId || !clientSecret) {
       throw new BadRequestException('Client authentication required');
     }
 
     const validSecret = await this.clientService.validateClientSecret(
-      client_id,
-      client_secret,
+      clientId,
+      clientSecret,
     );
     if (!validSecret) {
       throw new BadRequestException('Invalid client credentials');
     }
 
-    await this.tokenService.revokeToken(token, token_type_hint, client_id);
+    await this.tokenService.revokeToken(token, token_type_hint, clientId);
 
     return {};
   }
 
   @Post('oauth/token')
   async exchangeToken(
+    @Req() req: Request,
     @Body()
     body: {
       grant_type: string;
@@ -254,30 +266,33 @@ export class OAuthController {
     const grantType = body.grant_type;
 
     if (grantType === 'authorization_code') {
-      return this.handleAuthorizationCodeGrant(body);
+      return this.handleAuthorizationCodeGrant(req, body);
     }
 
     if (grantType === 'refresh_token') {
-      return this.handleRefreshTokenGrant(body);
+      return this.handleRefreshTokenGrant(req, body);
     }
 
     throw new BadRequestException(`Unsupported grant_type: ${grantType}`);
   }
 
-  private async handleAuthorizationCodeGrant(body: {
-    code?: string;
-    client_id?: string;
-    client_secret?: string;
-    code_verifier?: string;
-    redirect_uri?: string;
-  }) {
-    const { code, client_id, client_secret, code_verifier, redirect_uri } =
-      body;
+  private async handleAuthorizationCodeGrant(
+    req: Request,
+    body: {
+      code?: string;
+      client_id?: string;
+      client_secret?: string;
+      code_verifier?: string;
+      redirect_uri?: string;
+    },
+  ) {
+    const { code, code_verifier, redirect_uri } = body;
+    const { clientId, clientSecret } = this.extractClientCredentials(req, body);
 
     if (
       !code ||
-      !client_id ||
-      !client_secret ||
+      !clientId ||
+      !clientSecret ||
       !code_verifier ||
       !redirect_uri
     ) {
@@ -287,8 +302,8 @@ export class OAuthController {
     }
 
     const validSecret = await this.clientService.validateClientSecret(
-      client_id,
-      client_secret,
+      clientId,
+      clientSecret,
     );
     if (!validSecret) {
       throw new BadRequestException('Invalid client credentials');
@@ -296,13 +311,13 @@ export class OAuthController {
 
     const { userId, scope } = await this.authorizationService.exchangeCode({
       code,
-      clientId: client_id,
+      clientId,
       codeVerifier: code_verifier,
       redirectUri: redirect_uri,
     });
 
     const tokens = await this.tokenService.createTokens(
-      client_id,
+      clientId,
       userId,
       scope ?? undefined,
     );
@@ -315,22 +330,26 @@ export class OAuthController {
     };
   }
 
-  private async handleRefreshTokenGrant(body: {
-    client_id?: string;
-    client_secret?: string;
-    refresh_token?: string;
-  }) {
-    const { client_id, client_secret, refresh_token } = body;
+  private async handleRefreshTokenGrant(
+    req: Request,
+    body: {
+      client_id?: string;
+      client_secret?: string;
+      refresh_token?: string;
+    },
+  ) {
+    const { refresh_token } = body;
+    const { clientId, clientSecret } = this.extractClientCredentials(req, body);
 
-    if (!client_id || !client_secret || !refresh_token) {
+    if (!clientId || !clientSecret || !refresh_token) {
       throw new BadRequestException(
         'Missing required parameters for refresh_token grant',
       );
     }
 
     const validSecret = await this.clientService.validateClientSecret(
-      client_id,
-      client_secret,
+      clientId,
+      clientSecret,
     );
     if (!validSecret) {
       throw new BadRequestException('Invalid client credentials');
@@ -338,7 +357,7 @@ export class OAuthController {
 
     const tokens = await this.tokenService.refreshTokens(
       refresh_token,
-      client_id,
+      clientId,
     );
 
     return {
@@ -370,5 +389,35 @@ export class OAuthController {
     } catch {
       throw new UnauthorizedException('Invalid or expired token');
     }
+  }
+
+  private extractClientCredentials(
+    req: Request,
+    body: { client_id?: string; client_secret?: string },
+  ): { clientId?: string; clientSecret?: string } {
+    const authHeader = req.headers['authorization'];
+
+    if (authHeader?.startsWith('Basic ')) {
+      const encoded = authHeader.slice(6).trim();
+
+      try {
+        const decoded = Buffer.from(encoded, 'base64').toString('utf8');
+        const separatorIndex = decoded.indexOf(':');
+
+        if (separatorIndex > 0) {
+          return {
+            clientId: decoded.slice(0, separatorIndex),
+            clientSecret: decoded.slice(separatorIndex + 1),
+          };
+        }
+      } catch {
+        throw new BadRequestException('Invalid client credentials');
+      }
+    }
+
+    return {
+      clientId: body.client_id,
+      clientSecret: body.client_secret,
+    };
   }
 }

--- a/src/features/oauth/oauth.controller.ts
+++ b/src/features/oauth/oauth.controller.ts
@@ -8,14 +8,14 @@ import {
   Body,
   Query,
   BadRequestException,
-  UnauthorizedException,
+  UseGuards,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { JwtService } from '@nestjs/jwt';
 import { ApiExcludeController } from '@nestjs/swagger';
 import { Buffer } from 'node:buffer';
 import { Request, Response } from 'express';
-import { JwtSecretService } from 'src/features/auth/jwt-secret.service';
+import { HttpJwtAuthGuard } from 'src/features/auth/guards/jwt/http-jwt-auth-guard.service';
+import { IAuthUser } from 'src/features/auth/types';
 import { OAuthClientService } from './oauth-client.service';
 import { OAuthAuthorizationService } from './oauth-authorization.service';
 import { OAuthTokenService } from './oauth-token.service';
@@ -27,8 +27,6 @@ export class OAuthController {
 
   constructor(
     private readonly configService: ConfigService,
-    private readonly jwtService: JwtService,
-    private readonly jwtSecret: JwtSecretService,
     private readonly clientService: OAuthClientService,
     private readonly authorizationService: OAuthAuthorizationService,
     private readonly tokenService: OAuthTokenService,
@@ -166,9 +164,10 @@ export class OAuthController {
     res.redirect(302, `${this.publicUrl}/authorize?${params.toString()}`);
   }
 
+  @UseGuards(HttpJwtAuthGuard)
   @Post('oauth/authorize')
   async handleAuthorize(
-    @Req() req: Request,
+    @Req() req: Request & { user: IAuthUser },
     @Body()
     body: {
       client_id: string;
@@ -193,11 +192,9 @@ export class OAuthController {
       throw new BadRequestException('Invalid redirect_uri');
     }
 
-    const userId = this.extractUserIdFromBearer(req);
-
     const code = await this.authorizationService.createAuthorizationCode({
       clientId: client_id,
-      userId,
+      userId: req.user.userId,
       redirectUri: redirect_uri,
       codeChallenge: code_challenge,
       scope,
@@ -366,29 +363,6 @@ export class OAuthController {
       expires_in: tokens.expiresIn,
       refresh_token: tokens.refreshToken,
     };
-  }
-
-  private extractUserIdFromBearer(req: Request): string {
-    const authHeader = req.headers['authorization'];
-    if (!authHeader?.startsWith('Bearer ')) {
-      throw new UnauthorizedException('Missing Authorization header');
-    }
-
-    const token = authHeader.slice(7);
-
-    try {
-      const decoded: { sub?: string } = this.jwtService.verify(token, {
-        secret: this.jwtSecret.secret,
-      });
-
-      if (!decoded?.sub) {
-        throw new UnauthorizedException('Invalid token');
-      }
-
-      return decoded.sub;
-    } catch {
-      throw new UnauthorizedException('Invalid or expired token');
-    }
   }
 
   private extractClientCredentials(

--- a/src/features/oauth/oauth.controller.ts
+++ b/src/features/oauth/oauth.controller.ts
@@ -26,6 +26,8 @@ import { OAuthTokenService } from './oauth-token.service';
 @Controller()
 export class OAuthController {
   private readonly publicUrl: string;
+  private static readonly BASIC_AUTH_BASE64_REGEX =
+    /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
 
   constructor(
     private readonly configService: ConfigService,
@@ -384,6 +386,14 @@ export class OAuthController {
       const encoded = authHeader.slice(6).trim();
 
       try {
+        if (
+          encoded.length === 0 ||
+          encoded.length % 4 !== 0 ||
+          !OAuthController.BASIC_AUTH_BASE64_REGEX.test(encoded)
+        ) {
+          throw new BadRequestException('Invalid client credentials');
+        }
+
         const decoded = Buffer.from(encoded, 'base64').toString('utf8');
         const separatorIndex = decoded.indexOf(':');
 

--- a/src/features/oauth/oauth.controller.ts
+++ b/src/features/oauth/oauth.controller.ts
@@ -404,12 +404,21 @@ export class OAuthController {
         const decoded = Buffer.from(encoded, 'base64').toString('utf8');
         const separatorIndex = decoded.indexOf(':');
 
-        if (separatorIndex > 0) {
-          return {
-            clientId: decoded.slice(0, separatorIndex),
-            clientSecret: decoded.slice(separatorIndex + 1),
-          };
+        if (separatorIndex <= 0) {
+          throw new BadRequestException('Invalid client credentials');
         }
+
+        const clientId = decoded.slice(0, separatorIndex);
+        const clientSecret = decoded.slice(separatorIndex + 1);
+
+        if (!clientId || !clientSecret) {
+          throw new BadRequestException('Invalid client credentials');
+        }
+
+        return {
+          clientId,
+          clientSecret,
+        };
       } catch {
         throw new BadRequestException('Invalid client credentials');
       }

--- a/src/features/oauth/oauth.controller.ts
+++ b/src/features/oauth/oauth.controller.ts
@@ -1,4 +1,5 @@
 import {
+  ForbiddenException,
   Controller,
   Get,
   HttpCode,
@@ -15,6 +16,7 @@ import { ApiExcludeController } from '@nestjs/swagger';
 import { Buffer } from 'node:buffer';
 import { Request, Response } from 'express';
 import { HttpJwtAuthGuard } from 'src/features/auth/guards/jwt/http-jwt-auth-guard.service';
+import { NoAuthService } from 'src/features/auth/no-auth.service';
 import { IAuthUser } from 'src/features/auth/types';
 import { OAuthClientService } from './oauth-client.service';
 import { OAuthAuthorizationService } from './oauth-authorization.service';
@@ -30,6 +32,7 @@ export class OAuthController {
     private readonly clientService: OAuthClientService,
     private readonly authorizationService: OAuthAuthorizationService,
     private readonly tokenService: OAuthTokenService,
+    private readonly noAuth: NoAuthService,
   ) {
     this.publicUrl =
       this.configService.get<string>('PUBLIC_URL') || 'http://localhost:8080';
@@ -178,6 +181,12 @@ export class OAuthController {
     },
   ) {
     const { client_id, redirect_uri, code_challenge, state, scope } = body;
+
+    if (!this.noAuth.enabled && req.user.authMethod !== 'jwt') {
+      throw new ForbiddenException(
+        'OAuth authorize requires a JWT-authenticated user session',
+      );
+    }
 
     if (!client_id || !redirect_uri || !code_challenge || !state) {
       throw new BadRequestException('Missing required fields');


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds `client_secret_basic` to `/oauth/token` and `/oauth/revoke`, lets the Admin UI call `/oauth/authorize` with a session JWT cookie, and requires a JWT-authenticated session (no API keys) to mint auth codes.

- **New Features**
  - Token and revocation endpoints accept `Authorization: Basic base64(client_id:client_secret)`; discovery lists both methods; registration response includes `token_endpoint_auth_method: "client_secret_post"`.
  - `/oauth/authorize` accepts the session cookie (`rev_at`) as an alternative to a Bearer JWT for user auth.

- **Bug Fixes**
  - Malformed or incomplete Basic credentials return 400 "Invalid client credentials" with no fallback to body parameters.
  - `/oauth/authorize` enforces a JWT-authenticated user session and rejects API key auth or unauthenticated requests.

<sup>Written for commit da7e5b9165517a657fb7054263840ee577e98430. Summary will update on new commits. <a href="https://cubic.dev/pr/revisium/revisium-core/pull/492">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

