### PR TITLE
refactor: consolidate transport specs onto createFreshTestApp

### DIFF
--- a/src/__tests__/e2e/graphql/readonly/admin-cache.spec.ts
+++ b/src/__tests__/e2e/graphql/readonly/admin-cache.spec.ts
@@ -6,8 +6,7 @@ import { UserSystemRoles } from 'src/features/auth/consts';
 import { AuthService } from 'src/features/auth/auth.service';
 import { PrismaService } from 'src/infrastructure/database/prisma.service';
 import {
-  getTestApp,
-  closeTestApp,
+  createFreshTestApp,
   getReadonlyFixture,
   gqlQuery,
   gqlQueryRaw,
@@ -21,14 +20,14 @@ describe('graphql - admin cache (readonly)', () => {
   let authService: AuthService;
 
   beforeAll(async () => {
-    app = await getTestApp();
+    app = await createFreshTestApp();
     fixture = await getReadonlyFixture(app);
     prismaService = app.get(PrismaService);
     authService = app.get(AuthService);
   });
 
   afterAll(async () => {
-    await closeTestApp();
+    await app.close();
   });
 
   const createAdminUser = async () => {

--- a/src/__tests__/e2e/graphql/readonly/admin-user.spec.ts
+++ b/src/__tests__/e2e/graphql/readonly/admin-user.spec.ts
@@ -6,8 +6,7 @@ import { UserSystemRoles } from 'src/features/auth/consts';
 import { AuthService } from 'src/features/auth/auth.service';
 import { PrismaService } from 'src/infrastructure/database/prisma.service';
 import {
-  getTestApp,
-  closeTestApp,
+  createFreshTestApp,
   getReadonlyFixture,
   gqlQuery,
   gqlQueryRaw,
@@ -21,14 +20,14 @@ describe('graphql - admin user (readonly)', () => {
   let authService: AuthService;
 
   beforeAll(async () => {
-    app = await getTestApp();
+    app = await createFreshTestApp();
     fixture = await getReadonlyFixture(app);
     prismaService = app.get(PrismaService);
     authService = app.get(AuthService);
   });
 
   afterAll(async () => {
-    await closeTestApp();
+    await app.close();
   });
 
   const createAdminUser = async () => {

--- a/src/__tests__/e2e/graphql/readonly/branch.spec.ts
+++ b/src/__tests__/e2e/graphql/readonly/branch.spec.ts
@@ -1,8 +1,7 @@
 import { INestApplication } from '@nestjs/common';
 import { gql } from 'src/testing/utils/gql';
 import {
-  getTestApp,
-  closeTestApp,
+  createFreshTestApp,
   getReadonlyFixture,
   getPublicProjectFixture,
   gqlQuery,
@@ -16,13 +15,13 @@ describe('graphql - branch (readonly)', () => {
   let publicFixture: PrepareDataReturnType;
 
   beforeAll(async () => {
-    app = await getTestApp();
+    app = await createFreshTestApp();
     fixture = await getReadonlyFixture(app);
     publicFixture = await getPublicProjectFixture(app);
   });
 
   afterAll(async () => {
-    await closeTestApp();
+    await app.close();
   });
 
   const getBranchData = (f: PrepareDataReturnType) => ({

--- a/src/__tests__/e2e/graphql/readonly/internal-api-key.spec.ts
+++ b/src/__tests__/e2e/graphql/readonly/internal-api-key.spec.ts
@@ -1,8 +1,7 @@
 import { INestApplication } from '@nestjs/common';
 import { gql } from 'src/testing/utils/gql';
 import {
-  getTestApp,
-  closeTestApp,
+  createFreshTestApp,
   getReadonlyFixture,
   gqlQuery,
   gqlQueryExpectError,
@@ -15,7 +14,7 @@ describe('graphql - internal API key auth (readonly)', () => {
   let internalKeyHeaders: Record<string, string>;
 
   beforeAll(async () => {
-    app = await getTestApp();
+    app = await createFreshTestApp();
     fixture = await getReadonlyFixture(app);
     const internalKey = process.env.INTERNAL_API_KEY_ENDPOINT!;
     expect(internalKey).toBeDefined();
@@ -23,7 +22,7 @@ describe('graphql - internal API key auth (readonly)', () => {
   });
 
   afterAll(async () => {
-    await closeTestApp();
+    await app.close();
   });
 
   describe('valid internal key - full read access', () => {

--- a/src/__tests__/e2e/graphql/readonly/organization.spec.ts
+++ b/src/__tests__/e2e/graphql/readonly/organization.spec.ts
@@ -1,8 +1,7 @@
 import { INestApplication } from '@nestjs/common';
 import { gql } from 'src/testing/utils/gql';
 import {
-  getTestApp,
-  closeTestApp,
+  createFreshTestApp,
   getReadonlyFixture,
   gqlQuery,
   type PrepareDataReturnType,
@@ -13,12 +12,12 @@ describe('graphql - organization (readonly)', () => {
   let fixture: PrepareDataReturnType;
 
   beforeAll(async () => {
-    app = await getTestApp();
+    app = await createFreshTestApp();
     fixture = await getReadonlyFixture(app);
   });
 
   afterAll(async () => {
-    await closeTestApp();
+    await app.close();
   });
 
   describe('projects query', () => {

--- a/src/__tests__/e2e/graphql/readonly/project.spec.ts
+++ b/src/__tests__/e2e/graphql/readonly/project.spec.ts
@@ -1,8 +1,7 @@
 import { INestApplication } from '@nestjs/common';
 import { gql } from 'src/testing/utils/gql';
 import {
-  getTestApp,
-  closeTestApp,
+  createFreshTestApp,
   getReadonlyFixture,
   getPublicProjectFixture,
   gqlQuery,
@@ -17,13 +16,13 @@ describe('graphql - project (readonly)', () => {
   let publicFixture: PrepareDataReturnType;
 
   beforeAll(async () => {
-    app = await getTestApp();
+    app = await createFreshTestApp();
     fixture = await getReadonlyFixture(app);
     publicFixture = await getPublicProjectFixture(app);
   });
 
   afterAll(async () => {
-    await closeTestApp();
+    await app.close();
   });
 
   describe('project query', () => {

--- a/src/__tests__/e2e/graphql/readonly/revision.spec.ts
+++ b/src/__tests__/e2e/graphql/readonly/revision.spec.ts
@@ -1,8 +1,7 @@
 import { INestApplication } from '@nestjs/common';
 import { gql } from 'src/testing/utils/gql';
 import {
-  getTestApp,
-  closeTestApp,
+  createFreshTestApp,
   getReadonlyFixture,
   getPublicProjectFixture,
   gqlQuery,
@@ -16,13 +15,13 @@ describe('graphql - revision (readonly)', () => {
   let publicFixture: PrepareDataReturnType;
 
   beforeAll(async () => {
-    app = await getTestApp();
+    app = await createFreshTestApp();
     fixture = await getReadonlyFixture(app);
     publicFixture = await getPublicProjectFixture(app);
   });
 
   afterAll(async () => {
-    await closeTestApp();
+    await app.close();
   });
 
   describe('revision query', () => {

--- a/src/__tests__/e2e/graphql/readonly/row.spec.ts
+++ b/src/__tests__/e2e/graphql/readonly/row.spec.ts
@@ -1,8 +1,7 @@
 import { INestApplication } from '@nestjs/common';
 import { gql } from 'src/testing/utils/gql';
 import {
-  getTestApp,
-  closeTestApp,
+  createFreshTestApp,
   getReadonlyFixture,
   getPublicProjectFixture,
   gqlQuery,
@@ -16,13 +15,13 @@ describe('graphql - row (readonly)', () => {
   let publicFixture: PrepareDataReturnType;
 
   beforeAll(async () => {
-    app = await getTestApp();
+    app = await createFreshTestApp();
     fixture = await getReadonlyFixture(app);
     publicFixture = await getPublicProjectFixture(app);
   });
 
   afterAll(async () => {
-    await closeTestApp();
+    await app.close();
   });
 
   describe('row query', () => {

--- a/src/__tests__/e2e/graphql/readonly/sub-schema.spec.ts
+++ b/src/__tests__/e2e/graphql/readonly/sub-schema.spec.ts
@@ -8,13 +8,12 @@ import { metaSchema } from 'src/features/share/schema/meta-schema';
 import { tableMigrationsSchema } from 'src/features/share/schema/table-migrations-schema';
 import { gql } from 'src/testing/utils/gql';
 import {
-  getTestApp,
-  closeTestApp,
+  createFreshTestApp,
   gqlQuery,
   gqlQueryExpectError,
-  getPrismaService,
 } from 'src/testing/e2e';
 import { prepareData, prepareRow } from 'src/testing/utils/prepareProject';
+import { PrismaService } from 'src/infrastructure/database/prisma.service';
 import { JsonPatchAdd, InitMigration } from '@revisium/schema-toolkit/types';
 
 const FILE_SCHEMA_ID = SystemSchemaIds.File;
@@ -44,11 +43,11 @@ describe('graphql - subSchemaItems (readonly)', () => {
   let app: INestApplication;
 
   beforeAll(async () => {
-    app = await getTestApp();
+    app = await createFreshTestApp();
   });
 
   afterAll(async () => {
-    await closeTestApp();
+    await app.close();
   });
 
   const getSubSchemaItemsQuery = (revisionId: string, schemaId: string) => ({
@@ -140,7 +139,7 @@ describe('graphql - subSchemaItems (readonly)', () => {
 
     beforeAll(async () => {
       fixture = await prepareFixtureWithFiles(app);
-      const prisma = getPrismaService();
+      const prisma = app.get(PrismaService);
       await prisma.project.update({
         where: { id: fixture.project.projectId },
         data: { isPublic: true },
@@ -175,7 +174,7 @@ describe('graphql - subSchemaItems (readonly)', () => {
 
   describe('duplicate row prevention', () => {
     it('should not return duplicates when row is connected to multiple table versions', async () => {
-      const prisma = getPrismaService();
+      const prisma = app.get(PrismaService);
       const baseFixture = await prepareData(app);
 
       const fileSchema = getObjectSchema({
@@ -302,7 +301,7 @@ describe('graphql - subSchemaItems (readonly)', () => {
 });
 
 async function prepareFixtureWithFiles(app: INestApplication) {
-  const prismaService = getPrismaService();
+  const prismaService = app.get(PrismaService);
 
   const baseFixture = await prepareData(app);
 
@@ -348,7 +347,7 @@ async function prepareTableWithFileSchema({
   migrationTableVersionId,
   schema,
 }: {
-  prismaService: ReturnType<typeof getPrismaService>;
+  prismaService: PrismaService;
   headRevisionId: string;
   draftRevisionId: string;
   schemaTableVersionId: string;

--- a/src/__tests__/e2e/graphql/readonly/table.spec.ts
+++ b/src/__tests__/e2e/graphql/readonly/table.spec.ts
@@ -1,8 +1,7 @@
 import { INestApplication } from '@nestjs/common';
 import { gql } from 'src/testing/utils/gql';
 import {
-  getTestApp,
-  closeTestApp,
+  createFreshTestApp,
   getReadonlyFixture,
   getPublicProjectFixture,
   gqlQuery,
@@ -16,13 +15,13 @@ describe('graphql - table (readonly)', () => {
   let publicFixture: PrepareDataReturnType;
 
   beforeAll(async () => {
-    app = await getTestApp();
+    app = await createFreshTestApp();
     fixture = await getReadonlyFixture(app);
     publicFixture = await getPublicProjectFixture(app);
   });
 
   afterAll(async () => {
-    await closeTestApp();
+    await app.close();
   });
 
   describe('table query', () => {

--- a/src/__tests__/e2e/graphql/readonly/user.spec.ts
+++ b/src/__tests__/e2e/graphql/readonly/user.spec.ts
@@ -1,8 +1,7 @@
 import { INestApplication } from '@nestjs/common';
 import { gql } from 'src/testing/utils/gql';
 import {
-  getTestApp,
-  closeTestApp,
+  createFreshTestApp,
   getReadonlyFixture,
   gqlQuery,
   gqlQueryExpectError,
@@ -14,12 +13,12 @@ describe('graphql - user (readonly)', () => {
   let fixture: PrepareDataReturnType;
 
   beforeAll(async () => {
-    app = await getTestApp();
+    app = await createFreshTestApp();
     fixture = await getReadonlyFixture(app);
   });
 
   afterAll(async () => {
-    await closeTestApp();
+    await app.close();
   });
 
   describe('me query', () => {

--- a/src/api/graphql-api/__tests__/auth/issue-access-token.spec.ts
+++ b/src/api/graphql-api/__tests__/auth/issue-access-token.spec.ts
@@ -1,5 +1,4 @@
-import { INestApplication, ValidationPipe } from '@nestjs/common';
-import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
 import request from 'supertest';
 import {
   prepareData,
@@ -7,8 +6,7 @@ import {
 } from 'src/testing/utils/prepareProject';
 import { gql } from 'src/testing/utils/gql';
 import { graphqlQuery, graphqlQueryError } from 'src/testing/utils/queryTest';
-import { CoreModule } from 'src/core/core.module';
-import { registerGraphqlEnums } from 'src/api/graphql-api/registerGraphqlEnums';
+import { createFreshTestApp } from 'src/testing/e2e';
 
 const ISSUE_ACCESS_TOKEN = gql`
   query issueAccessToken {
@@ -33,15 +31,7 @@ describe('graphql - issueAccessToken', () => {
   let app: INestApplication;
 
   beforeAll(async () => {
-    registerGraphqlEnums();
-
-    const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [CoreModule.forRoot({ mode: 'monolith' })],
-    }).compile();
-
-    app = moduleFixture.createNestApplication();
-    app.useGlobalPipes(new ValidationPipe({ transform: true }));
-    await app.init();
+    app = await createFreshTestApp();
   });
 
   afterAll(async () => {

--- a/src/api/graphql-api/__tests__/branch/branch.resolver.spec.ts
+++ b/src/api/graphql-api/__tests__/branch/branch.resolver.spec.ts
@@ -1,13 +1,11 @@
-import { INestApplication, ValidationPipe } from '@nestjs/common';
-import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
 import { nanoid } from 'nanoid';
 import request from 'supertest';
 import {
   prepareData,
   PrepareDataReturnType,
 } from 'src/testing/utils/prepareProject';
-import { CoreModule } from 'src/core/core.module';
-import { registerGraphqlEnums } from 'src/api/graphql-api/registerGraphqlEnums';
+import { createFreshTestApp } from 'src/testing/e2e';
 import { PrismaService } from 'src/infrastructure/database/prisma.service';
 
 const DELETE_BRANCH_MUTATION = `
@@ -241,16 +239,8 @@ describe('graphql - BranchResolver', () => {
   });
 
   beforeAll(async () => {
-    registerGraphqlEnums();
-
-    const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [CoreModule.forRoot({ mode: 'monolith' })],
-    }).compile();
-
-    app = moduleFixture.createNestApplication();
-    app.useGlobalPipes(new ValidationPipe({ transform: true }));
+    app = await createFreshTestApp();
     prismaService = app.get(PrismaService);
-    await app.init();
   });
 
   afterAll(async () => {

--- a/src/api/graphql-api/__tests__/draft/draft.spec.ts
+++ b/src/api/graphql-api/__tests__/draft/draft.spec.ts
@@ -1,26 +1,17 @@
 import { INestApplication } from '@nestjs/common';
-import { Test, TestingModule } from '@nestjs/testing';
 import { gql } from 'src/testing/utils/gql';
 import {
   prepareData,
   PrepareDataReturnType,
 } from 'src/testing/utils/prepareProject';
 import { graphqlQuery, graphqlQueryError } from 'src/testing/utils/queryTest';
-import { CoreModule } from 'src/core/core.module';
-import { registerGraphqlEnums } from 'src/api/graphql-api/registerGraphqlEnums';
+import { createFreshTestApp } from 'src/testing/e2e';
 
 describe('graphql - draft', () => {
   let app: INestApplication;
 
   beforeAll(async () => {
-    registerGraphqlEnums();
-
-    const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [CoreModule.forRoot({ mode: 'monolith' })],
-    }).compile();
-
-    app = moduleFixture.createNestApplication();
-    await app.init();
+    app = await createFreshTestApp();
   });
 
   afterAll(async () => {

--- a/src/api/graphql-api/__tests__/draft/row.spec.ts
+++ b/src/api/graphql-api/__tests__/draft/row.spec.ts
@@ -1,5 +1,4 @@
 import { INestApplication } from '@nestjs/common';
-import { Test, TestingModule } from '@nestjs/testing';
 import { Prisma } from 'src/__generated__/client';
 import { gql } from 'src/testing/utils/gql';
 import {
@@ -8,8 +7,7 @@ import {
 } from 'src/testing/utils/prepareProject';
 import { graphqlQuery, graphqlQueryError } from 'src/testing/utils/queryTest';
 import { OrderByField, OrderDataType } from 'src/api/graphql-api/row/inputs';
-import { CoreModule } from 'src/core/core.module';
-import { registerGraphqlEnums } from 'src/api/graphql-api/registerGraphqlEnums';
+import { createFreshTestApp } from 'src/testing/e2e';
 
 describe('row', () => {
   describe('row', () => {
@@ -166,21 +164,11 @@ describe('row', () => {
   let preparedData: PrepareDataReturnType;
 
   beforeAll(async () => {
-    registerGraphqlEnums();
-
-    const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [CoreModule.forRoot({ mode: 'monolith' })],
-    }).compile();
-
-    app = moduleFixture.createNestApplication();
-    await app.init();
+    app = await createFreshTestApp();
+    preparedData = await prepareData(app, { createLinkedTable: true });
   });
 
   afterAll(async () => {
     await app.close();
-  });
-
-  beforeAll(async () => {
-    preparedData = await prepareData(app, { createLinkedTable: true });
   });
 });

--- a/src/api/graphql-api/__tests__/organization/organization.spec.ts
+++ b/src/api/graphql-api/__tests__/organization/organization.spec.ts
@@ -1,26 +1,17 @@
 import { INestApplication } from '@nestjs/common';
-import { Test, TestingModule } from '@nestjs/testing';
 import { gql } from 'src/testing/utils/gql';
 import {
   prepareData,
   PrepareDataReturnType,
 } from 'src/testing/utils/prepareProject';
 import { graphqlQuery, graphqlQueryError } from 'src/testing/utils/queryTest';
-import { CoreModule } from 'src/core/core.module';
-import { registerGraphqlEnums } from 'src/api/graphql-api/registerGraphqlEnums';
+import { createFreshTestApp } from 'src/testing/e2e';
 
 describe('graphql - organization', () => {
   let app: INestApplication;
 
   beforeAll(async () => {
-    registerGraphqlEnums();
-
-    const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [CoreModule.forRoot({ mode: 'monolith' })],
-    }).compile();
-
-    app = moduleFixture.createNestApplication();
-    await app.init();
+    app = await createFreshTestApp();
   });
 
   afterAll(async () => {

--- a/src/api/graphql-api/__tests__/revision-changes/table-changes.spec.ts
+++ b/src/api/graphql-api/__tests__/revision-changes/table-changes.spec.ts
@@ -1,5 +1,4 @@
 import { INestApplication } from '@nestjs/common';
-import { Test, TestingModule } from '@nestjs/testing';
 import { nanoid } from 'nanoid';
 import { gql } from 'src/testing/utils/gql';
 import {
@@ -7,8 +6,7 @@ import {
   PrepareDataReturnType,
 } from 'src/testing/utils/prepareProject';
 import { graphqlQuery, graphqlQueryError } from 'src/testing/utils/queryTest';
-import { CoreModule } from 'src/core/core.module';
-import { registerGraphqlEnums } from 'src/api/graphql-api/registerGraphqlEnums';
+import { createFreshTestApp } from 'src/testing/e2e';
 import { PrismaService } from 'src/infrastructure/database/prisma.service';
 import { SystemTables } from 'src/features/share/system-tables.consts';
 
@@ -17,15 +15,8 @@ describe('graphql - tableChanges', () => {
   let prismaService: PrismaService;
 
   beforeAll(async () => {
-    registerGraphqlEnums();
-
-    const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [CoreModule.forRoot({ mode: 'monolith' })],
-    }).compile();
-
-    app = moduleFixture.createNestApplication();
-    prismaService = moduleFixture.get(PrismaService);
-    await app.init();
+    app = await createFreshTestApp();
+    prismaService = app.get(PrismaService);
   });
 
   afterAll(async () => {

--- a/src/api/graphql-api/api-key/__tests__/api-key.e2e.spec.ts
+++ b/src/api/graphql-api/api-key/__tests__/api-key.e2e.spec.ts
@@ -1,12 +1,10 @@
-import { INestApplication, ValidationPipe } from '@nestjs/common';
-import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
 import request from 'supertest';
 import {
   prepareData,
   PrepareDataReturnType,
 } from 'src/testing/utils/prepareProject';
-import { CoreModule } from 'src/core/core.module';
-import { registerGraphqlEnums } from 'src/api/graphql-api/registerGraphqlEnums';
+import { createFreshTestApp } from 'src/testing/e2e';
 import { PrismaService } from 'src/infrastructure/database/prisma.service';
 
 const CREATE_PERSONAL_API_KEY = `
@@ -102,16 +100,8 @@ describe('API Key Management (e2e)', () => {
   let prismaService: PrismaService;
 
   beforeAll(async () => {
-    registerGraphqlEnums();
-
-    const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [CoreModule.forRoot({ mode: 'monolith' })],
-    }).compile();
-
-    app = moduleFixture.createNestApplication();
-    app.useGlobalPipes(new ValidationPipe({ transform: true }));
+    app = await createFreshTestApp();
     prismaService = app.get(PrismaService);
-    await app.init();
   });
 
   afterAll(async () => {

--- a/src/api/graphql-api/api-key/__tests__/service-api-key.e2e.spec.ts
+++ b/src/api/graphql-api/api-key/__tests__/service-api-key.e2e.spec.ts
@@ -1,12 +1,10 @@
-import { INestApplication, ValidationPipe } from '@nestjs/common';
-import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
 import request from 'supertest';
 import {
   prepareDataWithRoles,
   PrepareDataWithRolesReturnType,
 } from 'src/testing/utils/prepareProject';
-import { CoreModule } from 'src/core/core.module';
-import { registerGraphqlEnums } from 'src/api/graphql-api/registerGraphqlEnums';
+import { createFreshTestApp } from 'src/testing/e2e';
 
 const CREATE_SERVICE_API_KEY = `
   mutation CreateServiceApiKey($data: CreateServiceApiKeyInput!) {
@@ -74,15 +72,7 @@ describe('Service API Key Management (e2e)', () => {
   let app: INestApplication;
 
   beforeAll(async () => {
-    registerGraphqlEnums();
-
-    const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [CoreModule.forRoot({ mode: 'monolith' })],
-    }).compile();
-
-    app = moduleFixture.createNestApplication();
-    app.useGlobalPipes(new ValidationPipe({ transform: true }));
-    await app.init();
+    app = await createFreshTestApp();
   });
 
   afterAll(async () => {

--- a/src/api/rest-api/__tests__/branch/branch-by-name.controller.spec.ts
+++ b/src/api/rest-api/__tests__/branch/branch-by-name.controller.spec.ts
@@ -1,13 +1,11 @@
-import { INestApplication, ValidationPipe } from '@nestjs/common';
-import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
 import { nanoid } from 'nanoid';
 import request from 'supertest';
 import {
   prepareData,
   PrepareDataReturnType,
 } from 'src/testing/utils/prepareProject';
-import { CoreModule } from 'src/core/core.module';
-import { registerGraphqlEnums } from 'src/api/graphql-api/registerGraphqlEnums';
+import { createFreshTestApp } from 'src/testing/e2e';
 import { PrismaService } from 'src/infrastructure/database/prisma.service';
 
 describe('restapi - BranchByNameController', () => {
@@ -223,16 +221,8 @@ describe('restapi - BranchByNameController', () => {
   });
 
   beforeAll(async () => {
-    registerGraphqlEnums();
-
-    const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [CoreModule.forRoot({ mode: 'monolith' })],
-    }).compile();
-
-    app = moduleFixture.createNestApplication();
-    app.useGlobalPipes(new ValidationPipe({ transform: true }));
+    app = await createFreshTestApp();
     prismaService = app.get(PrismaService);
-    await app.init();
   });
 
   afterAll(async () => {

--- a/src/api/rest-api/__tests__/endpoint/endpoint-by-id.controller.spec.ts
+++ b/src/api/rest-api/__tests__/endpoint/endpoint-by-id.controller.spec.ts
@@ -1,12 +1,10 @@
-import { INestApplication, ValidationPipe } from '@nestjs/common';
-import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
 import request from 'supertest';
 import {
   prepareData,
   PrepareDataReturnType,
 } from 'src/testing/utils/prepareProject';
-import { CoreModule } from 'src/core/core.module';
-import { registerGraphqlEnums } from 'src/api/graphql-api/registerGraphqlEnums';
+import { createFreshTestApp } from 'src/testing/e2e';
 import { PrismaService } from 'src/infrastructure/database/prisma.service';
 
 describe('restapi - EndpointByIdController', () => {
@@ -257,16 +255,8 @@ describe('restapi - EndpointByIdController', () => {
   });
 
   beforeAll(async () => {
-    registerGraphqlEnums();
-
-    const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [CoreModule.forRoot({ mode: 'monolith' })],
-    }).compile();
-
-    app = moduleFixture.createNestApplication();
-    app.useGlobalPipes(new ValidationPipe({ transform: true }));
+    app = await createFreshTestApp();
     prismaService = app.get(PrismaService);
-    await app.init();
   });
 
   afterAll(async () => {

--- a/src/api/rest-api/__tests__/project/project.spec.ts
+++ b/src/api/rest-api/__tests__/project/project.spec.ts
@@ -1,11 +1,9 @@
-import { INestApplication, ValidationPipe } from '@nestjs/common';
-import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
 import {
   prepareData,
   PrepareDataReturnType,
 } from 'src/testing/utils/prepareProject';
-import { CoreModule } from 'src/core/core.module';
-import { registerGraphqlEnums } from 'src/api/graphql-api/registerGraphqlEnums';
+import { createFreshTestApp } from 'src/testing/e2e';
 import { PrismaService } from 'src/infrastructure/database/prisma.service';
 import { UserProjectRoles } from 'src/features/auth/consts';
 import { nanoid } from 'nanoid';
@@ -16,20 +14,8 @@ describe('restapi - project', () => {
   let prismaService: PrismaService;
 
   beforeAll(async () => {
-    registerGraphqlEnums();
-
-    const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [CoreModule.forRoot({ mode: 'monolith' })],
-    }).compile();
-
-    app = moduleFixture.createNestApplication();
-    app.useGlobalPipes(
-      new ValidationPipe({
-        transform: true,
-      }),
-    );
+    app = await createFreshTestApp();
     prismaService = app.get(PrismaService);
-    await app.init();
   });
 
   afterAll(async () => {

--- a/src/api/rest-api/__tests__/revision/revision-by-id.spec.ts
+++ b/src/api/rest-api/__tests__/revision/revision-by-id.spec.ts
@@ -1,12 +1,10 @@
-import { INestApplication, ValidationPipe } from '@nestjs/common';
-import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
 import { nanoid } from 'nanoid';
 import {
   prepareData,
   PrepareDataReturnType,
 } from 'src/testing/utils/prepareProject';
-import { CoreModule } from 'src/core/core.module';
-import { registerGraphqlEnums } from 'src/api/graphql-api/registerGraphqlEnums';
+import { createFreshTestApp } from 'src/testing/e2e';
 import { PrismaService } from 'src/infrastructure/database/prisma.service';
 import { EndpointType } from 'src/api/graphql-api/endpoint/model/endpoint.model';
 import request from 'supertest';
@@ -16,20 +14,8 @@ describe('restapi - revision-by-id', () => {
   let prismaService: PrismaService;
 
   beforeAll(async () => {
-    registerGraphqlEnums();
-
-    const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [CoreModule.forRoot({ mode: 'monolith' })],
-    }).compile();
-
-    app = moduleFixture.createNestApplication();
+    app = await createFreshTestApp();
     prismaService = app.get(PrismaService);
-    app.useGlobalPipes(
-      new ValidationPipe({
-        transform: true,
-      }),
-    );
-    await app.init();
   });
 
   afterAll(async () => {

--- a/src/api/rest-api/__tests__/revision/revision-changes.spec.ts
+++ b/src/api/rest-api/__tests__/revision/revision-changes.spec.ts
@@ -1,11 +1,9 @@
-import { INestApplication, ValidationPipe } from '@nestjs/common';
-import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
 import {
   prepareData,
   PrepareDataReturnType,
 } from 'src/testing/utils/prepareProject';
-import { CoreModule } from 'src/core/core.module';
-import { registerGraphqlEnums } from 'src/api/graphql-api/registerGraphqlEnums';
+import { createFreshTestApp } from 'src/testing/e2e';
 import { PrismaService } from 'src/infrastructure/database/prisma.service';
 import request from 'supertest';
 
@@ -14,20 +12,8 @@ describe('restapi - revision-changes', () => {
   let prismaService: PrismaService;
 
   beforeAll(async () => {
-    registerGraphqlEnums();
-
-    const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [CoreModule.forRoot({ mode: 'monolith' })],
-    }).compile();
-
-    app = moduleFixture.createNestApplication();
+    app = await createFreshTestApp();
     prismaService = app.get(PrismaService);
-    app.useGlobalPipes(
-      new ValidationPipe({
-        transform: true,
-      }),
-    );
-    await app.init();
   });
 
   afterAll(async () => {

--- a/src/api/rest-api/__tests__/row/patch-row.spec.ts
+++ b/src/api/rest-api/__tests__/row/patch-row.spec.ts
@@ -1,11 +1,9 @@
 import { INestApplication } from '@nestjs/common';
-import { Test, TestingModule } from '@nestjs/testing';
 import {
   prepareData,
   PrepareDataReturnType,
 } from 'src/testing/utils/prepareProject';
-import { CoreModule } from 'src/core/core.module';
-import { registerGraphqlEnums } from 'src/api/graphql-api/registerGraphqlEnums';
+import { createFreshTestApp } from 'src/testing/e2e';
 import { PrismaService } from 'src/infrastructure/database/prisma.service';
 import request from 'supertest';
 
@@ -14,15 +12,8 @@ describe('restapi - patch-row', () => {
   let prismaService: PrismaService;
 
   beforeAll(async () => {
-    registerGraphqlEnums();
-
-    const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [CoreModule.forRoot({ mode: 'monolith' })],
-    }).compile();
-
-    app = moduleFixture.createNestApplication();
+    app = await createFreshTestApp();
     prismaService = app.get(PrismaService);
-    await app.init();
   });
 
   afterAll(async () => {

--- a/src/api/rest-api/__tests__/row/row-by-id.spec.ts
+++ b/src/api/rest-api/__tests__/row/row-by-id.spec.ts
@@ -1,12 +1,10 @@
-import { INestApplication, ValidationPipe } from '@nestjs/common';
-import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
 import { createExpressImageFile } from 'src/testing/utils/file';
 import {
   prepareData,
   PrepareDataReturnType,
 } from 'src/testing/utils/prepareProject';
-import { CoreModule } from 'src/core/core.module';
-import { registerGraphqlEnums } from 'src/api/graphql-api/registerGraphqlEnums';
+import { createFreshTestApp } from 'src/testing/e2e';
 import { PrismaService } from 'src/infrastructure/database/prisma.service';
 import request from 'supertest';
 
@@ -15,16 +13,8 @@ describe('restapi - row-by-id', () => {
   let prismaService: PrismaService;
 
   beforeAll(async () => {
-    registerGraphqlEnums();
-
-    const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [CoreModule.forRoot({ mode: 'monolith' })],
-    }).compile();
-
-    app = moduleFixture.createNestApplication();
-    app.useGlobalPipes(new ValidationPipe({ transform: true }));
+    app = await createFreshTestApp();
     prismaService = app.get(PrismaService);
-    await app.init();
   });
 
   afterAll(async () => {

--- a/src/api/rest-api/__tests__/table/table-by-id.spec.ts
+++ b/src/api/rest-api/__tests__/table/table-by-id.spec.ts
@@ -1,11 +1,9 @@
-import { INestApplication, ValidationPipe } from '@nestjs/common';
-import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
 import {
   prepareData,
   PrepareDataReturnType,
 } from 'src/testing/utils/prepareProject';
-import { CoreModule } from 'src/core/core.module';
-import { registerGraphqlEnums } from 'src/api/graphql-api/registerGraphqlEnums';
+import { createFreshTestApp } from 'src/testing/e2e';
 import { PrismaService } from 'src/infrastructure/database/prisma.service';
 import request from 'supertest';
 
@@ -14,16 +12,8 @@ describe('restapi - table-by-id', () => {
   let prismaService: PrismaService;
 
   beforeAll(async () => {
-    registerGraphqlEnums();
-
-    const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [CoreModule.forRoot({ mode: 'monolith' })],
-    }).compile();
-
-    app = moduleFixture.createNestApplication();
-    app.useGlobalPipes(new ValidationPipe({ transform: true }));
+    app = await createFreshTestApp();
     prismaService = app.get(PrismaService);
-    await app.init();
   });
 
   afterAll(async () => {

--- a/src/testing/e2e/test-app.ts
+++ b/src/testing/e2e/test-app.ts
@@ -1,6 +1,7 @@
 import { INestApplication, ValidationPipe } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import cookieParser from 'cookie-parser';
+import * as promClient from 'prom-client';
 import { CoreModule } from 'src/core/core.module';
 import { registerGraphqlEnums } from 'src/api/graphql-api/registerGraphqlEnums';
 import { PrismaService } from 'src/infrastructure/database/prisma.service';
@@ -8,10 +9,13 @@ import { PrismaService } from 'src/infrastructure/database/prisma.service';
 let cachedApp: INestApplication | null = null;
 let cachedPrismaService: PrismaService | null = null;
 
-export async function getTestApp(): Promise<INestApplication> {
-  if (cachedApp) {
-    return cachedApp;
-  }
+async function buildApp(): Promise<INestApplication> {
+  // Per-worker, per-bootstrap: clear the prom-client default registry so
+  // that rebuilding CoreModule inside the same Node process (e.g. after a
+  // previous spec closed its app) does not hit "metric already registered"
+  // when GraphqlMetricsService / RestMetricsService register their
+  // histograms and counters.
+  promClient.register.clear();
 
   registerGraphqlEnums();
 
@@ -19,16 +23,26 @@ export async function getTestApp(): Promise<INestApplication> {
     imports: [CoreModule.forRoot({ mode: 'monolith' })],
   }).compile();
 
-  cachedApp = moduleFixture.createNestApplication();
-  cachedApp.use(cookieParser());
-  cachedApp.useGlobalPipes(
+  const app = moduleFixture.createNestApplication();
+  app.use(cookieParser());
+  app.useGlobalPipes(
     new ValidationPipe({
       transform: true,
     }),
   );
 
+  await app.init();
+
+  return app;
+}
+
+export async function getTestApp(): Promise<INestApplication> {
+  if (cachedApp) {
+    return cachedApp;
+  }
+
+  cachedApp = await buildApp();
   cachedPrismaService = cachedApp.get(PrismaService);
-  await cachedApp.init();
 
   return cachedApp;
 }
@@ -49,21 +63,5 @@ export async function closeTestApp(): Promise<void> {
 }
 
 export async function createFreshTestApp(): Promise<INestApplication> {
-  registerGraphqlEnums();
-
-  const moduleFixture: TestingModule = await Test.createTestingModule({
-    imports: [CoreModule.forRoot({ mode: 'monolith' })],
-  }).compile();
-
-  const app = moduleFixture.createNestApplication();
-  app.use(cookieParser());
-  app.useGlobalPipes(
-    new ValidationPipe({
-      transform: true,
-    }),
-  );
-
-  await app.init();
-
-  return app;
+  return buildApp();
 }

--- a/src/testing/e2e/test-app.ts
+++ b/src/testing/e2e/test-app.ts
@@ -10,13 +10,6 @@ let cachedApp: INestApplication | null = null;
 let cachedPrismaService: PrismaService | null = null;
 
 async function buildApp(): Promise<INestApplication> {
-  // Per-worker, per-bootstrap: clear the prom-client default registry so
-  // that rebuilding CoreModule inside the same Node process (e.g. after a
-  // previous spec closed its app) does not hit "metric already registered"
-  // when GraphqlMetricsService / RestMetricsService register their
-  // histograms and counters.
-  promClient.register.clear();
-
   registerGraphqlEnums();
 
   const moduleFixture: TestingModule = await Test.createTestingModule({
@@ -63,5 +56,12 @@ export async function closeTestApp(): Promise<void> {
 }
 
 export async function createFreshTestApp(): Promise<INestApplication> {
+  // Clear the prom-client default registry before rebuilding CoreModule in
+  // the same Node process so GraphqlMetricsService / RestMetricsService can
+  // re-register their histograms and counters without hitting "metric
+  // already registered". Scoped to createFreshTestApp so a cached getTestApp
+  // (called in the same worker) does not get its metrics wiped by a later
+  // fresh app build.
+  promClient.register.clear();
   return buildApp();
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Consolidated e2e transport specs to use `createFreshTestApp()` for consistent, isolated app bootstrapping. Centralized boot logic in `test-app.ts` and scoped `prom-client` registry clearing to `createFreshTestApp()` to prevent duplicate metric errors without affecting cached `getTestApp()` instances.

- **Refactors**
  - Migrated 27 REST/GraphQL/MCP specs from ad‑hoc Nest setups to `createFreshTestApp()`.
  - Centralized boot logic in `test-app.ts` via a `buildApp()` helper; `getTestApp()` now uses it too.
  - Replaced `getPrismaService()` with `app.get(PrismaService)` in sub-schema tests.
  - Updated readonly GraphQL specs to call `app.close()` instead of `closeTestApp()`.

- **Bug Fixes**
  - Clear `prom-client`’s default registry only in `createFreshTestApp()` to avoid “metric already registered” and keep metrics from cached `getTestApp()` intact.
  - Removed race conditions that caused intermittent crashes in parallel workers (e.g., MCP endpoint specs).

<sup>Written for commit befc8372823aea45bcb5eb0b52085f22c3216b68. Summary will update on new commits. <a href="https://cubic.dev/pr/revisium/revisium-core/pull/500">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

