### PR TITLE
refactor: user query test kit + scenarios + factories

### DIFF
--- a/src/features/user/queries/handlers/__tests__/admin-user.spec.ts
+++ b/src/features/user/queries/handlers/__tests__/admin-user.spec.ts
@@ -1,15 +1,17 @@
 import { NotFoundException } from '@nestjs/common';
-import { CqrsModule, QueryBus } from '@nestjs/cqrs';
-import { Test, TestingModule } from '@nestjs/testing';
+import { QueryBus } from '@nestjs/cqrs';
 import { nanoid } from 'nanoid';
 import { testCreateUser } from 'src/testing/factories/create-models';
+import {
+  createUserQueryTestKit,
+  type UserQueryTestKit,
+} from 'src/testing/kit/create-user-query-test-kit';
 import { UserSystemRoles } from 'src/features/auth/consts';
 import { PrismaService } from 'src/infrastructure/database/prisma.service';
 import {
   AdminUserQuery,
   AdminUserQueryReturnType,
 } from 'src/features/user/queries/impl';
-import { AdminUserHandler } from 'src/features/user/queries/handlers/admin-user.handler';
 
 describe('AdminUserHandler', () => {
   describe('get user by id', () => {
@@ -129,23 +131,18 @@ describe('AdminUserHandler', () => {
     });
   });
 
+  let kit: UserQueryTestKit;
   let queryBus: QueryBus;
   let prismaService: PrismaService;
 
   beforeAll(async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      imports: [CqrsModule],
-      providers: [PrismaService, AdminUserHandler],
-    }).compile();
-
-    await module.init();
-
-    prismaService = module.get(PrismaService);
-    queryBus = module.get(QueryBus);
+    kit = await createUserQueryTestKit();
+    prismaService = kit.prismaService;
+    queryBus = kit.queryBus;
   });
 
   afterAll(async () => {
-    await prismaService.$disconnect();
+    await kit.close();
   });
 
   const createQuery = (data: AdminUserQuery['data']): AdminUserQuery => {

--- a/src/features/user/queries/handlers/__tests__/get-projects-by-user-id.spec.ts
+++ b/src/features/user/queries/handlers/__tests__/get-projects-by-user-id.spec.ts
@@ -1,11 +1,11 @@
 import { QueryBus } from '@nestjs/cqrs';
-import {
-  Prisma,
-  UserOrganization,
-  UserProject,
-} from 'src/__generated__/client';
 import { nanoid } from 'nanoid';
-import { testCreateUser } from 'src/testing/factories/create-models';
+import {
+  testAddUserToOrganization,
+  testAddUserToProject,
+  testCreateOrganization,
+  testCreateUser,
+} from 'src/testing/factories/create-models';
 import {
   createUserQueryTestKit,
   type UserQueryTestKit,
@@ -35,12 +35,12 @@ describe('GetProjectsByUserIdHandler', () => {
     const organizationId = nanoid();
     const projectId = nanoid();
     await testCreateUser(prismaService, { id: userId });
-    await createOrganization(organizationId);
-    await addUserToOrganization(
+    await testCreateOrganization(prismaService, organizationId);
+    await testAddUserToOrganization(prismaService, {
       organizationId,
       userId,
-      UserOrganizationRoles.organizationOwner,
-    );
+      roleId: UserOrganizationRoles.organizationOwner,
+    });
     await createProject(organizationId, projectId);
 
     const query = createQuery({ first: 1, userId });
@@ -59,9 +59,13 @@ describe('GetProjectsByUserIdHandler', () => {
     const organizationId = nanoid();
     const projectId = nanoid();
     await testCreateUser(prismaService, { id: userId });
-    await createOrganization(organizationId);
+    await testCreateOrganization(prismaService, organizationId);
     await createProject(organizationId, projectId);
-    await addUserToProject(projectId, userId, UserProjectRoles.reader);
+    await testAddUserToProject(prismaService, {
+      projectId,
+      userId,
+      roleId: UserProjectRoles.reader,
+    });
 
     const query = createQuery({ first: 1, userId });
     const result = await queryBus.execute<
@@ -79,9 +83,13 @@ describe('GetProjectsByUserIdHandler', () => {
     const organizationId = nanoid();
     const projectId = nanoid();
     await testCreateUser(prismaService, { id: userId });
-    await createOrganization(organizationId);
+    await testCreateOrganization(prismaService, organizationId);
     await createProject(organizationId, projectId);
-    await addUserToProject(projectId, userId, UserProjectRoles.reader);
+    await testAddUserToProject(prismaService, {
+      projectId,
+      userId,
+      roleId: UserProjectRoles.reader,
+    });
 
     await prismaService.project.update({
       where: { id: projectId },
@@ -126,73 +134,6 @@ describe('GetProjectsByUserIdHandler', () => {
       userId: 'userId',
       first: 10,
       ...data,
-    });
-  };
-
-  const createOrganization = (organizationId: string) => {
-    return prismaService.organization.create({
-      data: {
-        id: organizationId,
-        createdId: nanoid(),
-      },
-    });
-  };
-
-  const addUserToOrganization = async (
-    organizationId: string,
-    userId: string,
-    roleId: UserOrganizationRoles,
-  ): Promise<UserOrganization> => {
-    const data: Prisma.UserOrganizationCreateInput = {
-      id: nanoid(),
-      role: {
-        connect: {
-          id: roleId,
-        },
-      },
-      organization: {
-        connect: {
-          id: organizationId,
-        },
-      },
-      user: {
-        connect: {
-          id: userId,
-        },
-      },
-    };
-
-    return prismaService.userOrganization.create({
-      data,
-    });
-  };
-
-  const addUserToProject = async (
-    projectId: string,
-    userId: string,
-    roleId: UserProjectRoles,
-  ): Promise<UserProject> => {
-    const data: Prisma.UserProjectCreateInput = {
-      id: nanoid(),
-      role: {
-        connect: {
-          id: roleId,
-        },
-      },
-      project: {
-        connect: {
-          id: projectId,
-        },
-      },
-      user: {
-        connect: {
-          id: userId,
-        },
-      },
-    };
-
-    return prismaService.userProject.create({
-      data,
     });
   };
 

--- a/src/features/user/queries/handlers/__tests__/get-projects-by-user-id.spec.ts
+++ b/src/features/user/queries/handlers/__tests__/get-projects-by-user-id.spec.ts
@@ -1,5 +1,4 @@
-import { CqrsModule, QueryBus } from '@nestjs/cqrs';
-import { Test, TestingModule } from '@nestjs/testing';
+import { QueryBus } from '@nestjs/cqrs';
 import {
   Prisma,
   UserOrganization,
@@ -7,6 +6,10 @@ import {
 } from 'src/__generated__/client';
 import { nanoid } from 'nanoid';
 import { testCreateUser } from 'src/testing/factories/create-models';
+import {
+  createUserQueryTestKit,
+  type UserQueryTestKit,
+} from 'src/testing/kit/create-user-query-test-kit';
 import {
   UserOrganizationRoles,
   UserProjectRoles,
@@ -16,7 +19,6 @@ import {
   GetProjectsByUserIdQuery,
   GetProjectsByUserIdQueryReturnType,
 } from 'src/features/user/queries/impl';
-import { GetProjectsByUserIdHandler } from 'src/features/user/queries/handlers/get-projects-by-user-id.handler';
 
 describe('GetProjectsByUserIdHandler', () => {
   it('should handle no projects found', async () => {
@@ -107,19 +109,14 @@ describe('GetProjectsByUserIdHandler', () => {
     });
   };
 
+  let kit: UserQueryTestKit;
   let prismaService: PrismaService;
   let queryBus: QueryBus;
 
   beforeAll(async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      imports: [CqrsModule],
-      providers: [PrismaService, GetProjectsByUserIdHandler],
-    }).compile();
-
-    await module.init();
-
-    prismaService = module.get<PrismaService>(PrismaService);
-    queryBus = module.get<QueryBus>(QueryBus);
+    kit = await createUserQueryTestKit();
+    prismaService = kit.prismaService;
+    queryBus = kit.queryBus;
   });
 
   const createQuery = (
@@ -200,6 +197,6 @@ describe('GetProjectsByUserIdHandler', () => {
   };
 
   afterAll(async () => {
-    await prismaService.$disconnect();
+    await kit.close();
   });
 });

--- a/src/features/user/queries/handlers/__tests__/get-user.spec.ts
+++ b/src/features/user/queries/handlers/__tests__/get-user.spec.ts
@@ -1,11 +1,13 @@
 import { NotFoundException } from '@nestjs/common';
-import { CqrsModule, QueryBus } from '@nestjs/cqrs';
-import { Test, TestingModule } from '@nestjs/testing';
+import { QueryBus } from '@nestjs/cqrs';
 import { nanoid } from 'nanoid';
 import { testCreateUser } from 'src/testing/factories/create-models';
+import {
+  createUserQueryTestKit,
+  type UserQueryTestKit,
+} from 'src/testing/kit/create-user-query-test-kit';
 import { PrismaService } from 'src/infrastructure/database/prisma.service';
 import { GetUserQuery } from 'src/features/user/queries/impl';
-import { GetUserHandler } from 'src/features/user/queries/handlers/get-user.handler';
 
 describe('GetUserHandler', () => {
   it('should return user data with hasPassword false when password is empty', async () => {
@@ -68,22 +70,17 @@ describe('GetUserHandler', () => {
     });
   };
 
+  let kit: UserQueryTestKit;
   let queryBus: QueryBus;
   let prismaService: PrismaService;
 
   beforeAll(async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      imports: [CqrsModule],
-      providers: [PrismaService, GetUserHandler],
-    }).compile();
-
-    await module.init();
-
-    prismaService = module.get(PrismaService);
-    queryBus = module.get(QueryBus);
+    kit = await createUserQueryTestKit();
+    prismaService = kit.prismaService;
+    queryBus = kit.queryBus;
   });
 
   afterAll(async () => {
-    await prismaService.$disconnect();
+    await kit.close();
   });
 });

--- a/src/features/user/queries/handlers/__tests__/search-users.spec.ts
+++ b/src/features/user/queries/handlers/__tests__/search-users.spec.ts
@@ -1,13 +1,15 @@
-import { CqrsModule, QueryBus } from '@nestjs/cqrs';
-import { Test, TestingModule } from '@nestjs/testing';
+import { QueryBus } from '@nestjs/cqrs';
 import { nanoid } from 'nanoid';
 import { testCreateUser } from 'src/testing/factories/create-models';
+import {
+  createUserQueryTestKit,
+  type UserQueryTestKit,
+} from 'src/testing/kit/create-user-query-test-kit';
 import { PrismaService } from 'src/infrastructure/database/prisma.service';
 import {
   SearchUsersQuery,
   SearchUsersQueryReturnType,
 } from 'src/features/user/queries/impl';
-import { SearchUsersHandler } from 'src/features/user/queries/handlers/search-users.handler';
 
 describe('SearchUsersHandler', () => {
   describe('basic search functionality', () => {
@@ -234,23 +236,18 @@ describe('SearchUsersHandler', () => {
     });
   });
 
+  let kit: UserQueryTestKit;
   let queryBus: QueryBus;
   let prismaService: PrismaService;
 
   beforeAll(async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      imports: [CqrsModule],
-      providers: [PrismaService, SearchUsersHandler],
-    }).compile();
-
-    await module.init();
-
-    prismaService = module.get(PrismaService);
-    queryBus = module.get(QueryBus);
+    kit = await createUserQueryTestKit();
+    prismaService = kit.prismaService;
+    queryBus = kit.queryBus;
   });
 
   afterAll(async () => {
-    await prismaService.$disconnect();
+    await kit.close();
   });
 
   const createQuery = (

--- a/src/testing/factories/create-models.ts
+++ b/src/testing/factories/create-models.ts
@@ -1,5 +1,16 @@
-import { Prisma, User } from 'src/__generated__/client';
-import { UserSystemRoles } from 'src/features/auth/consts';
+import { nanoid } from 'nanoid';
+import {
+  Organization,
+  Prisma,
+  User,
+  UserOrganization,
+  UserProject,
+} from 'src/__generated__/client';
+import {
+  UserOrganizationRoles,
+  UserProjectRoles,
+  UserSystemRoles,
+} from 'src/features/auth/consts';
 import { PrismaService } from 'src/infrastructure/database/prisma.service';
 
 type TestCreateUserInput = { id: string } & Partial<
@@ -30,5 +41,53 @@ export const testCreateUser = (
 
   return prisma.user.create({
     data,
+  });
+};
+
+export const testCreateOrganization = (
+  prisma: PrismaService,
+  organizationId: string = nanoid(),
+): Promise<Organization> => {
+  return prisma.organization.create({
+    data: {
+      id: organizationId,
+      createdId: nanoid(),
+    },
+  });
+};
+
+export const testAddUserToOrganization = (
+  prisma: PrismaService,
+  args: {
+    organizationId: string;
+    userId: string;
+    roleId: UserOrganizationRoles;
+  },
+): Promise<UserOrganization> => {
+  return prisma.userOrganization.create({
+    data: {
+      id: nanoid(),
+      role: { connect: { id: args.roleId } },
+      organization: { connect: { id: args.organizationId } },
+      user: { connect: { id: args.userId } },
+    },
+  });
+};
+
+export const testAddUserToProject = (
+  prisma: PrismaService,
+  args: {
+    projectId: string;
+    userId: string;
+    roleId: UserProjectRoles;
+  },
+): Promise<UserProject> => {
+  return prisma.userProject.create({
+    data: {
+      id: nanoid(),
+      role: { connect: { id: args.roleId } },
+      project: { connect: { id: args.projectId } },
+      user: { connect: { id: args.userId } },
+    },
   });
 };

--- a/src/testing/kit/create-user-query-test-kit.ts
+++ b/src/testing/kit/create-user-query-test-kit.ts
@@ -1,0 +1,38 @@
+import { CqrsModule, QueryBus } from '@nestjs/cqrs';
+import { Test, type TestingModule } from '@nestjs/testing';
+import { AdminUserHandler } from 'src/features/user/queries/handlers/admin-user.handler';
+import { GetProjectsByUserIdHandler } from 'src/features/user/queries/handlers/get-projects-by-user-id.handler';
+import { GetUserHandler } from 'src/features/user/queries/handlers/get-user.handler';
+import { SearchUsersHandler } from 'src/features/user/queries/handlers/search-users.handler';
+import { PrismaService } from 'src/infrastructure/database/prisma.service';
+
+export interface UserQueryTestKit {
+  module: TestingModule;
+  prismaService: PrismaService;
+  queryBus: QueryBus;
+  close(): Promise<void>;
+}
+
+export async function createUserQueryTestKit(): Promise<UserQueryTestKit> {
+  const module = await Test.createTestingModule({
+    imports: [CqrsModule],
+    providers: [
+      PrismaService,
+      AdminUserHandler,
+      GetProjectsByUserIdHandler,
+      GetUserHandler,
+      SearchUsersHandler,
+    ],
+  }).compile();
+
+  await module.init();
+
+  return {
+    module,
+    prismaService: module.get(PrismaService),
+    queryBus: module.get(QueryBus),
+    async close() {
+      await module.close();
+    },
+  };
+}

--- a/src/testing/scenarios/given-organization-with-owner.ts
+++ b/src/testing/scenarios/given-organization-with-owner.ts
@@ -1,0 +1,30 @@
+import { nanoid } from 'nanoid';
+import { UserOrganizationRoles } from 'src/features/auth/consts';
+import { PrismaService } from 'src/infrastructure/database/prisma.service';
+import {
+  testAddUserToOrganization,
+  testCreateOrganization,
+  testCreateUser,
+} from 'src/testing/factories/create-models';
+
+export interface OrganizationWithOwnerScenario {
+  organizationId: string;
+  userId: string;
+}
+
+export async function givenOrganizationWithOwner(
+  prisma: PrismaService,
+): Promise<OrganizationWithOwnerScenario> {
+  const organizationId = nanoid();
+  const userId = nanoid();
+
+  await testCreateUser(prisma, { id: userId });
+  await testCreateOrganization(prisma, organizationId);
+  await testAddUserToOrganization(prisma, {
+    organizationId,
+    userId,
+    roleId: UserOrganizationRoles.organizationOwner,
+  });
+
+  return { organizationId, userId };
+}

--- a/src/testing/scenarios/given-project-with-owner.ts
+++ b/src/testing/scenarios/given-project-with-owner.ts
@@ -1,0 +1,34 @@
+import { nanoid } from 'nanoid';
+import { UserProjectRoles } from 'src/features/auth/consts';
+import { PrismaService } from 'src/infrastructure/database/prisma.service';
+import { testAddUserToProject } from 'src/testing/factories/create-models';
+import { givenOrganizationWithOwner } from 'src/testing/scenarios/given-organization-with-owner';
+
+export interface ProjectWithOwnerScenario {
+  organizationId: string;
+  projectId: string;
+  userId: string;
+}
+
+export async function givenProjectWithOwner(
+  prisma: PrismaService,
+): Promise<ProjectWithOwnerScenario> {
+  const { organizationId, userId } = await givenOrganizationWithOwner(prisma);
+  const projectId = nanoid();
+
+  await prisma.project.create({
+    data: {
+      id: projectId,
+      organizationId,
+      name: `name=${projectId}`,
+    },
+  });
+
+  await testAddUserToProject(prisma, {
+    projectId,
+    userId,
+    roleId: UserProjectRoles.developer,
+  });
+
+  return { organizationId, projectId, userId };
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Introduce a shared user query test kit and scenario-based test helpers to simplify user query handler tests and cut boilerplate. Standardizes Nest `@nestjs/cqrs` + Prisma setup and makes teardown consistent.

- **Refactors**
  - Added `src/testing/kit/create-user-query-test-kit.ts` bundling `CqrsModule` from `@nestjs/cqrs`, `PrismaService`, and user query handlers; migrated four specs to `createUserQueryTestKit()` with `kit.close()` teardown.
  - Added factories (`testCreateOrganization`, `testAddUserToOrganization`, `testAddUserToProject`) and scenarios (`givenOrganizationWithOwner`, `givenProjectWithOwner`); updated the `get-projects-by-user-id` spec to use them.

<sup>Written for commit 7f01989c075bd421b8b350fbea2edb43ca459d9d. Summary will update on new commits. <a href="https://cubic.dev/pr/revisium/revisium-core/pull/499">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

