### PR TITLE
feat: enforce endpoint billing limits

### DIFF
--- a/ee/billing/__tests__/billing-api.e2e.spec.ts
+++ b/ee/billing/__tests__/billing-api.e2e.spec.ts
@@ -202,7 +202,7 @@ describe('Billing REST API (e2e)', () => {
       expect(res.body.projects).toBeDefined();
       expect(res.body.seats).toBeDefined();
       expect(res.body.storageBytes).toBeDefined();
-      expect(res.body.endpointsPerProject).toBeDefined();
+      expect(res.body.endpointsPerProject).toBeUndefined();
     });
   });
 

--- a/ee/billing/__tests__/billing-api.e2e.spec.ts
+++ b/ee/billing/__tests__/billing-api.e2e.spec.ts
@@ -26,6 +26,7 @@ const mockBillingClient: jest.Mocked<IBillingClient> = {
       rows_per_table: 1_000,
       tables_per_revision: 10,
       branches_per_project: 3,
+      endpoints_per_project: 2,
     },
   }),
   createCheckout: jest.fn(),
@@ -49,6 +50,7 @@ const mockBillingClient: jest.Mocked<IBillingClient> = {
         rows_per_table: 1_000,
         tables_per_revision: 10,
         branches_per_project: 3,
+        endpoints_per_project: 2,
       },
       features: {},
     },
@@ -67,6 +69,7 @@ const mockBillingClient: jest.Mocked<IBillingClient> = {
         rows_per_table: 10_000,
         tables_per_revision: 100,
         branches_per_project: 20,
+        endpoints_per_project: 10,
       },
       features: { sso: true, audit: true },
     },
@@ -199,6 +202,7 @@ describe('Billing REST API (e2e)', () => {
       expect(res.body.projects).toBeDefined();
       expect(res.body.seats).toBeDefined();
       expect(res.body.storageBytes).toBeDefined();
+      expect(res.body.endpointsPerProject).toBeDefined();
     });
   });
 

--- a/ee/billing/__tests__/billing-api.e2e.spec.ts
+++ b/ee/billing/__tests__/billing-api.e2e.spec.ts
@@ -219,5 +219,4 @@ describe('Billing REST API (e2e)', () => {
       expect(res.body.data.plans[0].id).toBeDefined();
     });
   });
-
 });

--- a/ee/billing/__tests__/billing-client.spec.ts
+++ b/ee/billing/__tests__/billing-client.spec.ts
@@ -53,6 +53,7 @@ describe('BillingClient', () => {
         rows_per_table: null,
         tables_per_revision: null,
         branches_per_project: null,
+        endpoints_per_project: null,
       },
     };
     mockFetch(200, limits);

--- a/ee/billing/__tests__/billing-graphql.e2e.spec.ts
+++ b/ee/billing/__tests__/billing-graphql.e2e.spec.ts
@@ -174,15 +174,10 @@ describe('Billing GraphQL API (e2e)', () => {
   };
 
   const createEndpointVersion = async (type: EndpointType) => {
-    const existing = await prisma.endpointVersion.findUnique({
+    const created = await prisma.endpointVersion.upsert({
       where: { type_version: { type, version: 1 } },
-    });
-    if (existing) {
-      return existing.id;
-    }
-
-    const created = await prisma.endpointVersion.create({
-      data: {
+      update: {},
+      create: {
         id: nanoid(),
         type,
         version: 1,

--- a/ee/billing/__tests__/billing-graphql.e2e.spec.ts
+++ b/ee/billing/__tests__/billing-graphql.e2e.spec.ts
@@ -97,13 +97,13 @@ const mockBillingClient: jest.Mocked<IBillingClient> = {
           projects: 20,
           seats: 10,
           storage_bytes: 10_000_000_000,
-        api_calls_per_day: 50_000,
-        rows_per_table: 10_000,
-        tables_per_revision: 100,
-        branches_per_project: 20,
-        endpoints_per_project: 10,
-      },
-      features: { sso: true, audit: true },
+          api_calls_per_day: 50_000,
+          rows_per_table: 10_000,
+          tables_per_revision: 100,
+          branches_per_project: 20,
+          endpoints_per_project: 10,
+        },
+        features: { sso: true, audit: true },
       });
     }
     return Promise.resolve(null);
@@ -407,7 +407,9 @@ describe('Billing GraphQL API (e2e)', () => {
       ).expect(200);
 
       expect(res.body.errors).toBeDefined();
-      expect(res.body.errors[0].message).toContain('must be a valid HTTP(S) URL');
+      expect(res.body.errors[0].message).toContain(
+        'must be a valid HTTP(S) URL',
+      );
     });
   });
 

--- a/ee/billing/__tests__/billing-graphql.e2e.spec.ts
+++ b/ee/billing/__tests__/billing-graphql.e2e.spec.ts
@@ -425,7 +425,6 @@ describe('Billing GraphQL API (e2e)', () => {
               projects { current limit percentage }
               seats { current limit percentage }
               storageBytes { current limit percentage }
-              endpointsPerProject { current limit percentage }
             }
           }
         }`,
@@ -438,7 +437,6 @@ describe('Billing GraphQL API (e2e)', () => {
       expect(usage.projects.limit).toBe(3);
       expect(usage.seats.limit).toBe(1);
       expect(usage.storageBytes.limit).toBe(500_000_000);
-      expect(usage.endpointsPerProject.limit).toBe(2);
       expect(mockBillingClient.getOrgLimits).toHaveBeenCalledWith(orgId);
     });
 

--- a/ee/billing/__tests__/billing-graphql.e2e.spec.ts
+++ b/ee/billing/__tests__/billing-graphql.e2e.spec.ts
@@ -2,6 +2,7 @@ import { INestApplication, ValidationPipe } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { nanoid } from 'nanoid';
 import request from 'supertest';
+import { EndpointType } from 'src/__generated__/client';
 import { CoreModule } from 'src/core/core.module';
 import { registerGraphqlEnums } from 'src/api/graphql-api/registerGraphqlEnums';
 import { PrismaService } from 'src/infrastructure/database/prisma.service';
@@ -26,6 +27,7 @@ const mockBillingClient: jest.Mocked<IBillingClient> = {
       rows_per_table: 1_000,
       tables_per_revision: 10,
       branches_per_project: 3,
+      endpoints_per_project: 2,
     },
   }),
   createCheckout: jest.fn().mockResolvedValue({
@@ -58,6 +60,7 @@ const mockBillingClient: jest.Mocked<IBillingClient> = {
         rows_per_table: 1_000,
         tables_per_revision: 10,
         branches_per_project: 3,
+        endpoints_per_project: 2,
       },
       features: {},
     },
@@ -76,6 +79,7 @@ const mockBillingClient: jest.Mocked<IBillingClient> = {
         rows_per_table: 10_000,
         tables_per_revision: 100,
         branches_per_project: 20,
+        endpoints_per_project: 10,
       },
       features: { sso: true, audit: true },
     },
@@ -93,12 +97,13 @@ const mockBillingClient: jest.Mocked<IBillingClient> = {
           projects: 20,
           seats: 10,
           storage_bytes: 10_000_000_000,
-          api_calls_per_day: 50_000,
-          rows_per_table: 10_000,
-          tables_per_revision: 100,
-          branches_per_project: 20,
-        },
-        features: { sso: true, audit: true },
+        api_calls_per_day: 50_000,
+        rows_per_table: 10_000,
+        tables_per_revision: 100,
+        branches_per_project: 20,
+        endpoints_per_project: 10,
+      },
+      features: { sso: true, audit: true },
       });
     }
     return Promise.resolve(null);
@@ -168,6 +173,98 @@ describe('Billing GraphQL API (e2e)', () => {
     return { orgId, userId, token };
   };
 
+  const createEndpointVersion = async (type: EndpointType) => {
+    const existing = await prisma.endpointVersion.findUnique({
+      where: { type_version: { type, version: 1 } },
+    });
+    if (existing) {
+      return existing.id;
+    }
+
+    const created = await prisma.endpointVersion.create({
+      data: {
+        id: nanoid(),
+        type,
+        version: 1,
+      },
+    });
+
+    return created.id;
+  };
+
+  const createProjectWithEndpoints = async (organizationId: string) => {
+    const projectId = nanoid();
+    const projectName = `project-${projectId}`;
+    const branchId = nanoid();
+    const revisionId = nanoid();
+    const secondBranchId = nanoid();
+    const secondRevisionId = nanoid();
+    const graphqlVersionId = await createEndpointVersion(EndpointType.GRAPHQL);
+    const restVersionId = await createEndpointVersion(EndpointType.REST_API);
+
+    await prisma.project.create({
+      data: {
+        id: projectId,
+        name: projectName,
+        organizationId,
+        branches: {
+          create: [
+            {
+              id: branchId,
+              name: 'master',
+              isRoot: true,
+              revisions: {
+                create: {
+                  id: revisionId,
+                  isHead: true,
+                  isDraft: true,
+                },
+              },
+            },
+            {
+              id: secondBranchId,
+              name: 'feature',
+              revisions: {
+                create: {
+                  id: secondRevisionId,
+                  isHead: true,
+                },
+              },
+            },
+          ],
+        },
+      },
+    });
+
+    await prisma.endpoint.create({
+      data: {
+        id: nanoid(),
+        type: EndpointType.GRAPHQL,
+        revisionId,
+        versionId: graphqlVersionId,
+      },
+    });
+    await prisma.endpoint.create({
+      data: {
+        id: nanoid(),
+        type: EndpointType.REST_API,
+        revisionId,
+        versionId: restVersionId,
+      },
+    });
+    await prisma.endpoint.create({
+      data: {
+        id: nanoid(),
+        type: EndpointType.REST_API,
+        revisionId: secondRevisionId,
+        versionId: restVersionId,
+        isDeleted: true,
+      },
+    });
+
+    return { projectId, projectName };
+  };
+
   const gql = (
     query: string,
     variables?: Record<string, unknown>,
@@ -199,7 +296,7 @@ describe('Billing GraphQL API (e2e)', () => {
       const res = await gql(`{
         plans {
           id name isPublic monthlyPriceUsd yearlyPriceUsd
-          limits { rowVersions projects seats storageBytes apiCallsPerDay rowsPerTable tablesPerRevision branchesPerProject }
+          limits { rowVersions projects seats storageBytes apiCallsPerDay rowsPerTable tablesPerRevision branchesPerProject endpointsPerProject }
           features
         }
       }`).expect(200);
@@ -209,6 +306,7 @@ describe('Billing GraphQL API (e2e)', () => {
       expect(pro.id).toBe('pro');
       expect(pro.limits.rowVersions).toBe(500_000);
       expect(pro.limits.apiCallsPerDay).toBe(50_000);
+      expect(pro.limits.endpointsPerProject).toBe(10);
       expect(pro.features).toEqual({ sso: true, audit: true });
     });
   });
@@ -330,6 +428,7 @@ describe('Billing GraphQL API (e2e)', () => {
               projects { current limit percentage }
               seats { current limit percentage }
               storageBytes { current limit percentage }
+              endpointsPerProject { current limit percentage }
             }
           }
         }`,
@@ -342,6 +441,7 @@ describe('Billing GraphQL API (e2e)', () => {
       expect(usage.projects.limit).toBe(3);
       expect(usage.seats.limit).toBe(1);
       expect(usage.storageBytes.limit).toBe(500_000_000);
+      expect(usage.endpointsPerProject.limit).toBe(2);
       expect(mockBillingClient.getOrgLimits).toHaveBeenCalledWith(orgId);
     });
 
@@ -364,6 +464,33 @@ describe('Billing GraphQL API (e2e)', () => {
       expect(seats.current).toBe(1);
       expect(seats.limit).toBe(1);
       expect(seats.percentage).toBe(100);
+    });
+  });
+
+  describe('project.endpointUsage', () => {
+    it('should return project-scoped endpoint usage and limit', async () => {
+      const { orgId, token } = await createOrgWithOwner();
+      const { projectName } = await createProjectWithEndpoints(orgId);
+
+      const res = await gql(
+        `query($data: GetProjectInput!) {
+          project(data: $data) {
+            endpointUsage {
+              current
+              limit
+              percentage
+            }
+          }
+        }`,
+        { data: { organizationId: orgId, projectName } },
+        token,
+      ).expect(200);
+
+      expect(res.body.data.project.endpointUsage).toEqual({
+        current: 2,
+        limit: 2,
+        percentage: 100,
+      });
     });
   });
 

--- a/ee/billing/__tests__/billing-graphql.service.spec.ts
+++ b/ee/billing/__tests__/billing-graphql.service.spec.ts
@@ -80,4 +80,48 @@ describe('BillingGraphqlService', () => {
       { projectId: 'project-1' },
     );
   });
+
+  it('reuses cached org limits across project endpoint usage lookups', async () => {
+    const billingClient = createBillingClient({
+      getOrgLimits: jest.fn().mockResolvedValue({
+        planId: 'pro',
+        status: BillingStatus.active,
+        limits: {
+          row_versions: null,
+          projects: null,
+          seats: null,
+          storage_bytes: null,
+          api_calls_per_day: null,
+          rows_per_table: null,
+          tables_per_revision: null,
+          branches_per_project: null,
+          endpoints_per_project: 10,
+        },
+      }),
+    });
+    const usageService = createUsageService({
+      computeUsage: jest
+        .fn()
+        .mockResolvedValueOnce(3)
+        .mockResolvedValueOnce(5),
+    });
+    const service = new BillingGraphqlService(billingClient, usageService);
+
+    await expect(
+      service.getProjectEndpointUsage('org-1', 'project-1'),
+    ).resolves.toEqual({
+      current: 3,
+      limit: 10,
+      percentage: 30,
+    });
+    await expect(
+      service.getProjectEndpointUsage('org-1', 'project-2'),
+    ).resolves.toEqual({
+      current: 5,
+      limit: 10,
+      percentage: 50,
+    });
+
+    expect(billingClient.getOrgLimits).toHaveBeenCalledTimes(1);
+  });
 });

--- a/ee/billing/__tests__/billing-graphql.service.spec.ts
+++ b/ee/billing/__tests__/billing-graphql.service.spec.ts
@@ -102,4 +102,39 @@ describe('BillingGraphqlService', () => {
     });
     expect(billingClient.getOrgLimits).not.toHaveBeenCalled();
   });
+
+  it('loads the endpoint limit when the injected option is undefined', async () => {
+    const billingClient = createBillingClient({
+      getOrgLimits: jest.fn().mockResolvedValue({
+        planId: 'pro',
+        status: BillingStatus.active,
+        limits: {
+          row_versions: null,
+          projects: null,
+          seats: null,
+          storage_bytes: null,
+          api_calls_per_day: null,
+          rows_per_table: null,
+          tables_per_revision: null,
+          branches_per_project: null,
+          endpoints_per_project: 12,
+        },
+      }),
+    });
+    const usageService = createUsageService({
+      computeUsage: jest.fn().mockResolvedValue(6),
+    });
+    const service = new BillingGraphqlService(billingClient, usageService);
+
+    await expect(
+      service.getProjectEndpointUsage('org-1', 'project-1', {
+        endpointLimit: undefined,
+      }),
+    ).resolves.toEqual({
+      current: 6,
+      limit: 12,
+      percentage: 50,
+    });
+    expect(billingClient.getOrgLimits).toHaveBeenCalledWith('org-1');
+  });
 });

--- a/ee/billing/__tests__/billing-graphql.service.spec.ts
+++ b/ee/billing/__tests__/billing-graphql.service.spec.ts
@@ -1,0 +1,83 @@
+import { BillingStatus } from 'src/api/graphql-api/billing/models/billing-status.enum';
+import { LimitMetric } from 'src/features/billing/limits.interface';
+import { BillingGraphqlService } from '../billing-graphql.service';
+import { IBillingClient } from '../billing-client.interface';
+import { UsageService } from '../usage/usage.service';
+
+describe('BillingGraphqlService', () => {
+  const createBillingClient = (
+    overrides: Partial<IBillingClient> = {},
+  ): IBillingClient => ({
+    configured: true,
+    getOrgLimits: jest.fn(),
+    createCheckout: jest.fn(),
+    cancelSubscription: jest.fn(),
+    getSubscription: jest.fn(),
+    getProviders: jest.fn(),
+    getPortalUrl: jest.fn(),
+    getPlans: jest.fn(),
+    getPlan: jest.fn(),
+    activateEarlyAccess: jest.fn(),
+    reportUsage: jest.fn(),
+    ...overrides,
+  });
+
+  const createUsageService = (
+    overrides: Partial<UsageService> = {},
+  ): UsageService =>
+    ({
+      computeUsage: jest.fn(),
+      computeUsageSummary: jest.fn(),
+      ...overrides,
+    }) as unknown as UsageService;
+
+  it('returns null project endpoint usage when billing is disabled', async () => {
+    const billingClient = createBillingClient({ configured: false });
+    const usageService = createUsageService();
+    const service = new BillingGraphqlService(billingClient, usageService);
+
+    await expect(
+      service.getProjectEndpointUsage('org-1', 'project-1'),
+    ).resolves.toBeNull();
+    expect(billingClient.getOrgLimits).not.toHaveBeenCalled();
+    expect(usageService.computeUsage).not.toHaveBeenCalled();
+  });
+
+  it('builds project endpoint usage from current usage and plan limit', async () => {
+    const billingClient = createBillingClient({
+      getOrgLimits: jest.fn().mockResolvedValue({
+        planId: 'pro',
+        status: BillingStatus.active,
+        limits: {
+          row_versions: null,
+          projects: null,
+          seats: null,
+          storage_bytes: null,
+          api_calls_per_day: null,
+          rows_per_table: null,
+          tables_per_revision: null,
+          branches_per_project: null,
+          endpoints_per_project: 10,
+        },
+      }),
+    });
+    const usageService = createUsageService({
+      computeUsage: jest.fn().mockResolvedValue(4),
+    });
+    const service = new BillingGraphqlService(billingClient, usageService);
+
+    await expect(
+      service.getProjectEndpointUsage('org-1', 'project-1'),
+    ).resolves.toEqual({
+      current: 4,
+      limit: 10,
+      percentage: 40,
+    });
+    expect(billingClient.getOrgLimits).toHaveBeenCalledWith('org-1');
+    expect(usageService.computeUsage).toHaveBeenCalledWith(
+      'org-1',
+      LimitMetric.ENDPOINTS_PER_PROJECT,
+      { projectId: 'project-1' },
+    );
+  });
+});

--- a/ee/billing/__tests__/billing-graphql.service.spec.ts
+++ b/ee/billing/__tests__/billing-graphql.service.spec.ts
@@ -37,6 +37,9 @@ describe('BillingGraphqlService', () => {
     const service = new BillingGraphqlService(billingClient, usageService);
 
     await expect(
+      service.getProjectEndpointLimit('org-1'),
+    ).resolves.toBeUndefined();
+    await expect(
       service.getProjectEndpointUsage('org-1', 'project-1'),
     ).resolves.toBeNull();
     expect(billingClient.getOrgLimits).not.toHaveBeenCalled();
@@ -81,47 +84,22 @@ describe('BillingGraphqlService', () => {
     );
   });
 
-  it('reuses cached org limits across project endpoint usage lookups', async () => {
-    const billingClient = createBillingClient({
-      getOrgLimits: jest.fn().mockResolvedValue({
-        planId: 'pro',
-        status: BillingStatus.active,
-        limits: {
-          row_versions: null,
-          projects: null,
-          seats: null,
-          storage_bytes: null,
-          api_calls_per_day: null,
-          rows_per_table: null,
-          tables_per_revision: null,
-          branches_per_project: null,
-          endpoints_per_project: 10,
-        },
-      }),
-    });
+  it('uses an injected endpoint limit when provided', async () => {
+    const billingClient = createBillingClient();
     const usageService = createUsageService({
-      computeUsage: jest
-        .fn()
-        .mockResolvedValueOnce(3)
-        .mockResolvedValueOnce(5),
+      computeUsage: jest.fn().mockResolvedValue(4),
     });
     const service = new BillingGraphqlService(billingClient, usageService);
 
     await expect(
-      service.getProjectEndpointUsage('org-1', 'project-1'),
+      service.getProjectEndpointUsage('org-1', 'project-1', {
+        endpointLimit: 10,
+      }),
     ).resolves.toEqual({
-      current: 3,
+      current: 4,
       limit: 10,
-      percentage: 30,
+      percentage: 40,
     });
-    await expect(
-      service.getProjectEndpointUsage('org-1', 'project-2'),
-    ).resolves.toEqual({
-      current: 5,
-      limit: 10,
-      percentage: 50,
-    });
-
-    expect(billingClient.getOrgLimits).toHaveBeenCalledTimes(1);
+    expect(billingClient.getOrgLimits).not.toHaveBeenCalled();
   });
 });

--- a/ee/billing/__tests__/limits.service.spec.ts
+++ b/ee/billing/__tests__/limits.service.spec.ts
@@ -26,6 +26,7 @@ const PRO_LIMITS: OrgLimits = {
     rows_per_table: 10_000,
     tables_per_revision: 100,
     branches_per_project: 20,
+    endpoints_per_project: 10,
   },
 };
 
@@ -41,6 +42,7 @@ const FREE_LIMITS: OrgLimits = {
     rows_per_table: 1_000,
     tables_per_revision: 10,
     branches_per_project: 3,
+    endpoints_per_project: 2,
   },
 };
 
@@ -145,6 +147,7 @@ describe('LimitsService (Ultra-Thin)', () => {
         rows_per_table: null,
         tables_per_revision: null,
         branches_per_project: null,
+        endpoints_per_project: null,
       },
     };
     mockBillingClient.getOrgLimits.mockResolvedValue(unlimited);
@@ -386,5 +389,29 @@ describe('LimitsService (Ultra-Thin)', () => {
     expect(result.current).toBe(3);
     expect(result.limit).toBe(3);
     expect(result.metric).toBe(LimitMetric.BRANCHES_PER_PROJECT);
+  });
+
+  it('should deny when endpoints_per_project limit reached', async () => {
+    mockBillingClient.getOrgLimits.mockResolvedValue(FREE_LIMITS);
+    const computeSpy = jest
+      .spyOn(usageService, 'computeUsage')
+      .mockResolvedValueOnce(2);
+
+    const result = await service.checkLimit(
+      'test-org',
+      LimitMetric.ENDPOINTS_PER_PROJECT,
+      1,
+      { projectId: 'proj-1' },
+    );
+
+    expect(result.allowed).toBe(false);
+    expect(result.current).toBe(2);
+    expect(result.limit).toBe(2);
+    expect(result.metric).toBe(LimitMetric.ENDPOINTS_PER_PROJECT);
+    expect(computeSpy).toHaveBeenCalledWith(
+      'test-org',
+      LimitMetric.ENDPOINTS_PER_PROJECT,
+      { projectId: 'proj-1' },
+    );
   });
 });

--- a/ee/billing/__tests__/limits.service.spec.ts
+++ b/ee/billing/__tests__/limits.service.spec.ts
@@ -318,7 +318,11 @@ describe('LimitsService (Ultra-Thin)', () => {
 
     await service.checkLimit('test-org', LimitMetric.PROJECTS, 1);
 
-    expect(computeSpy).toHaveBeenCalledWith('test-org', LimitMetric.PROJECTS, undefined);
+    expect(computeSpy).toHaveBeenCalledWith(
+      'test-org',
+      LimitMetric.PROJECTS,
+      undefined,
+    );
     expect(cacheSpy).not.toHaveBeenCalled();
   });
 
@@ -329,7 +333,11 @@ describe('LimitsService (Ultra-Thin)', () => {
 
     await service.checkLimit('test-org', LimitMetric.SEATS, 1);
 
-    expect(computeSpy).toHaveBeenCalledWith('test-org', LimitMetric.SEATS, undefined);
+    expect(computeSpy).toHaveBeenCalledWith(
+      'test-org',
+      LimitMetric.SEATS,
+      undefined,
+    );
     expect(cacheSpy).not.toHaveBeenCalled();
   });
 
@@ -351,7 +359,12 @@ describe('LimitsService (Ultra-Thin)', () => {
     mockBillingClient.getOrgLimits.mockResolvedValue(PRO_LIMITS);
 
     const context = { revisionId: 'rev-1', tableId: 'tbl-1' };
-    await service.checkLimit('test-org', LimitMetric.ROWS_PER_TABLE, 1, context);
+    await service.checkLimit(
+      'test-org',
+      LimitMetric.ROWS_PER_TABLE,
+      1,
+      context,
+    );
 
     expect(cacheSpy).toHaveBeenCalledWith(
       'test-org',

--- a/ee/billing/__tests__/usage.service.spec.ts
+++ b/ee/billing/__tests__/usage.service.spec.ts
@@ -241,77 +241,21 @@ describe('UsageService', () => {
   });
 
   describe('computeUsageSummary', () => {
-    it('should expose the max endpoints count across projects', async () => {
+    it('should only return org-scoped usage metrics', async () => {
       const orgId = await createOrg();
-      const firstProject = await createProjectWithRows(orgId, 0);
-      const secondProject = await createProjectWithRows(orgId, 0);
-      const graphqlVersionId = await createEndpointVersion(
-        EndpointType.GRAPHQL,
-      );
-      const restVersionId = await createEndpointVersion(EndpointType.REST_API);
-      const secondBranchId = nanoid();
-      const secondRevisionId = nanoid();
-
-      await prisma.branch.create({
-        data: {
-          id: secondBranchId,
-          name: `feature-${secondBranchId}`,
-          projectId: secondProject.projectId,
-          revisions: {
-            create: {
-              id: secondRevisionId,
-              isHead: true,
-            },
-          },
-        },
-      });
-
-      await prisma.endpoint.create({
-        data: {
-          id: nanoid(),
-          type: EndpointType.GRAPHQL,
-          revisionId: firstProject.revisionId,
-          versionId: graphqlVersionId,
-        },
-      });
-
-      await prisma.endpoint.create({
-        data: {
-          id: nanoid(),
-          type: EndpointType.GRAPHQL,
-          revisionId: secondProject.revisionId,
-          versionId: graphqlVersionId,
-        },
-      });
-      await prisma.endpoint.create({
-        data: {
-          id: nanoid(),
-          type: EndpointType.REST_API,
-          revisionId: secondProject.revisionId,
-          versionId: restVersionId,
-        },
-      });
-      await prisma.endpoint.create({
-        data: {
-          id: nanoid(),
-          type: EndpointType.REST_API,
-          revisionId: secondRevisionId,
-          versionId: restVersionId,
-          isDeleted: true,
-        },
-      });
-
       const result = await service.computeUsageSummary(orgId, {
         row_versions: 10_000,
         projects: 3,
         seats: 1,
         storage_bytes: 500_000_000,
-        endpoints_per_project: 2,
       });
 
-      expect(result.endpointsPerProject.current).toBe(2);
-      expect(result.endpointsPerProject.limit).toBe(2);
-      expect(result.endpointsPerProject.percentage).toBe(100);
+      expect(result).toEqual({
+        rowVersions: expect.any(Object),
+        projects: expect.any(Object),
+        seats: expect.any(Object),
+        storageBytes: expect.any(Object),
+      });
     });
   });
 });

--- a/ee/billing/__tests__/usage.service.spec.ts
+++ b/ee/billing/__tests__/usage.service.spec.ts
@@ -87,15 +87,10 @@ describe('UsageService', () => {
   };
 
   const createEndpointVersion = async (type: EndpointType) => {
-    const existing = await prisma.endpointVersion.findUnique({
+    const created = await prisma.endpointVersion.upsert({
       where: { type_version: { type, version: 1 } },
-    });
-    if (existing) {
-      return existing.id;
-    }
-
-    const created = await prisma.endpointVersion.create({
-      data: {
+      update: {},
+      create: {
         id: nanoid(),
         type,
         version: 1,

--- a/ee/billing/__tests__/usage.service.spec.ts
+++ b/ee/billing/__tests__/usage.service.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { nanoid } from 'nanoid';
+import { EndpointType } from 'src/__generated__/client';
 import { LimitMetric } from 'src/features/billing/limits.interface';
 import { DatabaseModule } from 'src/infrastructure/database/database.module';
 import { PrismaService } from 'src/infrastructure/database/prisma.service';
@@ -85,6 +86,24 @@ describe('UsageService', () => {
     return { projectId, revisionId };
   };
 
+  const createEndpointVersion = async (type: EndpointType) => {
+    const existing = await prisma.endpointVersion.findUnique({
+      where: { type_version: { type, version: 1 } },
+    });
+    if (existing) {
+      return existing.id;
+    }
+
+    const created = await prisma.endpointVersion.create({
+      data: {
+        id: nanoid(),
+        type,
+        version: 1,
+      },
+    });
+    return created.id;
+  };
+
   describe('computeUsage', () => {
     it('should count unique row versions across org', async () => {
       const orgId = await createOrg();
@@ -164,6 +183,136 @@ describe('UsageService', () => {
       const orgId = await createOrg();
       const result = await service.computeUsage(orgId, LimitMetric.API_CALLS);
       expect(result).toBe(0);
+    });
+
+    it('should count non-deleted endpoints in project', async () => {
+      const orgId = await createOrg();
+      const { projectId, revisionId } = await createProjectWithRows(orgId, 0);
+      const graphqlVersionId = await createEndpointVersion(EndpointType.GRAPHQL);
+      const restVersionId = await createEndpointVersion(EndpointType.REST_API);
+      const branchId = nanoid();
+      const secondRevisionId = nanoid();
+
+      await prisma.branch.create({
+        data: {
+          id: branchId,
+          name: `feature-${branchId}`,
+          projectId,
+          revisions: {
+            create: {
+              id: secondRevisionId,
+              isHead: true,
+            },
+          },
+        },
+      });
+
+      await prisma.endpoint.create({
+        data: {
+          id: nanoid(),
+          type: EndpointType.GRAPHQL,
+          revisionId,
+          versionId: graphqlVersionId,
+        },
+      });
+      await prisma.endpoint.create({
+        data: {
+          id: nanoid(),
+          type: EndpointType.REST_API,
+          revisionId,
+          versionId: restVersionId,
+        },
+      });
+      await prisma.endpoint.create({
+        data: {
+          id: nanoid(),
+          type: EndpointType.REST_API,
+          revisionId: secondRevisionId,
+          versionId: restVersionId,
+          isDeleted: true,
+        },
+      });
+
+      const result = await service.computeUsage(
+        orgId,
+        LimitMetric.ENDPOINTS_PER_PROJECT,
+        { projectId },
+      );
+
+      expect(result).toBe(2);
+    });
+  });
+
+  describe('computeUsageSummary', () => {
+    it('should expose the max endpoints count across projects', async () => {
+      const orgId = await createOrg();
+      const firstProject = await createProjectWithRows(orgId, 0);
+      const secondProject = await createProjectWithRows(orgId, 0);
+      const graphqlVersionId = await createEndpointVersion(EndpointType.GRAPHQL);
+      const restVersionId = await createEndpointVersion(EndpointType.REST_API);
+      const secondBranchId = nanoid();
+      const secondRevisionId = nanoid();
+
+      await prisma.branch.create({
+        data: {
+          id: secondBranchId,
+          name: `feature-${secondBranchId}`,
+          projectId: secondProject.projectId,
+          revisions: {
+            create: {
+              id: secondRevisionId,
+              isHead: true,
+            },
+          },
+        },
+      });
+
+      await prisma.endpoint.create({
+        data: {
+          id: nanoid(),
+          type: EndpointType.GRAPHQL,
+          revisionId: firstProject.revisionId,
+          versionId: graphqlVersionId,
+        },
+      });
+
+      await prisma.endpoint.create({
+        data: {
+          id: nanoid(),
+          type: EndpointType.GRAPHQL,
+          revisionId: secondProject.revisionId,
+          versionId: graphqlVersionId,
+        },
+      });
+      await prisma.endpoint.create({
+        data: {
+          id: nanoid(),
+          type: EndpointType.REST_API,
+          revisionId: secondProject.revisionId,
+          versionId: restVersionId,
+        },
+      });
+      await prisma.endpoint.create({
+        data: {
+          id: nanoid(),
+          type: EndpointType.REST_API,
+          revisionId: secondRevisionId,
+          versionId: restVersionId,
+          isDeleted: true,
+        },
+      });
+
+      const result = await service.computeUsageSummary(orgId, {
+        row_versions: 10_000,
+        projects: 3,
+        seats: 1,
+        storage_bytes: 500_000_000,
+        endpoints_per_project: 2,
+      });
+
+      expect(result.endpointsPerProject.current).toBe(2);
+      expect(result.endpointsPerProject.limit).toBe(2);
+      expect(result.endpointsPerProject.percentage).toBe(100);
     });
   });
 });

--- a/ee/billing/__tests__/usage.service.spec.ts
+++ b/ee/billing/__tests__/usage.service.spec.ts
@@ -183,7 +183,9 @@ describe('UsageService', () => {
     it('should count non-deleted endpoints in project', async () => {
       const orgId = await createOrg();
       const { projectId, revisionId } = await createProjectWithRows(orgId, 0);
-      const graphqlVersionId = await createEndpointVersion(EndpointType.GRAPHQL);
+      const graphqlVersionId = await createEndpointVersion(
+        EndpointType.GRAPHQL,
+      );
       const restVersionId = await createEndpointVersion(EndpointType.REST_API);
       const branchId = nanoid();
       const secondRevisionId = nanoid();
@@ -243,7 +245,9 @@ describe('UsageService', () => {
       const orgId = await createOrg();
       const firstProject = await createProjectWithRows(orgId, 0);
       const secondProject = await createProjectWithRows(orgId, 0);
-      const graphqlVersionId = await createEndpointVersion(EndpointType.GRAPHQL);
+      const graphqlVersionId = await createEndpointVersion(
+        EndpointType.GRAPHQL,
+      );
       const restVersionId = await createEndpointVersion(EndpointType.REST_API);
       const secondBranchId = nanoid();
       const secondRevisionId = nanoid();

--- a/ee/billing/__tests__/usage.service.unit.spec.ts
+++ b/ee/billing/__tests__/usage.service.unit.spec.ts
@@ -1,0 +1,62 @@
+import { UsageService } from '../usage/usage.service';
+
+describe('UsageService unit', () => {
+  const createService = () => {
+    const prisma = {
+      $queryRaw: jest.fn(),
+    };
+
+    return {
+      prisma,
+      service: new UsageService(prisma as never),
+    };
+  };
+
+  it('converts bigint max endpoint counts in usage summary', async () => {
+    const { prisma, service } = createService();
+
+    prisma.$queryRaw.mockResolvedValue([{ maxCount: 7n }]);
+    jest
+      .spyOn(service, 'computeUsage')
+      .mockResolvedValueOnce(12)
+      .mockResolvedValueOnce(3)
+      .mockResolvedValueOnce(2)
+      .mockResolvedValueOnce(0);
+
+    await expect(
+      service.computeUsageSummary('org-1', {
+        row_versions: 20,
+        projects: 5,
+        seats: 5,
+        storage_bytes: null,
+        endpoints_per_project: 10,
+      }),
+    ).resolves.toEqual({
+      rowVersions: { current: 12, limit: 20, percentage: 60 },
+      projects: { current: 3, limit: 5, percentage: 60 },
+      seats: { current: 2, limit: 5, percentage: 40 },
+      storageBytes: { current: 0, limit: null, percentage: null },
+      endpointsPerProject: { current: 7, limit: 10, percentage: 70 },
+    });
+  });
+
+  it('falls back to zero max endpoint count when aggregation returns no rows', async () => {
+    const { prisma, service } = createService();
+
+    prisma.$queryRaw.mockResolvedValue([]);
+    jest
+      .spyOn(service, 'computeUsage')
+      .mockResolvedValueOnce(0)
+      .mockResolvedValueOnce(0)
+      .mockResolvedValueOnce(0)
+      .mockResolvedValueOnce(0);
+
+    await expect(service.computeUsageSummary('org-1')).resolves.toEqual({
+      rowVersions: { current: 0, limit: null, percentage: null },
+      projects: { current: 0, limit: null, percentage: null },
+      seats: { current: 0, limit: null, percentage: null },
+      storageBytes: { current: 0, limit: null, percentage: null },
+      endpointsPerProject: { current: 0, limit: null, percentage: null },
+    });
+  });
+});

--- a/ee/billing/__tests__/usage.service.unit.spec.ts
+++ b/ee/billing/__tests__/usage.service.unit.spec.ts
@@ -2,9 +2,7 @@ import { UsageService } from '../usage/usage.service';
 
 describe('UsageService unit', () => {
   const createService = () => {
-    const prisma = {
-      $queryRaw: jest.fn(),
-    };
+    const prisma = {};
     const transactionService = {
       getTransactionOrPrisma: jest.fn().mockReturnValue(prisma),
     };
@@ -16,10 +14,9 @@ describe('UsageService unit', () => {
     };
   };
 
-  it('converts bigint max endpoint counts in usage summary', async () => {
-    const { prisma, service } = createService();
+  it('builds organization usage summary without project-scoped endpoint metrics', async () => {
+    const { service } = createService();
 
-    prisma.$queryRaw.mockResolvedValue([{ maxCount: 7n }]);
     jest
       .spyOn(service, 'computeUsage')
       .mockResolvedValueOnce(12)
@@ -33,34 +30,12 @@ describe('UsageService unit', () => {
         projects: 5,
         seats: 5,
         storage_bytes: null,
-        endpoints_per_project: 10,
       }),
     ).resolves.toEqual({
       rowVersions: { current: 12, limit: 20, percentage: 60 },
       projects: { current: 3, limit: 5, percentage: 60 },
       seats: { current: 2, limit: 5, percentage: 40 },
       storageBytes: { current: 0, limit: null, percentage: null },
-      endpointsPerProject: { current: 7, limit: 10, percentage: 70 },
-    });
-  });
-
-  it('falls back to zero max endpoint count when aggregation returns no rows', async () => {
-    const { prisma, service } = createService();
-
-    prisma.$queryRaw.mockResolvedValue([]);
-    jest
-      .spyOn(service, 'computeUsage')
-      .mockResolvedValueOnce(0)
-      .mockResolvedValueOnce(0)
-      .mockResolvedValueOnce(0)
-      .mockResolvedValueOnce(0);
-
-    await expect(service.computeUsageSummary('org-1')).resolves.toEqual({
-      rowVersions: { current: 0, limit: null, percentage: null },
-      projects: { current: 0, limit: null, percentage: null },
-      seats: { current: 0, limit: null, percentage: null },
-      storageBytes: { current: 0, limit: null, percentage: null },
-      endpointsPerProject: { current: 0, limit: null, percentage: null },
     });
   });
 });

--- a/ee/billing/__tests__/usage.service.unit.spec.ts
+++ b/ee/billing/__tests__/usage.service.unit.spec.ts
@@ -5,10 +5,14 @@ describe('UsageService unit', () => {
     const prisma = {
       $queryRaw: jest.fn(),
     };
+    const transactionService = {
+      getTransactionOrPrisma: jest.fn().mockReturnValue(prisma),
+    };
 
     return {
       prisma,
-      service: new UsageService(prisma as never),
+      transactionService,
+      service: new UsageService(prisma as never, transactionService as never),
     };
   };
 

--- a/ee/billing/billing-client.interface.ts
+++ b/ee/billing/billing-client.interface.ts
@@ -12,6 +12,7 @@ export interface OrgLimits {
     rows_per_table: number | null;
     tables_per_revision: number | null;
     branches_per_project: number | null;
+    endpoints_per_project: number | null;
   };
 }
 

--- a/ee/billing/billing-client.ts
+++ b/ee/billing/billing-client.ts
@@ -25,9 +25,7 @@ export class BillingClient implements IBillingClient {
     this.secret = configService.get<string>('PAYMENT_SERVICE_SECRET', '');
     this.configured = !!this.baseUrl;
     if (!this.configured) {
-      this.logger.warn(
-        'PAYMENT_SERVICE_URL not configured — billing disabled',
-      );
+      this.logger.warn('PAYMENT_SERVICE_URL not configured — billing disabled');
     }
   }
 

--- a/ee/billing/billing-graphql.service.ts
+++ b/ee/billing/billing-graphql.service.ts
@@ -102,8 +102,8 @@ export class BillingGraphqlService implements IBillingGraphqlService {
     }
 
     const limit =
-      options && 'endpointLimit' in options
-        ? (options.endpointLimit ?? null)
+      options?.endpointLimit !== undefined
+        ? options.endpointLimit
         : await this.getProjectEndpointLimit(organizationId);
     const current = await this.usageService.computeUsage(
       organizationId,

--- a/ee/billing/billing-graphql.service.ts
+++ b/ee/billing/billing-graphql.service.ts
@@ -20,9 +20,19 @@ import { UsageService } from './usage/usage.service';
 
 const VALID_BILLING_STATUSES = new Set<string>(Object.values(BillingStatus));
 const VALID_INTERVALS = new Set(['monthly', 'yearly']);
+const ORG_LIMITS_CACHE_TTL_MS = 60_000;
 
 @Injectable()
 export class BillingGraphqlService implements IBillingGraphqlService {
+  private readonly orgLimitsCache = new Map<
+    string,
+    {
+      data?: Awaited<ReturnType<IBillingClient['getOrgLimits']>>;
+      expiresAt: number;
+      promise?: Promise<Awaited<ReturnType<IBillingClient['getOrgLimits']>>>;
+    }
+  >();
+
   constructor(
     @Inject(BILLING_CLIENT_TOKEN)
     private readonly billingClient: IBillingClient,
@@ -101,7 +111,7 @@ export class BillingGraphqlService implements IBillingGraphqlService {
       return null;
     }
 
-    const orgLimits = await this.billingClient.getOrgLimits(organizationId);
+    const orgLimits = await this.getOrgLimitsCached(organizationId);
     const current = await this.usageService.computeUsage(
       organizationId,
       LimitMetric.ENDPOINTS_PER_PROJECT,
@@ -179,6 +189,37 @@ export class BillingGraphqlService implements IBillingGraphqlService {
     } catch {
       throw new BadRequestException(`${field} must be a valid HTTP(S) URL`);
     }
+  }
+
+  private async getOrgLimitsCached(organizationId: string) {
+    const cached = this.orgLimitsCache.get(organizationId);
+    if (cached?.data && cached.expiresAt > Date.now()) {
+      return cached.data;
+    }
+    if (cached?.promise) {
+      return cached.promise;
+    }
+
+    const promise = this.billingClient
+      .getOrgLimits(organizationId)
+      .then((data) => {
+        this.orgLimitsCache.set(organizationId, {
+          data,
+          expiresAt: Date.now() + ORG_LIMITS_CACHE_TTL_MS,
+        });
+        return data;
+      })
+      .catch((error) => {
+        this.orgLimitsCache.delete(organizationId);
+        throw error;
+      });
+
+    this.orgLimitsCache.set(organizationId, {
+      expiresAt: 0,
+      promise,
+    });
+
+    return promise;
   }
 
 }

--- a/ee/billing/billing-graphql.service.ts
+++ b/ee/billing/billing-graphql.service.ts
@@ -7,8 +7,11 @@ import {
   PaymentProviderResult,
   PlanResult,
   SubscriptionResult,
+  UsageMetricResult,
   UsageSummaryResult,
 } from 'src/features/billing/billing-graphql.interface';
+import { LimitMetric } from 'src/features/billing/limits.interface';
+import { buildMetric } from './usage/build-metric';
 import {
   BILLING_CLIENT_TOKEN,
   IBillingClient,
@@ -48,6 +51,7 @@ export class BillingGraphqlService implements IBillingGraphqlService {
         rowsPerTable: p.limits.rows_per_table,
         tablesPerRevision: p.limits.tables_per_revision,
         branchesPerProject: p.limits.branches_per_project,
+        endpointsPerProject: p.limits.endpoints_per_project,
       },
       features: p.features ?? {},
     }));
@@ -87,6 +91,24 @@ export class BillingGraphqlService implements IBillingGraphqlService {
       organizationId,
       orgLimits.limits,
     );
+  }
+
+  async getProjectEndpointUsage(
+    organizationId: string,
+    projectId: string,
+  ): Promise<UsageMetricResult | null> {
+    if (!this.billingClient.configured) {
+      return null;
+    }
+
+    const orgLimits = await this.billingClient.getOrgLimits(organizationId);
+    const current = await this.usageService.computeUsage(
+      organizationId,
+      LimitMetric.ENDPOINTS_PER_PROJECT,
+      { projectId },
+    );
+
+    return buildMetric(current, orgLimits.limits.endpoints_per_project);
   }
 
   async activateEarlyAccess(

--- a/ee/billing/billing-graphql.service.ts
+++ b/ee/billing/billing-graphql.service.ts
@@ -20,19 +20,9 @@ import { UsageService } from './usage/usage.service';
 
 const VALID_BILLING_STATUSES = new Set<string>(Object.values(BillingStatus));
 const VALID_INTERVALS = new Set(['monthly', 'yearly']);
-const ORG_LIMITS_CACHE_TTL_MS = 60_000;
 
 @Injectable()
 export class BillingGraphqlService implements IBillingGraphqlService {
-  private readonly orgLimitsCache = new Map<
-    string,
-    {
-      data?: Awaited<ReturnType<IBillingClient['getOrgLimits']>>;
-      expiresAt: number;
-      promise?: Promise<Awaited<ReturnType<IBillingClient['getOrgLimits']>>>;
-    }
-  >();
-
   constructor(
     @Inject(BILLING_CLIENT_TOKEN)
     private readonly billingClient: IBillingClient,
@@ -94,8 +84,7 @@ export class BillingGraphqlService implements IBillingGraphqlService {
 
   async getUsage(organizationId: string): Promise<UsageSummaryResult | null> {
     if (!this.billingClient.configured) return null;
-    const orgLimits =
-      await this.billingClient.getOrgLimits(organizationId);
+    const orgLimits = await this.billingClient.getOrgLimits(organizationId);
 
     return this.usageService.computeUsageSummary(
       organizationId,
@@ -106,19 +95,34 @@ export class BillingGraphqlService implements IBillingGraphqlService {
   async getProjectEndpointUsage(
     organizationId: string,
     projectId: string,
+    options?: { endpointLimit?: number | null },
   ): Promise<UsageMetricResult | null> {
     if (!this.billingClient.configured) {
       return null;
     }
 
-    const orgLimits = await this.getOrgLimitsCached(organizationId);
+    const limit =
+      options && 'endpointLimit' in options
+        ? (options.endpointLimit ?? null)
+        : await this.getProjectEndpointLimit(organizationId);
     const current = await this.usageService.computeUsage(
       organizationId,
       LimitMetric.ENDPOINTS_PER_PROJECT,
       { projectId },
     );
 
-    return buildMetric(current, orgLimits.limits.endpoints_per_project);
+    return buildMetric(current, limit ?? null);
+  }
+
+  async getProjectEndpointLimit(
+    organizationId: string,
+  ): Promise<number | null | undefined> {
+    if (!this.billingClient.configured) {
+      return undefined;
+    }
+
+    const orgLimits = await this.billingClient.getOrgLimits(organizationId);
+    return orgLimits.limits.endpoints_per_project;
   }
 
   async activateEarlyAccess(
@@ -190,36 +194,4 @@ export class BillingGraphqlService implements IBillingGraphqlService {
       throw new BadRequestException(`${field} must be a valid HTTP(S) URL`);
     }
   }
-
-  private async getOrgLimitsCached(organizationId: string) {
-    const cached = this.orgLimitsCache.get(organizationId);
-    if (cached?.data && cached.expiresAt > Date.now()) {
-      return cached.data;
-    }
-    if (cached?.promise) {
-      return cached.promise;
-    }
-
-    const promise = this.billingClient
-      .getOrgLimits(organizationId)
-      .then((data) => {
-        this.orgLimitsCache.set(organizationId, {
-          data,
-          expiresAt: Date.now() + ORG_LIMITS_CACHE_TTL_MS,
-        });
-        return data;
-      })
-      .catch((error) => {
-        this.orgLimitsCache.delete(organizationId);
-        throw error;
-      });
-
-    this.orgLimitsCache.set(organizationId, {
-      expiresAt: 0,
-      promise,
-    });
-
-    return promise;
-  }
-
 }

--- a/ee/billing/early-access/early-access.service.ts
+++ b/ee/billing/early-access/early-access.service.ts
@@ -36,9 +36,6 @@ export class EarlyAccessService {
       ? await this.billingClient.getPlan(subscription.planId)
       : null;
 
-    return this.usageService.computeUsageSummary(
-      organizationId,
-      plan?.limits,
-    );
+    return this.usageService.computeUsageSummary(organizationId, plan?.limits);
   }
 }

--- a/ee/billing/early-access/graphql/models/plan.model.spec.ts
+++ b/ee/billing/early-access/graphql/models/plan.model.spec.ts
@@ -1,0 +1,18 @@
+import { PlanLimitsModel, PlanModel } from './plan.model';
+
+describe('PlanModel', () => {
+  it('supports endpoint limits on the GraphQL model', () => {
+    const limits = new PlanLimitsModel();
+    limits.endpoints_per_project = 10;
+
+    const plan = new PlanModel();
+    plan.id = 'pro';
+    plan.name = 'Pro';
+    plan.isPublic = true;
+    plan.monthlyPriceUsd = 12;
+    plan.yearlyPriceUsd = 120;
+    plan.limits = limits;
+
+    expect(plan.limits.endpoints_per_project).toBe(10);
+  });
+});

--- a/ee/billing/early-access/graphql/models/plan.model.ts
+++ b/ee/billing/early-access/graphql/models/plan.model.ts
@@ -25,6 +25,9 @@ export class PlanLimitsModel {
 
   @Field(() => Int, { nullable: true })
   branches_per_project: number | null;
+
+  @Field(() => Int, { nullable: true })
+  endpoints_per_project: number | null;
 }
 
 @ObjectType()

--- a/ee/billing/limits/limits.service.ts
+++ b/ee/billing/limits/limits.service.ts
@@ -1,5 +1,6 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import {
+  BillingDbClient,
   ILimitsService,
   LimitCheckResult,
   LimitMetric,
@@ -42,6 +43,7 @@ export class LimitsService implements ILimitsService {
     metric: LimitMetric,
     increment: number = 1,
     context?: { revisionId?: string; tableId?: string; projectId?: string },
+    db?: BillingDbClient,
   ): Promise<LimitCheckResult> {
     const orgLimits = await this.getOrgLimits(organizationId);
     if (!orgLimits) return { allowed: true };
@@ -49,7 +51,7 @@ export class LimitsService implements ILimitsService {
     const limit = this.getLimitForMetric(orgLimits, metric);
     if (limit === null || limit === undefined) return { allowed: true };
 
-    const current = await this.getUsage(organizationId, metric, context);
+    const current = await this.getUsage(organizationId, metric, context, db);
     const projected = current + increment;
 
     if (projected > limit) {
@@ -70,9 +72,10 @@ export class LimitsService implements ILimitsService {
     organizationId: string,
     metric: LimitMetric,
     context?: { revisionId?: string; tableId?: string; projectId?: string },
+    db?: BillingDbClient,
   ): Promise<number> {
     if (LimitsService.UNCACHED_METRICS.has(metric)) {
-      return this.usageService.computeUsage(organizationId, metric, context);
+      return this.usageService.computeUsage(organizationId, metric, context, db);
     }
 
     const cacheKey =
@@ -81,7 +84,7 @@ export class LimitsService implements ILimitsService {
         : metric;
 
     return this.billingCache.usage(organizationId, cacheKey, () =>
-      this.usageService.computeUsage(organizationId, metric, context),
+      this.usageService.computeUsage(organizationId, metric, context, db),
     );
   }
 

--- a/ee/billing/limits/limits.service.ts
+++ b/ee/billing/limits/limits.service.ts
@@ -27,6 +27,7 @@ export class LimitsService implements ILimitsService {
     LimitMetric.SEATS,
     LimitMetric.BRANCHES_PER_PROJECT,
     LimitMetric.TABLES_PER_REVISION,
+    LimitMetric.ENDPOINTS_PER_PROJECT,
   ]);
 
   constructor(
@@ -106,6 +107,8 @@ export class LimitsService implements ILimitsService {
         return l.tables_per_revision;
       case LimitMetric.BRANCHES_PER_PROJECT:
         return l.branches_per_project;
+      case LimitMetric.ENDPOINTS_PER_PROJECT:
+        return l.endpoints_per_project;
       default:
         return null;
     }

--- a/ee/billing/limits/limits.service.ts
+++ b/ee/billing/limits/limits.service.ts
@@ -1,6 +1,5 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import {
-  BillingDbClient,
   ILimitsService,
   LimitCheckResult,
   LimitMetric,
@@ -43,7 +42,6 @@ export class LimitsService implements ILimitsService {
     metric: LimitMetric,
     increment: number = 1,
     context?: { revisionId?: string; tableId?: string; projectId?: string },
-    db?: BillingDbClient,
   ): Promise<LimitCheckResult> {
     const orgLimits = await this.getOrgLimits(organizationId);
     if (!orgLimits) return { allowed: true };
@@ -51,7 +49,7 @@ export class LimitsService implements ILimitsService {
     const limit = this.getLimitForMetric(orgLimits, metric);
     if (limit === null || limit === undefined) return { allowed: true };
 
-    const current = await this.getUsage(organizationId, metric, context, db);
+    const current = await this.getUsage(organizationId, metric, context);
     const projected = current + increment;
 
     if (projected > limit) {
@@ -72,10 +70,9 @@ export class LimitsService implements ILimitsService {
     organizationId: string,
     metric: LimitMetric,
     context?: { revisionId?: string; tableId?: string; projectId?: string },
-    db?: BillingDbClient,
   ): Promise<number> {
     if (LimitsService.UNCACHED_METRICS.has(metric)) {
-      return this.usageService.computeUsage(organizationId, metric, context, db);
+      return this.usageService.computeUsage(organizationId, metric, context);
     }
 
     const cacheKey =
@@ -84,7 +81,7 @@ export class LimitsService implements ILimitsService {
         : metric;
 
     return this.billingCache.usage(organizationId, cacheKey, () =>
-      this.usageService.computeUsage(organizationId, metric, context, db),
+      this.usageService.computeUsage(organizationId, metric, context),
     );
   }
 

--- a/ee/billing/usage/usage.service.ts
+++ b/ee/billing/usage/usage.service.ts
@@ -9,6 +9,11 @@ export interface UsageSummary {
   projects: { current: number; limit: number | null; percentage: number | null };
   seats: { current: number; limit: number | null; percentage: number | null };
   storageBytes: { current: number; limit: number | null; percentage: number | null };
+  endpointsPerProject: {
+    current: number;
+    limit: number | null;
+    percentage: number | null;
+  };
 }
 
 @Injectable()
@@ -22,13 +27,16 @@ export class UsageService {
       projects: number | null;
       seats: number | null;
       storage_bytes: number | null;
+      endpoints_per_project: number | null;
     } | null,
   ): Promise<UsageSummary> {
-    const [rowVersions, projects, seats, storageBytes] = await Promise.all([
+    const [rowVersions, projects, seats, storageBytes, endpointsPerProject] =
+      await Promise.all([
       this.computeUsage(organizationId, LimitMetric.ROW_VERSIONS),
       this.computeUsage(organizationId, LimitMetric.PROJECTS),
       this.computeUsage(organizationId, LimitMetric.SEATS),
       this.computeUsage(organizationId, LimitMetric.STORAGE_BYTES),
+      this.countMaxEndpointsInProjects(organizationId),
     ]);
 
     return {
@@ -36,6 +44,10 @@ export class UsageService {
       projects: buildMetric(projects, planLimits?.projects),
       seats: buildMetric(seats, planLimits?.seats),
       storageBytes: buildMetric(storageBytes, planLimits?.storage_bytes),
+      endpointsPerProject: buildMetric(
+        endpointsPerProject,
+        planLimits?.endpoints_per_project,
+      ),
     };
   }
 
@@ -72,6 +84,12 @@ export class UsageService {
           throw new Error('BRANCHES_PER_PROJECT requires projectId in context');
         }
         return this.countBranchesInProject(context.projectId);
+      }
+      case LimitMetric.ENDPOINTS_PER_PROJECT: {
+        if (!context?.projectId) {
+          throw new Error('ENDPOINTS_PER_PROJECT requires projectId in context');
+        }
+        return this.countEndpointsInProject(context.projectId);
       }
       default: {
         const _exhaustive: never = metric;
@@ -140,5 +158,38 @@ export class UsageService {
 
   private async countBranchesInProject(projectId: string): Promise<number> {
     return this.prisma.branch.count({ where: { projectId } });
+  }
+
+  private async countEndpointsInProject(projectId: string): Promise<number> {
+    return this.prisma.endpoint.count({
+      where: {
+        revision: { branch: { projectId } },
+        isDeleted: false,
+      },
+    });
+  }
+
+  private async countMaxEndpointsInProjects(
+    organizationId: string,
+  ): Promise<number> {
+    const projects = await this.prisma.project.findMany({
+      where: {
+        organizationId,
+        isDeleted: false,
+      },
+      select: {
+        id: true,
+      },
+    });
+
+    if (projects.length === 0) {
+      return 0;
+    }
+
+    const counts = await Promise.all(
+      projects.map(({ id }) => this.countEndpointsInProject(id)),
+    );
+
+    return Math.max(...counts);
   }
 }

--- a/ee/billing/usage/usage.service.ts
+++ b/ee/billing/usage/usage.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { Prisma } from 'src/__generated__/client';
+import { BillingDbClient } from 'src/features/billing/limits.interface';
 import { countOrgRowVersions } from 'src/__generated__/client/sql';
 import { LimitMetric } from 'src/features/billing/limits.interface';
 import { PrismaService } from 'src/infrastructure/database/prisma.service';
@@ -30,14 +31,35 @@ export class UsageService {
       storage_bytes: number | null;
       endpoints_per_project: number | null;
     } | null,
+    db: BillingDbClient = this.prisma,
   ): Promise<UsageSummary> {
     const [rowVersions, projects, seats, storageBytes, endpointsPerProject] =
       await Promise.all([
-        this.computeUsage(organizationId, LimitMetric.ROW_VERSIONS),
-        this.computeUsage(organizationId, LimitMetric.PROJECTS),
-        this.computeUsage(organizationId, LimitMetric.SEATS),
-        this.computeUsage(organizationId, LimitMetric.STORAGE_BYTES),
-        this.countMaxEndpointsInProjects(organizationId),
+        this.computeUsage(
+          organizationId,
+          LimitMetric.ROW_VERSIONS,
+          undefined,
+          db,
+        ),
+        this.computeUsage(
+          organizationId,
+          LimitMetric.PROJECTS,
+          undefined,
+          db,
+        ),
+        this.computeUsage(
+          organizationId,
+          LimitMetric.SEATS,
+          undefined,
+          db,
+        ),
+        this.computeUsage(
+          organizationId,
+          LimitMetric.STORAGE_BYTES,
+          undefined,
+          db,
+        ),
+        this.countMaxEndpointsInProjects(organizationId, db),
       ]);
 
     return {
@@ -56,14 +78,15 @@ export class UsageService {
     organizationId: string,
     metric: LimitMetric,
     context?: { revisionId?: string; tableId?: string; projectId?: string },
+    db: BillingDbClient = this.prisma,
   ): Promise<number> {
     switch (metric) {
       case LimitMetric.ROW_VERSIONS:
-        return this.countRowVersions(organizationId);
+        return this.countRowVersions(organizationId, db);
       case LimitMetric.PROJECTS:
-        return this.countProjects(organizationId);
+        return this.countProjects(organizationId, db);
       case LimitMetric.SEATS:
-        return this.countSeats(organizationId);
+        return this.countSeats(organizationId, db);
       case LimitMetric.STORAGE_BYTES:
         return this.countStorageBytes(organizationId);
       case LimitMetric.API_CALLS:
@@ -72,25 +95,25 @@ export class UsageService {
         if (!context?.revisionId || !context?.tableId) {
           throw new Error('ROWS_PER_TABLE requires revisionId and tableId in context');
         }
-        return this.countRowsInTable(context.revisionId, context.tableId);
+        return this.countRowsInTable(context.revisionId, context.tableId, db);
       }
       case LimitMetric.TABLES_PER_REVISION: {
         if (!context?.projectId) {
           throw new Error('TABLES_PER_REVISION requires projectId in context');
         }
-        return this.countTablesInRevision(context.projectId);
+        return this.countTablesInRevision(context.projectId, db);
       }
       case LimitMetric.BRANCHES_PER_PROJECT: {
         if (!context?.projectId) {
           throw new Error('BRANCHES_PER_PROJECT requires projectId in context');
         }
-        return this.countBranchesInProject(context.projectId);
+        return this.countBranchesInProject(context.projectId, db);
       }
       case LimitMetric.ENDPOINTS_PER_PROJECT: {
         if (!context?.projectId) {
           throw new Error('ENDPOINTS_PER_PROJECT requires projectId in context');
         }
-        return this.countEndpointsInProject(context.projectId);
+        return this.countEndpointsInProject(context.projectId, db);
       }
       default: {
         const _exhaustive: never = metric;
@@ -103,21 +126,30 @@ export class UsageService {
    * Count UNIQUE row versions across all revisions in all projects of the org.
    * Copy-on-write: unchanged rows share versionId - counted once.
    */
-  private async countRowVersions(organizationId: string): Promise<number> {
-    const result = await this.prisma.$queryRawTyped(
+  private async countRowVersions(
+    organizationId: string,
+    db: BillingDbClient,
+  ): Promise<number> {
+    const result = await db.$queryRawTyped(
       countOrgRowVersions(organizationId),
     );
     return Number(result[0].count);
   }
 
-  private async countProjects(organizationId: string): Promise<number> {
-    return this.prisma.project.count({
+  private async countProjects(
+    organizationId: string,
+    db: BillingDbClient,
+  ): Promise<number> {
+    return db.project.count({
       where: { organizationId, isDeleted: false },
     });
   }
 
-  private async countSeats(organizationId: string): Promise<number> {
-    return this.prisma.userOrganization.count({
+  private async countSeats(
+    organizationId: string,
+    db: BillingDbClient,
+  ): Promise<number> {
+    return db.userOrganization.count({
       where: { organizationId },
     });
   }
@@ -135,8 +167,9 @@ export class UsageService {
   private async countRowsInTable(
     revisionId: string,
     tableId: string,
+    db: BillingDbClient,
   ): Promise<number> {
-    const table = await this.prisma.table.findFirst({
+    const table = await db.table.findFirst({
       where: {
         id: tableId,
         revisions: { some: { id: revisionId } },
@@ -146,8 +179,11 @@ export class UsageService {
     return table?._count.rows ?? 0;
   }
 
-  private async countTablesInRevision(projectId: string): Promise<number> {
-    const revision = await this.prisma.revision.findFirst({
+  private async countTablesInRevision(
+    projectId: string,
+    db: BillingDbClient,
+  ): Promise<number> {
+    const revision = await db.revision.findFirst({
       where: {
         isDraft: true,
         branch: { projectId, isRoot: true },
@@ -157,12 +193,18 @@ export class UsageService {
     return revision?._count.tables ?? 0;
   }
 
-  private async countBranchesInProject(projectId: string): Promise<number> {
-    return this.prisma.branch.count({ where: { projectId } });
+  private async countBranchesInProject(
+    projectId: string,
+    db: BillingDbClient,
+  ): Promise<number> {
+    return db.branch.count({ where: { projectId } });
   }
 
-  private async countEndpointsInProject(projectId: string): Promise<number> {
-    return this.prisma.endpoint.count({
+  private async countEndpointsInProject(
+    projectId: string,
+    db: BillingDbClient,
+  ): Promise<number> {
+    return db.endpoint.count({
       where: {
         revision: { branch: { projectId } },
         isDeleted: false,
@@ -172,8 +214,9 @@ export class UsageService {
 
   private async countMaxEndpointsInProjects(
     organizationId: string,
+    db: BillingDbClient,
   ): Promise<number> {
-    const result = await this.prisma.$queryRaw<Array<{ maxCount: bigint | number }>>(
+    const result = await db.$queryRaw<Array<{ maxCount: bigint | number }>>(
       Prisma.sql`
         SELECT COALESCE(MAX(project_counts.count), 0)::bigint AS "maxCount"
         FROM (

--- a/ee/billing/usage/usage.service.ts
+++ b/ee/billing/usage/usage.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { Prisma } from 'src/__generated__/client';
 import { countOrgRowVersions } from 'src/__generated__/client/sql';
 import { LimitMetric } from 'src/features/billing/limits.interface';
 import { PrismaService } from 'src/infrastructure/database/prisma.service';
@@ -32,12 +33,12 @@ export class UsageService {
   ): Promise<UsageSummary> {
     const [rowVersions, projects, seats, storageBytes, endpointsPerProject] =
       await Promise.all([
-      this.computeUsage(organizationId, LimitMetric.ROW_VERSIONS),
-      this.computeUsage(organizationId, LimitMetric.PROJECTS),
-      this.computeUsage(organizationId, LimitMetric.SEATS),
-      this.computeUsage(organizationId, LimitMetric.STORAGE_BYTES),
-      this.countMaxEndpointsInProjects(organizationId),
-    ]);
+        this.computeUsage(organizationId, LimitMetric.ROW_VERSIONS),
+        this.computeUsage(organizationId, LimitMetric.PROJECTS),
+        this.computeUsage(organizationId, LimitMetric.SEATS),
+        this.computeUsage(organizationId, LimitMetric.STORAGE_BYTES),
+        this.countMaxEndpointsInProjects(organizationId),
+      ]);
 
     return {
       rowVersions: buildMetric(rowVersions, planLimits?.row_versions),
@@ -172,24 +173,26 @@ export class UsageService {
   private async countMaxEndpointsInProjects(
     organizationId: string,
   ): Promise<number> {
-    const projects = await this.prisma.project.findMany({
-      where: {
-        organizationId,
-        isDeleted: false,
-      },
-      select: {
-        id: true,
-      },
-    });
-
-    if (projects.length === 0) {
-      return 0;
-    }
-
-    const counts = await Promise.all(
-      projects.map(({ id }) => this.countEndpointsInProject(id)),
+    const result = await this.prisma.$queryRaw<Array<{ maxCount: bigint | number }>>(
+      Prisma.sql`
+        SELECT COALESCE(MAX(project_counts.count), 0)::bigint AS "maxCount"
+        FROM (
+          SELECT COUNT(e."id")::bigint AS count
+          FROM "Project" p
+          LEFT JOIN "Branch" b
+            ON b."projectId" = p."id"
+          LEFT JOIN "Revision" r
+            ON r."branchId" = b."id"
+          LEFT JOIN "Endpoint" e
+            ON e."revisionId" = r."id"
+           AND e."isDeleted" = false
+          WHERE p."organizationId" = ${organizationId}
+            AND p."isDeleted" = false
+          GROUP BY p."id"
+        ) AS project_counts
+      `,
     );
 
-    return Math.max(...counts);
+    return Number(result[0]?.maxCount ?? 0);
   }
 }

--- a/ee/billing/usage/usage.service.ts
+++ b/ee/billing/usage/usage.service.ts
@@ -1,5 +1,4 @@
 import { Injectable } from '@nestjs/common';
-import { Prisma } from 'src/__generated__/client';
 import { countOrgRowVersions } from 'src/__generated__/client/sql';
 import { LimitMetric } from 'src/features/billing/limits.interface';
 import { PrismaService } from 'src/infrastructure/database/prisma.service';
@@ -19,11 +18,6 @@ export interface UsageSummary {
   };
   seats: { current: number; limit: number | null; percentage: number | null };
   storageBytes: {
-    current: number;
-    limit: number | null;
-    percentage: number | null;
-  };
-  endpointsPerProject: {
     current: number;
     limit: number | null;
     percentage: number | null;
@@ -48,27 +42,20 @@ export class UsageService {
       projects: number | null;
       seats: number | null;
       storage_bytes: number | null;
-      endpoints_per_project: number | null;
     } | null,
   ): Promise<UsageSummary> {
-    const [rowVersions, projects, seats, storageBytes, endpointsPerProject] =
-      await Promise.all([
-        this.computeUsage(organizationId, LimitMetric.ROW_VERSIONS),
-        this.computeUsage(organizationId, LimitMetric.PROJECTS),
-        this.computeUsage(organizationId, LimitMetric.SEATS),
-        this.computeUsage(organizationId, LimitMetric.STORAGE_BYTES),
-        this.countMaxEndpointsInProjects(organizationId),
-      ]);
+    const [rowVersions, projects, seats, storageBytes] = await Promise.all([
+      this.computeUsage(organizationId, LimitMetric.ROW_VERSIONS),
+      this.computeUsage(organizationId, LimitMetric.PROJECTS),
+      this.computeUsage(organizationId, LimitMetric.SEATS),
+      this.computeUsage(organizationId, LimitMetric.STORAGE_BYTES),
+    ]);
 
     return {
       rowVersions: buildMetric(rowVersions, planLimits?.row_versions),
       projects: buildMetric(projects, planLimits?.projects),
       seats: buildMetric(seats, planLimits?.seats),
       storageBytes: buildMetric(storageBytes, planLimits?.storage_bytes),
-      endpointsPerProject: buildMetric(
-        endpointsPerProject,
-        planLimits?.endpoints_per_project,
-      ),
     };
   }
 
@@ -192,33 +179,5 @@ export class UsageService {
         isDeleted: false,
       },
     });
-  }
-
-  private async countMaxEndpointsInProjects(
-    organizationId: string,
-  ): Promise<number> {
-    const result = await this.db.$queryRaw<
-      Array<{ maxCount: bigint | number }>
-    >(
-      Prisma.sql`
-        SELECT COALESCE(MAX(project_counts.count), 0)::bigint AS "maxCount"
-        FROM (
-          SELECT COUNT(e."id")::bigint AS count
-          FROM "Project" p
-          LEFT JOIN "Branch" b
-            ON b."projectId" = p."id"
-          LEFT JOIN "Revision" r
-            ON r."branchId" = b."id"
-          LEFT JOIN "Endpoint" e
-            ON e."revisionId" = r."id"
-           AND e."isDeleted" = false
-          WHERE p."organizationId" = ${organizationId}
-            AND p."isDeleted" = false
-          GROUP BY p."id"
-        ) AS project_counts
-      `,
-    );
-
-    return Number(result[0]?.maxCount ?? 0);
   }
 }

--- a/ee/billing/usage/usage.service.ts
+++ b/ee/billing/usage/usage.service.ts
@@ -1,16 +1,28 @@
 import { Injectable } from '@nestjs/common';
 import { Prisma } from 'src/__generated__/client';
-import { BillingDbClient } from 'src/features/billing/limits.interface';
 import { countOrgRowVersions } from 'src/__generated__/client/sql';
 import { LimitMetric } from 'src/features/billing/limits.interface';
 import { PrismaService } from 'src/infrastructure/database/prisma.service';
+import { TransactionPrismaService } from 'src/infrastructure/database/transaction-prisma.service';
 import { buildMetric } from './build-metric';
 
 export interface UsageSummary {
-  rowVersions: { current: number; limit: number | null; percentage: number | null };
-  projects: { current: number; limit: number | null; percentage: number | null };
+  rowVersions: {
+    current: number;
+    limit: number | null;
+    percentage: number | null;
+  };
+  projects: {
+    current: number;
+    limit: number | null;
+    percentage: number | null;
+  };
   seats: { current: number; limit: number | null; percentage: number | null };
-  storageBytes: { current: number; limit: number | null; percentage: number | null };
+  storageBytes: {
+    current: number;
+    limit: number | null;
+    percentage: number | null;
+  };
   endpointsPerProject: {
     current: number;
     limit: number | null;
@@ -20,7 +32,14 @@ export interface UsageSummary {
 
 @Injectable()
 export class UsageService {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly transactionService: TransactionPrismaService,
+  ) {}
+
+  private get db() {
+    return this.transactionService.getTransactionOrPrisma();
+  }
 
   async computeUsageSummary(
     organizationId: string,
@@ -31,35 +50,14 @@ export class UsageService {
       storage_bytes: number | null;
       endpoints_per_project: number | null;
     } | null,
-    db: BillingDbClient = this.prisma,
   ): Promise<UsageSummary> {
     const [rowVersions, projects, seats, storageBytes, endpointsPerProject] =
       await Promise.all([
-        this.computeUsage(
-          organizationId,
-          LimitMetric.ROW_VERSIONS,
-          undefined,
-          db,
-        ),
-        this.computeUsage(
-          organizationId,
-          LimitMetric.PROJECTS,
-          undefined,
-          db,
-        ),
-        this.computeUsage(
-          organizationId,
-          LimitMetric.SEATS,
-          undefined,
-          db,
-        ),
-        this.computeUsage(
-          organizationId,
-          LimitMetric.STORAGE_BYTES,
-          undefined,
-          db,
-        ),
-        this.countMaxEndpointsInProjects(organizationId, db),
+        this.computeUsage(organizationId, LimitMetric.ROW_VERSIONS),
+        this.computeUsage(organizationId, LimitMetric.PROJECTS),
+        this.computeUsage(organizationId, LimitMetric.SEATS),
+        this.computeUsage(organizationId, LimitMetric.STORAGE_BYTES),
+        this.countMaxEndpointsInProjects(organizationId),
       ]);
 
     return {
@@ -78,42 +76,45 @@ export class UsageService {
     organizationId: string,
     metric: LimitMetric,
     context?: { revisionId?: string; tableId?: string; projectId?: string },
-    db: BillingDbClient = this.prisma,
   ): Promise<number> {
     switch (metric) {
       case LimitMetric.ROW_VERSIONS:
-        return this.countRowVersions(organizationId, db);
+        return this.countRowVersions(organizationId);
       case LimitMetric.PROJECTS:
-        return this.countProjects(organizationId, db);
+        return this.countProjects(organizationId);
       case LimitMetric.SEATS:
-        return this.countSeats(organizationId, db);
+        return this.countSeats(organizationId);
       case LimitMetric.STORAGE_BYTES:
         return this.countStorageBytes(organizationId);
       case LimitMetric.API_CALLS:
         return this.countApiCalls(organizationId);
       case LimitMetric.ROWS_PER_TABLE: {
         if (!context?.revisionId || !context?.tableId) {
-          throw new Error('ROWS_PER_TABLE requires revisionId and tableId in context');
+          throw new Error(
+            'ROWS_PER_TABLE requires revisionId and tableId in context',
+          );
         }
-        return this.countRowsInTable(context.revisionId, context.tableId, db);
+        return this.countRowsInTable(context.revisionId, context.tableId);
       }
       case LimitMetric.TABLES_PER_REVISION: {
         if (!context?.projectId) {
           throw new Error('TABLES_PER_REVISION requires projectId in context');
         }
-        return this.countTablesInRevision(context.projectId, db);
+        return this.countTablesInRevision(context.projectId);
       }
       case LimitMetric.BRANCHES_PER_PROJECT: {
         if (!context?.projectId) {
           throw new Error('BRANCHES_PER_PROJECT requires projectId in context');
         }
-        return this.countBranchesInProject(context.projectId, db);
+        return this.countBranchesInProject(context.projectId);
       }
       case LimitMetric.ENDPOINTS_PER_PROJECT: {
         if (!context?.projectId) {
-          throw new Error('ENDPOINTS_PER_PROJECT requires projectId in context');
+          throw new Error(
+            'ENDPOINTS_PER_PROJECT requires projectId in context',
+          );
         }
-        return this.countEndpointsInProject(context.projectId, db);
+        return this.countEndpointsInProject(context.projectId);
       }
       default: {
         const _exhaustive: never = metric;
@@ -126,30 +127,21 @@ export class UsageService {
    * Count UNIQUE row versions across all revisions in all projects of the org.
    * Copy-on-write: unchanged rows share versionId - counted once.
    */
-  private async countRowVersions(
-    organizationId: string,
-    db: BillingDbClient,
-  ): Promise<number> {
-    const result = await db.$queryRawTyped(
+  private async countRowVersions(organizationId: string): Promise<number> {
+    const result = await this.db.$queryRawTyped(
       countOrgRowVersions(organizationId),
     );
     return Number(result[0].count);
   }
 
-  private async countProjects(
-    organizationId: string,
-    db: BillingDbClient,
-  ): Promise<number> {
-    return db.project.count({
+  private async countProjects(organizationId: string): Promise<number> {
+    return this.db.project.count({
       where: { organizationId, isDeleted: false },
     });
   }
 
-  private async countSeats(
-    organizationId: string,
-    db: BillingDbClient,
-  ): Promise<number> {
-    return db.userOrganization.count({
+  private async countSeats(organizationId: string): Promise<number> {
+    return this.db.userOrganization.count({
       where: { organizationId },
     });
   }
@@ -167,9 +159,8 @@ export class UsageService {
   private async countRowsInTable(
     revisionId: string,
     tableId: string,
-    db: BillingDbClient,
   ): Promise<number> {
-    const table = await db.table.findFirst({
+    const table = await this.db.table.findFirst({
       where: {
         id: tableId,
         revisions: { some: { id: revisionId } },
@@ -179,11 +170,8 @@ export class UsageService {
     return table?._count.rows ?? 0;
   }
 
-  private async countTablesInRevision(
-    projectId: string,
-    db: BillingDbClient,
-  ): Promise<number> {
-    const revision = await db.revision.findFirst({
+  private async countTablesInRevision(projectId: string): Promise<number> {
+    const revision = await this.db.revision.findFirst({
       where: {
         isDraft: true,
         branch: { projectId, isRoot: true },
@@ -193,18 +181,12 @@ export class UsageService {
     return revision?._count.tables ?? 0;
   }
 
-  private async countBranchesInProject(
-    projectId: string,
-    db: BillingDbClient,
-  ): Promise<number> {
-    return db.branch.count({ where: { projectId } });
+  private async countBranchesInProject(projectId: string): Promise<number> {
+    return this.db.branch.count({ where: { projectId } });
   }
 
-  private async countEndpointsInProject(
-    projectId: string,
-    db: BillingDbClient,
-  ): Promise<number> {
-    return db.endpoint.count({
+  private async countEndpointsInProject(projectId: string): Promise<number> {
+    return this.db.endpoint.count({
       where: {
         revision: { branch: { projectId } },
         isDeleted: false,
@@ -214,9 +196,10 @@ export class UsageService {
 
   private async countMaxEndpointsInProjects(
     organizationId: string,
-    db: BillingDbClient,
   ): Promise<number> {
-    const result = await db.$queryRaw<Array<{ maxCount: bigint | number }>>(
+    const result = await this.db.$queryRaw<
+      Array<{ maxCount: bigint | number }>
+    >(
       Prisma.sql`
         SELECT COALESCE(MAX(project_counts.count), 0)::bigint AS "maxCount"
         FROM (

--- a/src/api/graphql-api/billing/models/plan.model.ts
+++ b/src/api/graphql-api/billing/models/plan.model.ts
@@ -26,6 +26,9 @@ export class PlanLimitsModel {
 
   @Field(() => Int, { nullable: true })
   branchesPerProject: number | null;
+
+  @Field(() => Int, { nullable: true })
+  endpointsPerProject: number | null;
 }
 
 @ObjectType()

--- a/src/api/graphql-api/billing/models/usage.model.ts
+++ b/src/api/graphql-api/billing/models/usage.model.ts
@@ -25,7 +25,4 @@ export class UsageSummaryModel {
 
   @Field(() => UsageMetricModel)
   storageBytes: UsageMetricModel;
-
-  @Field(() => UsageMetricModel)
-  endpointsPerProject: UsageMetricModel;
 }

--- a/src/api/graphql-api/billing/models/usage.model.ts
+++ b/src/api/graphql-api/billing/models/usage.model.ts
@@ -25,4 +25,7 @@ export class UsageSummaryModel {
 
   @Field(() => UsageMetricModel)
   storageBytes: UsageMetricModel;
+
+  @Field(() => UsageMetricModel)
+  endpointsPerProject: UsageMetricModel;
 }

--- a/src/api/graphql-api/project/__tests__/project.resolver.spec.ts
+++ b/src/api/graphql-api/project/__tests__/project.resolver.spec.ts
@@ -1,0 +1,34 @@
+import { ProjectResolver } from '../project.resolver';
+
+describe('ProjectResolver', () => {
+  it('delegates endpoint usage lookup to the billing service', async () => {
+    const billingService = {
+      getProjectEndpointUsage: jest.fn().mockResolvedValue({
+        current: 2,
+        limit: 10,
+        percentage: 20,
+      }),
+    };
+    const resolver = new ProjectResolver(
+      {} as never,
+      {} as never,
+      {} as never,
+      billingService as never,
+    );
+
+    await expect(
+      resolver.endpointUsage({
+        id: 'project-1',
+        organizationId: 'org-1',
+      } as never),
+    ).resolves.toEqual({
+      current: 2,
+      limit: 10,
+      percentage: 20,
+    });
+    expect(billingService.getProjectEndpointUsage).toHaveBeenCalledWith(
+      'org-1',
+      'project-1',
+    );
+  });
+});

--- a/src/api/graphql-api/project/__tests__/project.resolver.spec.ts
+++ b/src/api/graphql-api/project/__tests__/project.resolver.spec.ts
@@ -3,6 +3,7 @@ import { ProjectResolver } from '../project.resolver';
 describe('ProjectResolver', () => {
   it('delegates endpoint usage lookup to the billing service', async () => {
     const billingService = {
+      getProjectEndpointLimit: jest.fn().mockResolvedValue(10),
       getProjectEndpointUsage: jest.fn().mockResolvedValue({
         current: 2,
         limit: 10,
@@ -17,18 +18,58 @@ describe('ProjectResolver', () => {
     );
 
     await expect(
-      resolver.endpointUsage({
-        id: 'project-1',
-        organizationId: 'org-1',
-      } as never),
+      resolver.endpointUsage(
+        {
+          id: 'project-1',
+          organizationId: 'org-1',
+        } as never,
+        {},
+      ),
     ).resolves.toEqual({
       current: 2,
       limit: 10,
       percentage: 20,
     });
+    expect(billingService.getProjectEndpointLimit).toHaveBeenCalledWith(
+      'org-1',
+    );
     expect(billingService.getProjectEndpointUsage).toHaveBeenCalledWith(
       'org-1',
       'project-1',
+      { endpointLimit: 10 },
+    );
+  });
+
+  it('memoizes endpoint limits per organization in the request context', async () => {
+    const ctx = {};
+    const billingService = {
+      getProjectEndpointLimit: jest.fn().mockResolvedValue(10),
+      getProjectEndpointUsage: jest
+        .fn()
+        .mockResolvedValue({ current: 1, limit: 10, percentage: 10 }),
+    };
+    const resolver = new ProjectResolver(
+      {} as never,
+      {} as never,
+      {} as never,
+      billingService as never,
+    );
+
+    await resolver.endpointUsage(
+      { id: 'project-1', organizationId: 'org-1' } as never,
+      ctx as never,
+    );
+    await resolver.endpointUsage(
+      { id: 'project-2', organizationId: 'org-1' } as never,
+      ctx as never,
+    );
+
+    expect(billingService.getProjectEndpointLimit).toHaveBeenCalledTimes(1);
+    expect(billingService.getProjectEndpointUsage).toHaveBeenNthCalledWith(
+      2,
+      'org-1',
+      'project-2',
+      { endpointLimit: 10 },
     );
   });
 });

--- a/src/api/graphql-api/project/model/project.model.ts
+++ b/src/api/graphql-api/project/model/project.model.ts
@@ -7,6 +7,7 @@ import {
 import { OrganizationModel } from 'src/api/graphql-api/organization/model/organization.model';
 import { UsersProjectModel } from 'src/api/graphql-api/project/model/users-project.model';
 import { Relation } from 'src/api/graphql-api/share/model/relation.type';
+import { UsageMetricModel } from 'src/api/graphql-api/billing/models/usage.model';
 
 @ObjectType()
 export class ProjectModel {
@@ -36,4 +37,7 @@ export class ProjectModel {
 
   @Field(() => UsersProjectModel, { nullable: true })
   userProject?: UsersProjectModel;
+
+  @Field(() => UsageMetricModel, { nullable: true })
+  endpointUsage?: Relation<UsageMetricModel | null>;
 }

--- a/src/api/graphql-api/project/project.resolver.ts
+++ b/src/api/graphql-api/project/project.resolver.ts
@@ -182,9 +182,7 @@ export class ProjectResolver {
     organizationId: string,
     ctx: ProjectResolverContext,
   ) {
-    if (!ctx.endpointUsageLimitByOrg) {
-      ctx.endpointUsageLimitByOrg = new Map();
-    }
+    ctx.endpointUsageLimitByOrg ??= new Map();
 
     const existing = ctx.endpointUsageLimitByOrg.get(organizationId);
     if (existing) {

--- a/src/api/graphql-api/project/project.resolver.ts
+++ b/src/api/graphql-api/project/project.resolver.ts
@@ -1,4 +1,4 @@
-import { UseGuards } from '@nestjs/common';
+import { Inject, UseGuards } from '@nestjs/common';
 import {
   Args,
   Mutation,
@@ -23,12 +23,17 @@ import {
   UpdateUserProjectRoleInput,
 } from 'src/api/graphql-api/project/inputs';
 import { GetProjectBranchesInput } from 'src/api/graphql-api/project/inputs/get-project-branches.input';
+import { UsageMetricModel } from 'src/api/graphql-api/billing/models/usage.model';
 import { ProjectModel } from 'src/api/graphql-api/project/model';
 import { UsersProjectConnection } from 'src/api/graphql-api/project/model/users-project.connection';
 import { IOptionalAuthUser } from 'src/features/auth/types';
 import { OrganizationApiService } from 'src/features/organization/organization-api.service';
 import { ProjectApiService } from 'src/features/project/project-api.service';
 import { UserApiService } from 'src/features/user/user-api.service';
+import {
+  BILLING_GRAPHQL_SERVICE_TOKEN,
+  IBillingGraphqlService,
+} from 'src/features/billing/billing-graphql.interface';
 
 @PermissionParams({
   action: PermissionAction.read,
@@ -40,6 +45,8 @@ export class ProjectResolver {
     private readonly projectApi: ProjectApiService,
     private readonly organizationApi: OrganizationApiService,
     private readonly userApi: UserApiService,
+    @Inject(BILLING_GRAPHQL_SERVICE_TOKEN)
+    private readonly billingService: IBillingGraphqlService,
   ) {}
 
   @UseGuards(OptionalGqlJwtAuthGuard, GQLProjectGuard)
@@ -143,5 +150,13 @@ export class ProjectResolver {
       projectId: parent.id,
       userId: user.userId,
     });
+  }
+
+  @ResolveField(() => UsageMetricModel, { nullable: true })
+  endpointUsage(@Parent() parent: ProjectModel) {
+    return this.billingService.getProjectEndpointUsage(
+      parent.organizationId,
+      parent.id,
+    );
   }
 }

--- a/src/api/graphql-api/project/project.resolver.ts
+++ b/src/api/graphql-api/project/project.resolver.ts
@@ -1,6 +1,7 @@
 import { Inject, UseGuards } from '@nestjs/common';
 import {
   Args,
+  Context,
   Mutation,
   Parent,
   Query,
@@ -34,6 +35,10 @@ import {
   BILLING_GRAPHQL_SERVICE_TOKEN,
   IBillingGraphqlService,
 } from 'src/features/billing/billing-graphql.interface';
+
+type ProjectResolverContext = {
+  endpointUsageLimitByOrg?: Map<string, Promise<number | null | undefined>>;
+};
 
 @PermissionParams({
   action: PermissionAction.read,
@@ -153,10 +158,43 @@ export class ProjectResolver {
   }
 
   @ResolveField(() => UsageMetricModel, { nullable: true })
-  endpointUsage(@Parent() parent: ProjectModel) {
+  async endpointUsage(
+    @Parent() parent: ProjectModel,
+    @Context() ctx: ProjectResolverContext,
+  ) {
+    const endpointLimit = await this.getEndpointUsageLimitForOrganization(
+      parent.organizationId,
+      ctx,
+    );
+
+    if (endpointLimit === undefined) {
+      return null;
+    }
+
     return this.billingService.getProjectEndpointUsage(
       parent.organizationId,
       parent.id,
+      { endpointLimit },
     );
+  }
+
+  private getEndpointUsageLimitForOrganization(
+    organizationId: string,
+    ctx: ProjectResolverContext,
+  ) {
+    if (!ctx.endpointUsageLimitByOrg) {
+      ctx.endpointUsageLimitByOrg = new Map();
+    }
+
+    const existing = ctx.endpointUsageLimitByOrg.get(organizationId);
+    if (existing) {
+      return existing;
+    }
+
+    const limitPromise =
+      this.billingService.getProjectEndpointLimit(organizationId);
+    ctx.endpointUsageLimitByOrg.set(organizationId, limitPromise);
+
+    return limitPromise;
   }
 }

--- a/src/api/graphql-api/schema.graphql
+++ b/src/api/graphql-api/schema.graphql
@@ -1487,7 +1487,6 @@ type UsageMetricModel {
 }
 
 type UsageSummaryModel {
-  endpointsPerProject: UsageMetricModel!
   projects: UsageMetricModel!
   rowVersions: UsageMetricModel!
   seats: UsageMetricModel!

--- a/src/api/graphql-api/schema.graphql
+++ b/src/api/graphql-api/schema.graphql
@@ -833,6 +833,7 @@ type PermissionModel {
 type PlanLimitsModel {
   apiCallsPerDay: Int
   branchesPerProject: Int
+  endpointsPerProject: Int
   projects: Int
   rowVersions: Int
   rowsPerTable: Int
@@ -858,6 +859,7 @@ type PluginsModel {
 type ProjectModel {
   allBranches(data: GetProjectBranchesInput!): BranchesConnection!
   createdAt: DateTime!
+  endpointUsage: UsageMetricModel
   id: String!
   isPublic: Boolean!
   name: String!
@@ -1485,6 +1487,7 @@ type UsageMetricModel {
 }
 
 type UsageSummaryModel {
+  endpointsPerProject: UsageMetricModel!
   projects: UsageMetricModel!
   rowVersions: UsageMetricModel!
   seats: UsageMetricModel!

--- a/src/core/shared/__tests__/billing-check.service.spec.ts
+++ b/src/core/shared/__tests__/billing-check.service.spec.ts
@@ -1,0 +1,114 @@
+import { Test } from '@nestjs/testing';
+import { BillingCheckService } from '../billing-check.service';
+import {
+  ILimitsService,
+  LIMITS_SERVICE_TOKEN,
+  LimitMetric,
+} from 'src/features/billing/limits.interface';
+import { PrismaService } from 'src/infrastructure/database/prisma.service';
+import { LimitExceededException } from 'src/features/billing/limit-exceeded.exception';
+
+describe('BillingCheckService', () => {
+  let service: BillingCheckService;
+  let prisma: {
+    revision: {
+      findUniqueOrThrow: jest.Mock;
+    };
+  };
+  let limitsService: jest.Mocked<ILimitsService>;
+
+  beforeEach(async () => {
+    prisma = {
+      revision: {
+        findUniqueOrThrow: jest.fn().mockResolvedValue({
+          branch: {
+            project: {
+              id: 'project-1',
+              organizationId: 'org-1',
+            },
+          },
+        }),
+      },
+    };
+    limitsService = {
+      checkLimit: jest.fn().mockResolvedValue({ allowed: true }),
+    };
+
+    const module = await Test.createTestingModule({
+      providers: [
+        BillingCheckService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: LIMITS_SERVICE_TOKEN, useValue: limitsService },
+      ],
+    }).compile();
+
+    service = module.get(BillingCheckService);
+  });
+
+  it('adds resolved project context for endpoints-per-project checks', async () => {
+    await service.check('revision-1', LimitMetric.ENDPOINTS_PER_PROJECT, 1);
+
+    expect(prisma.revision.findUniqueOrThrow).toHaveBeenCalledWith({
+      where: { id: 'revision-1' },
+      select: {
+        branch: {
+          select: {
+            project: {
+              select: { id: true, organizationId: true },
+            },
+          },
+        },
+      },
+    });
+    expect(limitsService.checkLimit).toHaveBeenCalledWith(
+      'org-1',
+      LimitMetric.ENDPOINTS_PER_PROJECT,
+      1,
+      {
+        revisionId: 'revision-1',
+        projectId: 'project-1',
+      },
+    );
+  });
+
+  it('passes through explicit context while preserving resolved project id', async () => {
+    await service.check('revision-1', LimitMetric.ENDPOINTS_PER_PROJECT, 2, {
+      tableId: 'table-1',
+    });
+
+    expect(limitsService.checkLimit).toHaveBeenCalledWith(
+      'org-1',
+      LimitMetric.ENDPOINTS_PER_PROJECT,
+      2,
+      {
+        revisionId: 'revision-1',
+        projectId: 'project-1',
+        tableId: 'table-1',
+      },
+    );
+  });
+
+  it('does not inject project context for org-scoped metrics', async () => {
+    await service.check('revision-1', LimitMetric.PROJECTS);
+
+    expect(limitsService.checkLimit).toHaveBeenCalledWith(
+      'org-1',
+      LimitMetric.PROJECTS,
+      undefined,
+      undefined,
+    );
+  });
+
+  it('throws LimitExceededException when the limit service denies the action', async () => {
+    limitsService.checkLimit.mockResolvedValueOnce({
+      allowed: false,
+      metric: LimitMetric.ENDPOINTS_PER_PROJECT,
+      current: 2,
+      limit: 2,
+    });
+
+    await expect(
+      service.check('revision-1', LimitMetric.ENDPOINTS_PER_PROJECT),
+    ).rejects.toBeInstanceOf(LimitExceededException);
+  });
+});

--- a/src/core/shared/__tests__/billing-check.service.spec.ts
+++ b/src/core/shared/__tests__/billing-check.service.spec.ts
@@ -68,12 +68,14 @@ describe('BillingCheckService', () => {
         revisionId: 'revision-1',
         projectId: 'project-1',
       },
+      prisma,
     );
   });
 
   it('passes through explicit context while preserving resolved project id', async () => {
     await service.check('revision-1', LimitMetric.ENDPOINTS_PER_PROJECT, 2, {
       tableId: 'table-1',
+      projectId: 'user-project',
     });
 
     expect(limitsService.checkLimit).toHaveBeenCalledWith(
@@ -85,6 +87,7 @@ describe('BillingCheckService', () => {
         projectId: 'project-1',
         tableId: 'table-1',
       },
+      prisma,
     );
   });
 
@@ -96,6 +99,7 @@ describe('BillingCheckService', () => {
       LimitMetric.PROJECTS,
       undefined,
       undefined,
+      prisma,
     );
   });
 

--- a/src/core/shared/__tests__/billing-check.service.spec.ts
+++ b/src/core/shared/__tests__/billing-check.service.spec.ts
@@ -5,8 +5,8 @@ import {
   LIMITS_SERVICE_TOKEN,
   LimitMetric,
 } from 'src/features/billing/limits.interface';
-import { PrismaService } from 'src/infrastructure/database/prisma.service';
 import { LimitExceededException } from 'src/features/billing/limit-exceeded.exception';
+import { TransactionPrismaService } from 'src/infrastructure/database/transaction-prisma.service';
 
 describe('BillingCheckService', () => {
   let service: BillingCheckService;
@@ -15,6 +15,7 @@ describe('BillingCheckService', () => {
       findUniqueOrThrow: jest.Mock;
     };
   };
+  let transactionService: { getTransactionOrPrisma: jest.Mock };
   let limitsService: jest.Mocked<ILimitsService>;
 
   beforeEach(async () => {
@@ -33,11 +34,14 @@ describe('BillingCheckService', () => {
     limitsService = {
       checkLimit: jest.fn().mockResolvedValue({ allowed: true }),
     };
+    transactionService = {
+      getTransactionOrPrisma: jest.fn().mockReturnValue(prisma),
+    };
 
     const module = await Test.createTestingModule({
       providers: [
         BillingCheckService,
-        { provide: PrismaService, useValue: prisma },
+        { provide: TransactionPrismaService, useValue: transactionService },
         { provide: LIMITS_SERVICE_TOKEN, useValue: limitsService },
       ],
     }).compile();
@@ -68,7 +72,6 @@ describe('BillingCheckService', () => {
         revisionId: 'revision-1',
         projectId: 'project-1',
       },
-      prisma,
     );
   });
 
@@ -87,7 +90,6 @@ describe('BillingCheckService', () => {
         projectId: 'project-1',
         tableId: 'table-1',
       },
-      prisma,
     );
   });
 
@@ -99,7 +101,6 @@ describe('BillingCheckService', () => {
       LimitMetric.PROJECTS,
       undefined,
       undefined,
-      prisma,
     );
   });
 

--- a/src/core/shared/billing-check.service.ts
+++ b/src/core/shared/billing-check.service.ts
@@ -1,5 +1,6 @@
 import { Inject, Injectable } from '@nestjs/common';
 import {
+  BillingDbClient,
   ILimitsService,
   LimitMetric,
   LIMITS_SERVICE_TOKEN,
@@ -20,8 +21,9 @@ export class BillingCheckService {
     metric: LimitMetric,
     increment?: number,
     context?: { tableId?: string; projectId?: string },
+    db: BillingDbClient = this.prisma,
   ): Promise<void> {
-    const resolved = await this.resolveContext(revisionId);
+    const resolved = await this.resolveContext(revisionId, db);
     const needsContext =
       metric === LimitMetric.ROWS_PER_TABLE ||
       metric === LimitMetric.TABLES_PER_REVISION ||
@@ -29,9 +31,9 @@ export class BillingCheckService {
       metric === LimitMetric.ENDPOINTS_PER_PROJECT;
     const fullContext = needsContext
       ? {
+          ...context,
           revisionId,
           projectId: resolved.projectId,
-          ...context,
         }
       : context;
     const result = await this.limitsService.checkLimit(
@@ -39,6 +41,7 @@ export class BillingCheckService {
       metric,
       increment,
       fullContext,
+      db,
     );
     if (!result.allowed) {
       throw new LimitExceededException(result);
@@ -47,8 +50,9 @@ export class BillingCheckService {
 
   private async resolveContext(
     revisionId: string,
+    db: BillingDbClient,
   ): Promise<{ organizationId: string; projectId: string }> {
-    const revision = await this.prisma.revision.findUniqueOrThrow({
+    const revision = await db.revision.findUniqueOrThrow({
       where: { id: revisionId },
       select: {
         branch: {

--- a/src/core/shared/billing-check.service.ts
+++ b/src/core/shared/billing-check.service.ts
@@ -1,29 +1,31 @@
 import { Inject, Injectable } from '@nestjs/common';
 import {
-  BillingDbClient,
   ILimitsService,
   LimitMetric,
   LIMITS_SERVICE_TOKEN,
 } from 'src/features/billing/limits.interface';
 import { LimitExceededException } from 'src/features/billing/limit-exceeded.exception';
-import { PrismaService } from 'src/infrastructure/database/prisma.service';
+import { TransactionPrismaService } from 'src/infrastructure/database/transaction-prisma.service';
 
 @Injectable()
 export class BillingCheckService {
   constructor(
-    private readonly prisma: PrismaService,
+    private readonly transactionService: TransactionPrismaService,
     @Inject(LIMITS_SERVICE_TOKEN)
     private readonly limitsService: ILimitsService,
   ) {}
+
+  private get db() {
+    return this.transactionService.getTransactionOrPrisma();
+  }
 
   async check(
     revisionId: string,
     metric: LimitMetric,
     increment?: number,
     context?: { tableId?: string; projectId?: string },
-    db: BillingDbClient = this.prisma,
   ): Promise<void> {
-    const resolved = await this.resolveContext(revisionId, db);
+    const resolved = await this.resolveContext(revisionId);
     const needsContext =
       metric === LimitMetric.ROWS_PER_TABLE ||
       metric === LimitMetric.TABLES_PER_REVISION ||
@@ -41,7 +43,6 @@ export class BillingCheckService {
       metric,
       increment,
       fullContext,
-      db,
     );
     if (!result.allowed) {
       throw new LimitExceededException(result);
@@ -50,9 +51,8 @@ export class BillingCheckService {
 
   private async resolveContext(
     revisionId: string,
-    db: BillingDbClient,
   ): Promise<{ organizationId: string; projectId: string }> {
-    const revision = await db.revision.findUniqueOrThrow({
+    const revision = await this.db.revision.findUniqueOrThrow({
       where: { id: revisionId },
       select: {
         branch: {

--- a/src/core/shared/billing-check.service.ts
+++ b/src/core/shared/billing-check.service.ts
@@ -25,7 +25,8 @@ export class BillingCheckService {
     const needsContext =
       metric === LimitMetric.ROWS_PER_TABLE ||
       metric === LimitMetric.TABLES_PER_REVISION ||
-      metric === LimitMetric.BRANCHES_PER_PROJECT;
+      metric === LimitMetric.BRANCHES_PER_PROJECT ||
+      metric === LimitMetric.ENDPOINTS_PER_PROJECT;
     const fullContext = needsContext
       ? {
           revisionId,

--- a/src/features/billing/__tests__/noop-billing-graphql.service.spec.ts
+++ b/src/features/billing/__tests__/noop-billing-graphql.service.spec.ts
@@ -26,6 +26,10 @@ describe('NoopBillingGraphqlService', () => {
     expect(await service.getUsage()).toBeNull();
   });
 
+  it('getProjectEndpointLimit returns undefined', async () => {
+    expect(await service.getProjectEndpointLimit()).toBeUndefined();
+  });
+
   it('getProjectEndpointUsage returns null', async () => {
     expect(await service.getProjectEndpointUsage()).toBeNull();
   });

--- a/src/features/billing/__tests__/noop-billing-graphql.service.spec.ts
+++ b/src/features/billing/__tests__/noop-billing-graphql.service.spec.ts
@@ -26,6 +26,10 @@ describe('NoopBillingGraphqlService', () => {
     expect(await service.getUsage()).toBeNull();
   });
 
+  it('getProjectEndpointUsage returns null', async () => {
+    expect(await service.getProjectEndpointUsage()).toBeNull();
+  });
+
   it('activateEarlyAccess throws', async () => {
     await expect(service.activateEarlyAccess()).rejects.toThrow(
       BadRequestException,

--- a/src/features/billing/billing-graphql.interface.ts
+++ b/src/features/billing/billing-graphql.interface.ts
@@ -47,7 +47,6 @@ export interface UsageSummaryResult {
   projects: UsageMetricResult;
   seats: UsageMetricResult;
   storageBytes: UsageMetricResult;
-  endpointsPerProject: UsageMetricResult;
 }
 
 export interface PaymentProviderResult {

--- a/src/features/billing/billing-graphql.interface.ts
+++ b/src/features/billing/billing-graphql.interface.ts
@@ -13,6 +13,7 @@ export interface PlanLimitsResult {
   rowsPerTable: number | null;
   tablesPerRevision: number | null;
   branchesPerProject: number | null;
+  endpointsPerProject: number | null;
 }
 
 export interface PlanResult {
@@ -46,6 +47,7 @@ export interface UsageSummaryResult {
   projects: UsageMetricResult;
   seats: UsageMetricResult;
   storageBytes: UsageMetricResult;
+  endpointsPerProject: UsageMetricResult;
 }
 
 export interface PaymentProviderResult {
@@ -79,6 +81,11 @@ export interface IBillingGraphqlService {
   getSubscription(organizationId: string): Promise<SubscriptionResult | null>;
 
   getUsage(organizationId: string): Promise<UsageSummaryResult | null>;
+
+  getProjectEndpointUsage(
+    organizationId: string,
+    projectId: string,
+  ): Promise<UsageMetricResult | null>;
 
   activateEarlyAccess(
     organizationId: string,

--- a/src/features/billing/billing-graphql.interface.ts
+++ b/src/features/billing/billing-graphql.interface.ts
@@ -82,9 +82,14 @@ export interface IBillingGraphqlService {
 
   getUsage(organizationId: string): Promise<UsageSummaryResult | null>;
 
+  getProjectEndpointLimit(
+    organizationId: string,
+  ): Promise<number | null | undefined>;
+
   getProjectEndpointUsage(
     organizationId: string,
     projectId: string,
+    options?: { endpointLimit?: number | null },
   ): Promise<UsageMetricResult | null>;
 
   activateEarlyAccess(

--- a/src/features/billing/limits.interface.ts
+++ b/src/features/billing/limits.interface.ts
@@ -1,4 +1,8 @@
+import { Prisma, PrismaClient } from 'src/__generated__/client';
+
 export const LIMITS_SERVICE_TOKEN = Symbol('LIMITS_SERVICE');
+
+export type BillingDbClient = PrismaClient | Prisma.TransactionClient;
 
 export enum LimitMetric {
   // Absolute metrics — total count across the org, never resets
@@ -30,5 +34,6 @@ export interface ILimitsService {
     metric: LimitMetric,
     increment?: number,
     context?: { revisionId?: string; tableId?: string; projectId?: string },
+    db?: BillingDbClient,
   ): Promise<LimitCheckResult>;
 }

--- a/src/features/billing/limits.interface.ts
+++ b/src/features/billing/limits.interface.ts
@@ -1,8 +1,4 @@
-import { Prisma, PrismaClient } from 'src/__generated__/client';
-
 export const LIMITS_SERVICE_TOKEN = Symbol('LIMITS_SERVICE');
-
-export type BillingDbClient = PrismaClient | Prisma.TransactionClient;
 
 export enum LimitMetric {
   // Absolute metrics — total count across the org, never resets
@@ -34,6 +30,5 @@ export interface ILimitsService {
     metric: LimitMetric,
     increment?: number,
     context?: { revisionId?: string; tableId?: string; projectId?: string },
-    db?: BillingDbClient,
   ): Promise<LimitCheckResult>;
 }

--- a/src/features/billing/limits.interface.ts
+++ b/src/features/billing/limits.interface.ts
@@ -14,6 +14,7 @@ export enum LimitMetric {
   ROWS_PER_TABLE = 'rows_per_table',
   TABLES_PER_REVISION = 'tables_per_revision',
   BRANCHES_PER_PROJECT = 'branches_per_project',
+  ENDPOINTS_PER_PROJECT = 'endpoints_per_project',
 }
 
 export interface LimitCheckResult {

--- a/src/features/billing/noop-billing-graphql.service.ts
+++ b/src/features/billing/noop-billing-graphql.service.ts
@@ -6,6 +6,7 @@ import {
   PaymentProviderResult,
   PlanResult,
   SubscriptionResult,
+  UsageMetricResult,
   UsageSummaryResult,
 } from './billing-graphql.interface';
 
@@ -28,6 +29,10 @@ export class NoopBillingGraphqlService implements IBillingGraphqlService {
   }
 
   async getUsage(): Promise<UsageSummaryResult | null> {
+    return null;
+  }
+
+  async getProjectEndpointUsage(): Promise<UsageMetricResult | null> {
     return null;
   }
 

--- a/src/features/billing/noop-billing-graphql.service.ts
+++ b/src/features/billing/noop-billing-graphql.service.ts
@@ -32,6 +32,10 @@ export class NoopBillingGraphqlService implements IBillingGraphqlService {
     return null;
   }
 
+  async getProjectEndpointLimit(): Promise<number | null | undefined> {
+    return undefined;
+  }
+
   async getProjectEndpointUsage(): Promise<UsageMetricResult | null> {
     return null;
   }

--- a/src/features/billing/noop-limits.service.ts
+++ b/src/features/billing/noop-limits.service.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@nestjs/common';
 import {
-  BillingDbClient,
   ILimitsService,
   LimitCheckResult,
   LimitMetric,
@@ -13,7 +12,6 @@ export class NoopLimitsService implements ILimitsService {
     _metric: LimitMetric,
     _increment?: number,
     _context?: { revisionId?: string; tableId?: string; projectId?: string },
-    _db?: BillingDbClient,
   ): Promise<LimitCheckResult> {
     return { allowed: true };
   }

--- a/src/features/billing/noop-limits.service.ts
+++ b/src/features/billing/noop-limits.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import {
+  BillingDbClient,
   ILimitsService,
   LimitCheckResult,
   LimitMetric,
@@ -12,6 +13,7 @@ export class NoopLimitsService implements ILimitsService {
     _metric: LimitMetric,
     _increment?: number,
     _context?: { revisionId?: string; tableId?: string; projectId?: string },
+    _db?: BillingDbClient,
   ): Promise<LimitCheckResult> {
     return { allowed: true };
   }

--- a/src/features/endpoint/commands/handlers/__tests__/create-endpoint.handler.spec.ts
+++ b/src/features/endpoint/commands/handlers/__tests__/create-endpoint.handler.spec.ts
@@ -1,0 +1,93 @@
+import { Test } from '@nestjs/testing';
+import { EndpointType } from 'src/__generated__/client';
+import { BillingCheckService } from 'src/core/shared/billing-check.service';
+import { LimitMetric } from 'src/features/billing/limits.interface';
+import { PrismaService } from 'src/infrastructure/database/prisma.service';
+import { EndpointNotificationService } from 'src/infrastructure/notification/endpoint-notification.service';
+import { CreateEndpointCommand } from '../../impl';
+import { CreateEndpointHandler } from '../create-endpoint.handler';
+
+describe('CreateEndpointHandler', () => {
+  let handler: CreateEndpointHandler;
+  let prisma: {
+    endpoint: {
+      findFirst: jest.Mock;
+      create: jest.Mock;
+      update: jest.Mock;
+    };
+  };
+  let billingCheck: { check: jest.Mock };
+  let endpointNotification: { create: jest.Mock };
+
+  beforeEach(async () => {
+    prisma = {
+      endpoint: {
+        findFirst: jest.fn(),
+        create: jest.fn(),
+        update: jest.fn(),
+      },
+    };
+    billingCheck = { check: jest.fn() };
+    endpointNotification = { create: jest.fn() };
+
+    const module = await Test.createTestingModule({
+      providers: [
+        CreateEndpointHandler,
+        { provide: PrismaService, useValue: prisma },
+        { provide: BillingCheckService, useValue: billingCheck },
+        {
+          provide: EndpointNotificationService,
+          useValue: endpointNotification,
+        },
+      ],
+    }).compile();
+
+    handler = module.get(CreateEndpointHandler);
+  });
+
+  it('checks endpoint limits before creating a new endpoint', async () => {
+    prisma.endpoint.findFirst.mockResolvedValue(null);
+    prisma.endpoint.create.mockResolvedValue({ id: 'endpoint-1' });
+
+    const result = await handler.execute(
+      new CreateEndpointCommand({
+        revisionId: 'rev-1',
+        type: EndpointType.GRAPHQL,
+      }),
+    );
+
+    expect(billingCheck.check).toHaveBeenCalledWith(
+      'rev-1',
+      LimitMetric.ENDPOINTS_PER_PROJECT,
+    );
+    expect(prisma.endpoint.create).toHaveBeenCalled();
+    expect(endpointNotification.create).toHaveBeenCalledWith('endpoint-1');
+    expect(result).toBe('endpoint-1');
+  });
+
+  it('checks endpoint limits before restoring a deleted endpoint', async () => {
+    prisma.endpoint.findFirst.mockResolvedValue({
+      id: 'endpoint-2',
+      isDeleted: true,
+    });
+    prisma.endpoint.update.mockResolvedValue({ id: 'endpoint-2' });
+
+    const result = await handler.execute(
+      new CreateEndpointCommand({
+        revisionId: 'rev-1',
+        type: EndpointType.REST_API,
+      }),
+    );
+
+    expect(billingCheck.check).toHaveBeenCalledWith(
+      'rev-1',
+      LimitMetric.ENDPOINTS_PER_PROJECT,
+    );
+    expect(prisma.endpoint.update).toHaveBeenCalledWith({
+      where: { id: 'endpoint-2' },
+      data: { isDeleted: false, createdAt: expect.any(Date) },
+    });
+    expect(endpointNotification.create).toHaveBeenCalledWith('endpoint-2');
+    expect(result).toBe('endpoint-2');
+  });
+});

--- a/src/features/endpoint/commands/handlers/__tests__/create-endpoint.handler.spec.ts
+++ b/src/features/endpoint/commands/handlers/__tests__/create-endpoint.handler.spec.ts
@@ -3,6 +3,7 @@ import { EndpointType } from 'src/__generated__/client';
 import { BillingCheckService } from 'src/core/shared/billing-check.service';
 import { LimitMetric } from 'src/features/billing/limits.interface';
 import { PrismaService } from 'src/infrastructure/database/prisma.service';
+import { TransactionPrismaService } from 'src/infrastructure/database/transaction-prisma.service';
 import { EndpointNotificationService } from 'src/infrastructure/notification/endpoint-notification.service';
 import { CreateEndpointCommand } from '../../impl';
 import { CreateEndpointHandler } from '../create-endpoint.handler';
@@ -10,42 +11,33 @@ import { CreateEndpointHandler } from '../create-endpoint.handler';
 describe('CreateEndpointHandler', () => {
   let handler: CreateEndpointHandler;
   let prisma: {
-    $transaction: jest.Mock;
-    revision: {
-      findUniqueOrThrow: jest.Mock;
-    };
-    $queryRaw: jest.Mock;
     endpoint: {
       findFirst: jest.Mock;
       create: jest.Mock;
       update: jest.Mock;
     };
   };
+  let transactionService: {
+    runSerializable: jest.Mock;
+    getTransaction: jest.Mock;
+  };
   let billingCheck: { check: jest.Mock };
   let endpointNotification: { create: jest.Mock };
 
   beforeEach(async () => {
     prisma = {
-      $transaction: jest.fn(),
-      revision: {
-        findUniqueOrThrow: jest.fn().mockResolvedValue({
-          branch: {
-            project: {
-              id: 'project-1',
-            },
-          },
-        }),
-      },
-      $queryRaw: jest.fn(),
       endpoint: {
         findFirst: jest.fn(),
         create: jest.fn(),
         update: jest.fn(),
       },
     };
-    prisma.$transaction.mockImplementation(
-      async (callback: (tx: typeof prisma) => unknown) => callback(prisma),
-    );
+    transactionService = {
+      runSerializable: jest
+        .fn()
+        .mockImplementation((callback: () => unknown) => callback()),
+      getTransaction: jest.fn().mockReturnValue(prisma),
+    };
     billingCheck = { check: jest.fn() };
     endpointNotification = { create: jest.fn() };
 
@@ -53,6 +45,7 @@ describe('CreateEndpointHandler', () => {
       providers: [
         CreateEndpointHandler,
         { provide: PrismaService, useValue: prisma },
+        { provide: TransactionPrismaService, useValue: transactionService },
         { provide: BillingCheckService, useValue: billingCheck },
         {
           provide: EndpointNotificationService,
@@ -78,11 +71,8 @@ describe('CreateEndpointHandler', () => {
     expect(billingCheck.check).toHaveBeenCalledWith(
       'rev-1',
       LimitMetric.ENDPOINTS_PER_PROJECT,
-      undefined,
-      undefined,
-      prisma,
     );
-    expect(prisma.$queryRaw).toHaveBeenCalled();
+    expect(transactionService.runSerializable).toHaveBeenCalled();
     expect(prisma.endpoint.create).toHaveBeenCalled();
     expect(endpointNotification.create).toHaveBeenCalledWith('endpoint-1');
     expect(result).toBe('endpoint-1');
@@ -123,9 +113,6 @@ describe('CreateEndpointHandler', () => {
     expect(billingCheck.check).toHaveBeenCalledWith(
       'rev-1',
       LimitMetric.ENDPOINTS_PER_PROJECT,
-      undefined,
-      undefined,
-      prisma,
     );
     expect(prisma.endpoint.update).toHaveBeenCalledWith({
       where: { id: 'endpoint-2' },

--- a/src/features/endpoint/commands/handlers/__tests__/create-endpoint.handler.spec.ts
+++ b/src/features/endpoint/commands/handlers/__tests__/create-endpoint.handler.spec.ts
@@ -10,6 +10,11 @@ import { CreateEndpointHandler } from '../create-endpoint.handler';
 describe('CreateEndpointHandler', () => {
   let handler: CreateEndpointHandler;
   let prisma: {
+    $transaction: jest.Mock;
+    revision: {
+      findUniqueOrThrow: jest.Mock;
+    };
+    $queryRaw: jest.Mock;
     endpoint: {
       findFirst: jest.Mock;
       create: jest.Mock;
@@ -21,12 +26,26 @@ describe('CreateEndpointHandler', () => {
 
   beforeEach(async () => {
     prisma = {
+      $transaction: jest.fn(),
+      revision: {
+        findUniqueOrThrow: jest.fn().mockResolvedValue({
+          branch: {
+            project: {
+              id: 'project-1',
+            },
+          },
+        }),
+      },
+      $queryRaw: jest.fn(),
       endpoint: {
         findFirst: jest.fn(),
         create: jest.fn(),
         update: jest.fn(),
       },
     };
+    prisma.$transaction.mockImplementation(
+      async (callback: (tx: typeof prisma) => unknown) => callback(prisma),
+    );
     billingCheck = { check: jest.fn() };
     endpointNotification = { create: jest.fn() };
 
@@ -59,10 +78,32 @@ describe('CreateEndpointHandler', () => {
     expect(billingCheck.check).toHaveBeenCalledWith(
       'rev-1',
       LimitMetric.ENDPOINTS_PER_PROJECT,
+      undefined,
+      undefined,
+      prisma,
     );
+    expect(prisma.$queryRaw).toHaveBeenCalled();
     expect(prisma.endpoint.create).toHaveBeenCalled();
     expect(endpointNotification.create).toHaveBeenCalledWith('endpoint-1');
     expect(result).toBe('endpoint-1');
+  });
+
+  it('does not write or notify when the billing check fails', async () => {
+    prisma.endpoint.findFirst.mockResolvedValue(null);
+    billingCheck.check.mockRejectedValue(new Error('limit exceeded'));
+
+    await expect(
+      handler.execute(
+        new CreateEndpointCommand({
+          revisionId: 'rev-1',
+          type: EndpointType.GRAPHQL,
+        }),
+      ),
+    ).rejects.toThrow('limit exceeded');
+
+    expect(prisma.endpoint.create).not.toHaveBeenCalled();
+    expect(prisma.endpoint.update).not.toHaveBeenCalled();
+    expect(endpointNotification.create).not.toHaveBeenCalled();
   });
 
   it('checks endpoint limits before restoring a deleted endpoint', async () => {
@@ -82,6 +123,9 @@ describe('CreateEndpointHandler', () => {
     expect(billingCheck.check).toHaveBeenCalledWith(
       'rev-1',
       LimitMetric.ENDPOINTS_PER_PROJECT,
+      undefined,
+      undefined,
+      prisma,
     );
     expect(prisma.endpoint.update).toHaveBeenCalledWith({
       where: { id: 'endpoint-2' },

--- a/src/features/endpoint/commands/handlers/__tests__/create-endpoint.handler.spec.ts
+++ b/src/features/endpoint/commands/handlers/__tests__/create-endpoint.handler.spec.ts
@@ -1,5 +1,5 @@
 import { Test } from '@nestjs/testing';
-import { EndpointType } from 'src/__generated__/client';
+import { EndpointType, Prisma } from 'src/__generated__/client';
 import { BillingCheckService } from 'src/core/shared/billing-check.service';
 import { LimitMetric } from 'src/features/billing/limits.interface';
 import { PrismaService } from 'src/infrastructure/database/prisma.service';
@@ -93,6 +93,27 @@ describe('CreateEndpointHandler', () => {
 
     expect(prisma.endpoint.create).not.toHaveBeenCalled();
     expect(prisma.endpoint.update).not.toHaveBeenCalled();
+    expect(endpointNotification.create).not.toHaveBeenCalled();
+  });
+
+  it('translates endpoint unique conflicts into the expected validation error', async () => {
+    prisma.endpoint.findFirst.mockResolvedValue(null);
+    prisma.endpoint.create.mockRejectedValue(
+      new Prisma.PrismaClientKnownRequestError('Unique constraint failed', {
+        code: 'P2002',
+        clientVersion: 'test',
+      }),
+    );
+
+    await expect(
+      handler.execute(
+        new CreateEndpointCommand({
+          revisionId: 'rev-1',
+          type: EndpointType.GRAPHQL,
+        }),
+      ),
+    ).rejects.toThrow('Endpoint already has been created');
+
     expect(endpointNotification.create).not.toHaveBeenCalled();
   });
 

--- a/src/features/endpoint/commands/handlers/create-endpoint.handler.ts
+++ b/src/features/endpoint/commands/handlers/create-endpoint.handler.ts
@@ -1,6 +1,7 @@
 import { BadRequestException } from '@nestjs/common';
 import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 import { nanoid } from 'nanoid';
+import { Prisma } from 'src/__generated__/client';
 import { BillingCheckService } from 'src/core/shared/billing-check.service';
 import { LimitMetric } from 'src/features/billing/limits.interface';
 import { PrismaService } from 'src/infrastructure/database/prisma.service';
@@ -29,9 +30,15 @@ export class CreateEndpointHandler implements ICommandHandler<
   }
 
   async execute({ data }: CreateEndpointCommand): Promise<string> {
-    const endpoint = await this.transactionService.runSerializable(() =>
-      this.transactionHandler(data),
-    );
+    const endpoint = await this.transactionService
+      .runSerializable(() => this.transactionHandler(data))
+      .catch((error) => {
+        if (this.isEndpointAlreadyCreatedError(error)) {
+          throw new BadRequestException('Endpoint already has been created');
+        }
+
+        throw error;
+      });
 
     await this.endpointNotification.create(endpoint.id);
 
@@ -97,5 +104,12 @@ export class CreateEndpointHandler implements ICommandHandler<
         },
       },
     });
+  }
+
+  private isEndpointAlreadyCreatedError(error: unknown) {
+    return (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === 'P2002'
+    );
   }
 }

--- a/src/features/endpoint/commands/handlers/create-endpoint.handler.ts
+++ b/src/features/endpoint/commands/handlers/create-endpoint.handler.ts
@@ -1,6 +1,8 @@
 import { BadRequestException } from '@nestjs/common';
 import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 import { nanoid } from 'nanoid';
+import { BillingCheckService } from 'src/core/shared/billing-check.service';
+import { LimitMetric } from 'src/features/billing/limits.interface';
 import { PrismaService } from 'src/infrastructure/database/prisma.service';
 import {
   CreateEndpointCommand,
@@ -15,6 +17,7 @@ export class CreateEndpointHandler implements ICommandHandler<
 > {
   constructor(
     private readonly prisma: PrismaService,
+    private readonly billingCheck: BillingCheckService,
     private readonly endpointNotification: EndpointNotificationService,
   ) {}
 
@@ -24,6 +27,11 @@ export class CreateEndpointHandler implements ICommandHandler<
     if (existEndpoint && !existEndpoint.isDeleted) {
       throw new BadRequestException('Endpoint already has been created');
     }
+
+    await this.billingCheck.check(
+      data.revisionId,
+      LimitMetric.ENDPOINTS_PER_PROJECT,
+    );
 
     const endpoint = existEndpoint
       ? await this.restoreEndpoint(existEndpoint.id)

--- a/src/features/endpoint/commands/handlers/create-endpoint.handler.ts
+++ b/src/features/endpoint/commands/handlers/create-endpoint.handler.ts
@@ -1,6 +1,7 @@
 import { BadRequestException } from '@nestjs/common';
 import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 import { nanoid } from 'nanoid';
+import { Prisma } from 'src/__generated__/client';
 import { BillingCheckService } from 'src/core/shared/billing-check.service';
 import { LimitMetric } from 'src/features/billing/limits.interface';
 import { PrismaService } from 'src/infrastructure/database/prisma.service';
@@ -22,41 +23,72 @@ export class CreateEndpointHandler implements ICommandHandler<
   ) {}
 
   async execute({ data }: CreateEndpointCommand): Promise<string> {
-    const existEndpoint = await this.getEndpoint(data);
+    const endpoint = await this.prisma.$transaction(async (tx) => {
+      const revision = await tx.revision.findUniqueOrThrow({
+        where: { id: data.revisionId },
+        select: {
+          branch: {
+            select: {
+              project: {
+                select: { id: true },
+              },
+            },
+          },
+        },
+      });
 
-    if (existEndpoint && !existEndpoint.isDeleted) {
-      throw new BadRequestException('Endpoint already has been created');
-    }
+      await tx.$queryRaw(
+        Prisma.sql`SELECT pg_advisory_xact_lock(hashtext(${revision.branch.project.id}))`,
+      );
 
-    await this.billingCheck.check(
-      data.revisionId,
-      LimitMetric.ENDPOINTS_PER_PROJECT,
-    );
+      const existEndpoint = await this.getEndpoint(data, tx);
 
-    const endpoint = existEndpoint
-      ? await this.restoreEndpoint(existEndpoint.id)
-      : await this.createEndpoint(data);
+      if (existEndpoint && !existEndpoint.isDeleted) {
+        throw new BadRequestException('Endpoint already has been created');
+      }
+
+      await this.billingCheck.check(
+        data.revisionId,
+        LimitMetric.ENDPOINTS_PER_PROJECT,
+        undefined,
+        undefined,
+        tx,
+      );
+
+      return existEndpoint
+        ? this.restoreEndpoint(existEndpoint.id, tx)
+        : this.createEndpoint(data, tx);
+    });
 
     await this.endpointNotification.create(endpoint.id);
 
     return endpoint.id;
   }
 
-  private getEndpoint({ revisionId, type }: CreateEndpointCommand['data']) {
-    return this.prisma.endpoint.findFirst({
+  private getEndpoint(
+    { revisionId, type }: CreateEndpointCommand['data'],
+    prisma: Prisma.TransactionClient | PrismaService = this.prisma,
+  ) {
+    return prisma.endpoint.findFirst({
       where: { revisionId, type },
     });
   }
 
-  private restoreEndpoint(endpointId: string) {
-    return this.prisma.endpoint.update({
+  private restoreEndpoint(
+    endpointId: string,
+    prisma: Prisma.TransactionClient | PrismaService = this.prisma,
+  ) {
+    return prisma.endpoint.update({
       where: { id: endpointId },
       data: { isDeleted: false, createdAt: new Date() },
     });
   }
 
-  private createEndpoint({ revisionId, type }: CreateEndpointCommand['data']) {
-    return this.prisma.endpoint.create({
+  private createEndpoint(
+    { revisionId, type }: CreateEndpointCommand['data'],
+    prisma: Prisma.TransactionClient | PrismaService = this.prisma,
+  ) {
+    return prisma.endpoint.create({
       data: {
         id: nanoid(),
         revision: {

--- a/src/features/endpoint/commands/handlers/create-endpoint.handler.ts
+++ b/src/features/endpoint/commands/handlers/create-endpoint.handler.ts
@@ -1,15 +1,16 @@
 import { BadRequestException } from '@nestjs/common';
 import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 import { nanoid } from 'nanoid';
-import { Prisma } from 'src/__generated__/client';
 import { BillingCheckService } from 'src/core/shared/billing-check.service';
 import { LimitMetric } from 'src/features/billing/limits.interface';
 import { PrismaService } from 'src/infrastructure/database/prisma.service';
+import { TransactionPrismaService } from 'src/infrastructure/database/transaction-prisma.service';
 import {
   CreateEndpointCommand,
   CreateEndpointCommandReturnType,
 } from 'src/features/endpoint/commands/impl';
 import { EndpointNotificationService } from 'src/infrastructure/notification/endpoint-notification.service';
+import { TransactionPrismaClient } from 'src/features/share/types';
 
 @CommandHandler(CreateEndpointCommand)
 export class CreateEndpointHandler implements ICommandHandler<
@@ -18,56 +19,45 @@ export class CreateEndpointHandler implements ICommandHandler<
 > {
   constructor(
     private readonly prisma: PrismaService,
+    private readonly transactionService: TransactionPrismaService,
     private readonly billingCheck: BillingCheckService,
     private readonly endpointNotification: EndpointNotificationService,
   ) {}
 
+  private get transaction() {
+    return this.transactionService.getTransaction();
+  }
+
   async execute({ data }: CreateEndpointCommand): Promise<string> {
-    const endpoint = await this.prisma.$transaction(async (tx) => {
-      const revision = await tx.revision.findUniqueOrThrow({
-        where: { id: data.revisionId },
-        select: {
-          branch: {
-            select: {
-              project: {
-                select: { id: true },
-              },
-            },
-          },
-        },
-      });
-
-      await tx.$queryRaw(
-        Prisma.sql`SELECT pg_advisory_xact_lock(hashtext(${revision.branch.project.id}))`,
-      );
-
-      const existEndpoint = await this.getEndpoint(data, tx);
-
-      if (existEndpoint && !existEndpoint.isDeleted) {
-        throw new BadRequestException('Endpoint already has been created');
-      }
-
-      await this.billingCheck.check(
-        data.revisionId,
-        LimitMetric.ENDPOINTS_PER_PROJECT,
-        undefined,
-        undefined,
-        tx,
-      );
-
-      return existEndpoint
-        ? this.restoreEndpoint(existEndpoint.id, tx)
-        : this.createEndpoint(data, tx);
-    });
+    const endpoint = await this.transactionService.runSerializable(() =>
+      this.transactionHandler(data),
+    );
 
     await this.endpointNotification.create(endpoint.id);
 
     return endpoint.id;
   }
 
+  private async transactionHandler(data: CreateEndpointCommand['data']) {
+    const existEndpoint = await this.getEndpoint(data, this.transaction);
+
+    if (existEndpoint && !existEndpoint.isDeleted) {
+      throw new BadRequestException('Endpoint already has been created');
+    }
+
+    await this.billingCheck.check(
+      data.revisionId,
+      LimitMetric.ENDPOINTS_PER_PROJECT,
+    );
+
+    return existEndpoint
+      ? this.restoreEndpoint(existEndpoint.id, this.transaction)
+      : this.createEndpoint(data, this.transaction);
+  }
+
   private getEndpoint(
     { revisionId, type }: CreateEndpointCommand['data'],
-    prisma: Prisma.TransactionClient | PrismaService = this.prisma,
+    prisma: TransactionPrismaClient | PrismaService = this.prisma,
   ) {
     return prisma.endpoint.findFirst({
       where: { revisionId, type },
@@ -76,7 +66,7 @@ export class CreateEndpointHandler implements ICommandHandler<
 
   private restoreEndpoint(
     endpointId: string,
-    prisma: Prisma.TransactionClient | PrismaService = this.prisma,
+    prisma: TransactionPrismaClient | PrismaService = this.prisma,
   ) {
     return prisma.endpoint.update({
       where: { id: endpointId },
@@ -86,7 +76,7 @@ export class CreateEndpointHandler implements ICommandHandler<
 
   private createEndpoint(
     { revisionId, type }: CreateEndpointCommand['data'],
-    prisma: Prisma.TransactionClient | PrismaService = this.prisma,
+    prisma: TransactionPrismaClient | PrismaService = this.prisma,
   ) {
     return prisma.endpoint.create({
       data: {

--- a/src/features/endpoint/endpoint.module.ts
+++ b/src/features/endpoint/endpoint.module.ts
@@ -5,9 +5,10 @@ import { DatabaseModule } from 'src/infrastructure/database/database.module';
 import { ENDPOINT_COMMANDS } from 'src/features/endpoint/commands/handlers';
 import { ENDPOINT_QUERIES } from 'src/features/endpoint/queries/handlers';
 import { NotificationModule } from 'src/infrastructure/notification/notification.module';
+import { SharedModule } from 'src/core/shared/shared.module';
 
 @Module({
-  imports: [CqrsModule, DatabaseModule, NotificationModule],
+  imports: [CqrsModule, DatabaseModule, NotificationModule, SharedModule],
   providers: [EndpointApiService, ...ENDPOINT_COMMANDS, ...ENDPOINT_QUERIES],
   exports: [EndpointApiService],
 })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enforces per-project endpoint limits on create/restore and adds project-scoped endpoint usage in GraphQL via `project.endpointUsage`. All billing checks and writes run inside a shared serializable transaction.

- **New Features**
  - Added limit `ENDPOINTS_PER_PROJECT` (counts non-deleted endpoints per project).
  - GraphQL: plan limits expose `endpointsPerProject`; new `project.endpointUsage` returns current/limit/percentage and memoizes the org limit per request; `BillingGraphqlService` adds `getProjectEndpointLimit`/`getProjectEndpointUsage` (noop returns `undefined`/`null`).
  - Billing client and models accept `endpoints_per_project`; org usage summaries intentionally exclude endpoint metrics (kept project-scoped).

- **Refactors**
  - `UsageService`, `LimitsService`, and `BillingCheckService` use `TransactionPrismaService`; endpoint checks auto-resolve `projectId` from `revisionId`.
  - `CreateEndpointHandler` wraps create/restore in `runSerializable`, checks the endpoint limit before any writes, and converts unique conflicts to “Endpoint already has been created.”
  - `UsageService` adds a project-scoped endpoint counter and keeps `computeUsageSummary` org-scoped only.
  - Project resolver memoizes endpoint limits per organization within the request context.

<sup>Written for commit d70deb5ff0f6621c2dd0839a02c9cd64ffd1861e. Summary will update on new commits. <a href="https://cubic.dev/pr/revisium/revisium-core/pull/495">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

