### PR TITLE
fix: change LimitExceededException from 403 to 402 Payment Required

### DIFF
--- a/docs/billing/developer-guide.md
+++ b/docs/billing/developer-guide.md
@@ -9,7 +9,7 @@ src/features/billing/               # Core (Apache 2.0)
   billing.module.ts                 # @Global, provides NoopLimitsService
   limits.interface.ts               # ILimitsService, LimitMetric, LimitCheckResult
   noop-limits.service.ts            # Always returns { allowed: true }
-  limit-exceeded.exception.ts       # HTTP 403 with structured error
+  limit-exceeded.exception.ts       # HTTP 402 with structured error
 
 ee/billing/                         # Enterprise (proprietary)
   ee-billing.module.ts              # Registers all providers, overrides noop

--- a/docs/billing/enforcement.md
+++ b/docs/billing/enforcement.md
@@ -98,11 +98,11 @@ await this.billingCheck.check(revisionId, LimitMetric.ROWS_PER_TABLE, rows.lengt
 
 ## Error Response
 
-When a limit is exceeded, `LimitExceededException` returns HTTP 403:
+When a limit is exceeded, `LimitExceededException` returns HTTP 402 (Payment Required):
 
 ```json
 {
-  "statusCode": 403,
+  "statusCode": 402,
   "code": "LIMIT_EXCEEDED",
   "metric": "row_versions",
   "current": 10000,

--- a/src/features/billing/__tests__/limit-exceeded.exception.spec.ts
+++ b/src/features/billing/__tests__/limit-exceeded.exception.spec.ts
@@ -10,7 +10,9 @@ describe('LimitExceededException', () => {
       metric: LimitMetric.PROJECTS,
     });
 
+    expect(exception.getStatus()).toBe(402);
     const response = exception.getResponse() as any;
+    expect(response.statusCode).toBe(402);
     expect(response.code).toBe('LIMIT_EXCEEDED');
     expect(response.metric).toBe(LimitMetric.PROJECTS);
     expect(response.current).toBe(5);

--- a/src/features/billing/limit-exceeded.exception.ts
+++ b/src/features/billing/limit-exceeded.exception.ts
@@ -1,14 +1,18 @@
-import { ForbiddenException } from '@nestjs/common';
+import { HttpException, HttpStatus } from '@nestjs/common';
 import { LimitCheckResult } from './limits.interface';
 
-export class LimitExceededException extends ForbiddenException {
+export class LimitExceededException extends HttpException {
   constructor(result: LimitCheckResult) {
-    super({
-      code: 'LIMIT_EXCEEDED',
-      metric: result.metric,
-      current: result.current,
-      limit: result.limit,
-      message: `Plan limit exceeded for ${result.metric ?? 'unknown'}. Current: ${result.current ?? 0}, Limit: ${result.limit ?? 'unknown'}`,
-    });
+    super(
+      {
+        statusCode: HttpStatus.PAYMENT_REQUIRED,
+        code: 'LIMIT_EXCEEDED',
+        metric: result.metric,
+        current: result.current,
+        limit: result.limit,
+        message: `Plan limit exceeded for ${result.metric ?? 'unknown'}. Current: ${result.current ?? 0}, Limit: ${result.limit ?? 'unknown'}`,
+      },
+      HttpStatus.PAYMENT_REQUIRED,
+    );
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Return HTTP 402 Payment Required for billing limit overages instead of 403 Forbidden. LimitExceededException now extends HttpException with 402 status and includes statusCode in the response body while preserving existing error fields (code, metric, current, limit); tests and docs updated.

<sup>Written for commit 3206251c709705329d6ad682fd0ba7c74f232757. Summary will update on new commits. <a href="https://cubic.dev/pr/revisium/revisium-core/pull/494">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

