### PR TITLE
refactor: introduce api-key command test kit

### DIFF
--- a/src/features/api-key/commands/__tests__/create-api-key-limits.handler.spec.ts
+++ b/src/features/api-key/commands/__tests__/create-api-key-limits.handler.spec.ts
@@ -1,17 +1,17 @@
 import { BadRequestException } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
-import { CommandBus, CqrsModule } from '@nestjs/cqrs';
-import { Test, TestingModule } from '@nestjs/testing';
+import { CommandBus } from '@nestjs/cqrs';
 import { nanoid } from 'nanoid';
 import { ApiKeyType } from 'src/__generated__/client';
 import { testCreateUser } from 'src/testing/factories/create-models';
-import { ApiKeyService } from 'src/features/api-key/api-key.service';
-import { CreateApiKeyHandler } from 'src/features/api-key/commands/handlers';
+import {
+  createApiKeyCommandTestKit,
+  type ApiKeyCommandTestKit,
+} from 'src/testing/kit/create-api-key-command-test-kit';
 import { CreateApiKeyCommand } from 'src/features/api-key/commands/impl';
-import { RevisiumCacheModule } from 'src/infrastructure/cache';
 import { PrismaService } from 'src/infrastructure/database/prisma.service';
 
 describe('CreateApiKeyHandler — key limits', () => {
+  let kit: ApiKeyCommandTestKit;
   let commandBus: CommandBus;
   let prisma: PrismaService;
 
@@ -19,34 +19,18 @@ describe('CreateApiKeyHandler — key limits', () => {
   const TEST_SERVICE_LIMIT = 3;
 
   beforeAll(async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      imports: [CqrsModule, RevisiumCacheModule.forRootAsync()],
-      providers: [
-        CreateApiKeyHandler,
-        ApiKeyService,
-        PrismaService,
-        {
-          provide: ConfigService,
-          useValue: {
-            get: (key: string) => {
-              if (key === 'API_KEY_MAX_PER_USER') return TEST_PERSONAL_LIMIT;
-              if (key === 'API_KEY_MAX_SERVICE_PER_ORG')
-                return TEST_SERVICE_LIMIT;
-              return undefined;
-            },
-          },
-        },
-      ],
-    }).compile();
-
-    await module.init();
-
-    commandBus = module.get(CommandBus);
-    prisma = module.get(PrismaService);
+    kit = await createApiKeyCommandTestKit({
+      configValues: {
+        API_KEY_MAX_PER_USER: TEST_PERSONAL_LIMIT,
+        API_KEY_MAX_SERVICE_PER_ORG: TEST_SERVICE_LIMIT,
+      },
+    });
+    commandBus = kit.commandBus;
+    prisma = kit.prismaService;
   });
 
   afterAll(async () => {
-    await prisma.$disconnect();
+    await kit.close();
   });
 
   describe('personal key limit', () => {

--- a/src/features/api-key/commands/__tests__/create-api-key.handler.spec.ts
+++ b/src/features/api-key/commands/__tests__/create-api-key.handler.spec.ts
@@ -3,41 +3,30 @@ import {
   ConflictException,
   NotFoundException,
 } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
-import { CommandBus, CqrsModule } from '@nestjs/cqrs';
-import { Test, TestingModule } from '@nestjs/testing';
+import { CommandBus } from '@nestjs/cqrs';
 import { nanoid } from 'nanoid';
 import { ApiKeyType } from 'src/__generated__/client';
 import { testCreateUser } from 'src/testing/factories/create-models';
-import { ApiKeyService } from 'src/features/api-key/api-key.service';
-import { CreateApiKeyHandler } from 'src/features/api-key/commands/handlers';
+import {
+  createApiKeyCommandTestKit,
+  type ApiKeyCommandTestKit,
+} from 'src/testing/kit/create-api-key-command-test-kit';
 import { CreateApiKeyCommand } from 'src/features/api-key/commands/impl';
-import { RevisiumCacheModule } from 'src/infrastructure/cache';
 import { PrismaService } from 'src/infrastructure/database/prisma.service';
 
 describe('CreateApiKeyHandler', () => {
+  let kit: ApiKeyCommandTestKit;
   let commandBus: CommandBus;
   let prisma: PrismaService;
 
   beforeAll(async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      imports: [CqrsModule, RevisiumCacheModule.forRootAsync()],
-      providers: [
-        CreateApiKeyHandler,
-        ApiKeyService,
-        PrismaService,
-        { provide: ConfigService, useValue: { get: () => undefined } },
-      ],
-    }).compile();
-
-    await module.init();
-
-    commandBus = module.get(CommandBus);
-    prisma = module.get(PrismaService);
+    kit = await createApiKeyCommandTestKit();
+    commandBus = kit.commandBus;
+    prisma = kit.prismaService;
   });
 
   afterAll(async () => {
-    await prisma.$disconnect();
+    await kit.close();
   });
 
   it('should create a personal key and return id + key', async () => {

--- a/src/features/api-key/commands/__tests__/revoke-api-key.handler.spec.ts
+++ b/src/features/api-key/commands/__tests__/revoke-api-key.handler.spec.ts
@@ -1,46 +1,31 @@
 import { BadRequestException, NotFoundException } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
-import { CommandBus, CqrsModule } from '@nestjs/cqrs';
-import { Test, TestingModule } from '@nestjs/testing';
+import { CommandBus } from '@nestjs/cqrs';
 import { nanoid } from 'nanoid';
 import { ApiKeyType } from 'src/__generated__/client';
 import { testCreateUser } from 'src/testing/factories/create-models';
-import { ApiKeyService } from 'src/features/api-key/api-key.service';
 import {
-  CreateApiKeyHandler,
-  RevokeApiKeyHandler,
-} from 'src/features/api-key/commands/handlers';
+  createApiKeyCommandTestKit,
+  type ApiKeyCommandTestKit,
+} from 'src/testing/kit/create-api-key-command-test-kit';
 import {
   CreateApiKeyCommand,
   RevokeApiKeyCommand,
 } from 'src/features/api-key/commands/impl';
-import { RevisiumCacheModule } from 'src/infrastructure/cache';
 import { PrismaService } from 'src/infrastructure/database/prisma.service';
 
 describe('RevokeApiKeyHandler', () => {
+  let kit: ApiKeyCommandTestKit;
   let commandBus: CommandBus;
   let prisma: PrismaService;
 
   beforeAll(async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      imports: [CqrsModule, RevisiumCacheModule.forRootAsync()],
-      providers: [
-        RevokeApiKeyHandler,
-        CreateApiKeyHandler,
-        ApiKeyService,
-        PrismaService,
-        { provide: ConfigService, useValue: { get: () => undefined } },
-      ],
-    }).compile();
-
-    await module.init();
-
-    commandBus = module.get(CommandBus);
-    prisma = module.get(PrismaService);
+    kit = await createApiKeyCommandTestKit();
+    commandBus = kit.commandBus;
+    prisma = kit.prismaService;
   });
 
   afterAll(async () => {
-    await prisma.$disconnect();
+    await kit.close();
   });
 
   it('should set revokedAt on the key', async () => {

--- a/src/features/api-key/commands/__tests__/rotate-api-key.handler.spec.ts
+++ b/src/features/api-key/commands/__tests__/rotate-api-key.handler.spec.ts
@@ -1,49 +1,32 @@
 import { BadRequestException, NotFoundException } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
-import { CommandBus, CqrsModule } from '@nestjs/cqrs';
-import { Test, TestingModule } from '@nestjs/testing';
+import { CommandBus } from '@nestjs/cqrs';
 import { nanoid } from 'nanoid';
 import { ApiKeyType } from 'src/__generated__/client';
 import { testCreateUser } from 'src/testing/factories/create-models';
-import { ApiKeyService } from 'src/features/api-key/api-key.service';
 import {
-  CreateApiKeyHandler,
-  RevokeApiKeyHandler,
-  RotateApiKeyHandler,
-} from 'src/features/api-key/commands/handlers';
+  createApiKeyCommandTestKit,
+  type ApiKeyCommandTestKit,
+} from 'src/testing/kit/create-api-key-command-test-kit';
 import {
   CreateApiKeyCommand,
   RevokeApiKeyCommand,
   RotateApiKeyCommand,
 } from 'src/features/api-key/commands/impl';
-import { RevisiumCacheModule } from 'src/infrastructure/cache';
 import { PrismaService } from 'src/infrastructure/database/prisma.service';
 
 describe('RotateApiKeyHandler', () => {
+  let kit: ApiKeyCommandTestKit;
   let commandBus: CommandBus;
   let prisma: PrismaService;
 
   beforeAll(async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      imports: [CqrsModule, RevisiumCacheModule.forRootAsync()],
-      providers: [
-        RotateApiKeyHandler,
-        RevokeApiKeyHandler,
-        CreateApiKeyHandler,
-        ApiKeyService,
-        PrismaService,
-        { provide: ConfigService, useValue: { get: () => undefined } },
-      ],
-    }).compile();
-
-    await module.init();
-
-    commandBus = module.get(CommandBus);
-    prisma = module.get(PrismaService);
+    kit = await createApiKeyCommandTestKit();
+    commandBus = kit.commandBus;
+    prisma = kit.prismaService;
   });
 
   afterAll(async () => {
-    await prisma.$disconnect();
+    await kit.close();
   });
 
   it('should create new key and revoke old one', async () => {

--- a/src/features/api-key/queries/__tests__/get-api-keys.handler.spec.ts
+++ b/src/features/api-key/queries/__tests__/get-api-keys.handler.spec.ts
@@ -1,50 +1,33 @@
-import { ConfigService } from '@nestjs/config';
-import { CommandBus, CqrsModule, QueryBus } from '@nestjs/cqrs';
-import { Test, TestingModule } from '@nestjs/testing';
+import { CommandBus, QueryBus } from '@nestjs/cqrs';
 import { nanoid } from 'nanoid';
 import { ApiKeyType } from 'src/__generated__/client';
 import { testCreateUser } from 'src/testing/factories/create-models';
-import { ApiKeyService } from 'src/features/api-key/api-key.service';
 import {
-  CreateApiKeyHandler,
-  RevokeApiKeyHandler,
-} from 'src/features/api-key/commands/handlers';
+  createApiKeyCommandTestKit,
+  type ApiKeyCommandTestKit,
+} from 'src/testing/kit/create-api-key-command-test-kit';
 import {
   CreateApiKeyCommand,
   RevokeApiKeyCommand,
 } from 'src/features/api-key/commands/impl';
-import { GetApiKeysHandler } from 'src/features/api-key/queries/handlers';
 import { GetApiKeysQuery } from 'src/features/api-key/queries/impl';
-import { RevisiumCacheModule } from 'src/infrastructure/cache';
 import { PrismaService } from 'src/infrastructure/database/prisma.service';
 
 describe('GetApiKeysHandler', () => {
+  let kit: ApiKeyCommandTestKit;
   let commandBus: CommandBus;
   let queryBus: QueryBus;
   let prisma: PrismaService;
 
   beforeAll(async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      imports: [CqrsModule, RevisiumCacheModule.forRootAsync()],
-      providers: [
-        GetApiKeysHandler,
-        CreateApiKeyHandler,
-        RevokeApiKeyHandler,
-        ApiKeyService,
-        PrismaService,
-        { provide: ConfigService, useValue: { get: () => undefined } },
-      ],
-    }).compile();
-
-    await module.init();
-
-    commandBus = module.get(CommandBus);
-    queryBus = module.get(QueryBus);
-    prisma = module.get(PrismaService);
+    kit = await createApiKeyCommandTestKit();
+    commandBus = kit.commandBus;
+    queryBus = kit.queryBus;
+    prisma = kit.prismaService;
   });
 
   afterAll(async () => {
-    await prisma.$disconnect();
+    await kit.close();
   });
 
   it('should not return revoked keys', async () => {

--- a/src/testing/kit/create-api-key-command-test-kit.ts
+++ b/src/testing/kit/create-api-key-command-test-kit.ts
@@ -1,0 +1,59 @@
+import { ConfigService } from '@nestjs/config';
+import { CommandBus, CqrsModule, QueryBus } from '@nestjs/cqrs';
+import { Test, type TestingModule } from '@nestjs/testing';
+import { ApiKeyService } from 'src/features/api-key/api-key.service';
+import {
+  CreateApiKeyHandler,
+  RevokeApiKeyHandler,
+  RotateApiKeyHandler,
+} from 'src/features/api-key/commands/handlers';
+import { GetApiKeysHandler } from 'src/features/api-key/queries/handlers';
+import { RevisiumCacheModule } from 'src/infrastructure/cache';
+import { PrismaService } from 'src/infrastructure/database/prisma.service';
+
+export interface ApiKeyCommandTestKitOptions {
+  configValues?: Record<string, unknown>;
+}
+
+export interface ApiKeyCommandTestKit {
+  module: TestingModule;
+  prismaService: PrismaService;
+  commandBus: CommandBus;
+  queryBus: QueryBus;
+  apiKeyService: ApiKeyService;
+  close(): Promise<void>;
+}
+
+export async function createApiKeyCommandTestKit(
+  options: ApiKeyCommandTestKitOptions = {},
+): Promise<ApiKeyCommandTestKit> {
+  const { configValues = {} } = options;
+  const module = await Test.createTestingModule({
+    imports: [CqrsModule, RevisiumCacheModule.forRootAsync()],
+    providers: [
+      CreateApiKeyHandler,
+      RevokeApiKeyHandler,
+      RotateApiKeyHandler,
+      GetApiKeysHandler,
+      ApiKeyService,
+      PrismaService,
+      {
+        provide: ConfigService,
+        useValue: { get: (key: string) => configValues[key] },
+      },
+    ],
+  }).compile();
+
+  await module.init();
+
+  return {
+    module,
+    prismaService: module.get(PrismaService),
+    commandBus: module.get(CommandBus),
+    queryBus: module.get(QueryBus),
+    apiKeyService: module.get(ApiKeyService),
+    async close() {
+      await module.close();
+    },
+  };
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Introduces a reusable test kit for API key commands and queries to reduce test boilerplate and standardize Nest module setup. Migrates five CQRS specs to use the kit while keeping service-level specs unchanged.

- **Refactors**
  - Added `src/testing/kit/create-api-key-command-test-kit.ts` that composes `CqrsModule`, `RevisiumCacheModule`, handlers (`CreateApiKeyHandler`, `RevokeApiKeyHandler`, `RotateApiKeyHandler`, `GetApiKeysHandler`), `ApiKeyService`, `PrismaService`, and a stubbed `ConfigService`.
  - Exposes `commandBus`, `queryBus`, `prismaService`, and `close()` for teardown.
  - Updated specs to use the kit: `create-api-key.handler.spec.ts`, `create-api-key-limits.handler.spec.ts`, `revoke-api-key.handler.spec.ts`, `rotate-api-key.handler.spec.ts`, `get-api-keys.handler.spec.ts`.
  - Supports custom `configValues`; limits spec sets `API_KEY_MAX_PER_USER` and `API_KEY_MAX_SERVICE_PER_ORG`. Service-level specs remain on their minimal modules.

<sup>Written for commit 401154a7f00c2e3de514c54cf97b7d6590bb0ae8. Summary will update on new commits. <a href="https://cubic.dev/pr/revisium/revisium-core/pull/498">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

