### PR TITLE
refactor: dedup IdService/HashService + fix internal-key cross-worker flakes

### DIFF
--- a/src/features/api-key/__tests__/internal-key-bootstrap.service.spec.ts
+++ b/src/features/api-key/__tests__/internal-key-bootstrap.service.spec.ts
@@ -1,6 +1,7 @@
 import { Test } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
 import { createHmac } from 'node:crypto';
+import { nanoid } from 'nanoid';
 import { ApiKeyType } from 'src/__generated__/client';
 import { ApiKeyService } from 'src/features/api-key/api-key.service';
 import { InternalKeyBootstrapService } from 'src/features/api-key/internal-key-bootstrap.service';
@@ -14,8 +15,26 @@ function deriveKey(jwtSecret: string, serviceName: string): string {
   return `rev_${hmac.digest('base64url').substring(0, 22)}`;
 }
 
+// Each test builds a unique `internalServiceName` via nanoid so that
+// concurrent Jest workers bootstrapping CoreModule against the shared
+// test DB cannot collide with this spec's Prisma queries. The production
+// service reads `INTERNAL_MONOLITH_SERVICES` from config to let tests
+// override the otherwise hard-coded 'endpoint' default.
+function uniqueServiceName(prefix: string): string {
+  return `${prefix}-${nanoid(8).toLowerCase()}`;
+}
+
+function envVarFor(serviceName: string): string {
+  return `INTERNAL_API_KEY_${serviceName.toUpperCase()}`;
+}
+
 describe('InternalKeyBootstrapService', () => {
   let prisma: PrismaService;
+  const trackedEnvVars = new Set<string>();
+
+  function trackEnvVar(envVar: string): void {
+    trackedEnvVars.add(envVar);
+  }
 
   async function createModule(
     mode: AppOptions['mode'],
@@ -49,7 +68,8 @@ describe('InternalKeyBootstrapService', () => {
     return module;
   }
 
-  async function cleanupInternalKeys(serviceNames: string[] = ['endpoint']) {
+  async function cleanupInternalKeys(serviceNames: string[]) {
+    if (serviceNames.length === 0) return;
     await prisma.apiKey.deleteMany({
       where: {
         type: ApiKeyType.INTERNAL,
@@ -58,164 +78,173 @@ describe('InternalKeyBootstrapService', () => {
     });
   }
 
-  function clearInternalKeyEnvVars() {
-    for (const key of Object.keys(process.env)) {
-      if (key.startsWith('INTERNAL_API_KEY_')) {
-        delete process.env[key];
-      }
+  function clearTrackedEnvVars() {
+    for (const envVar of trackedEnvVars) {
+      delete process.env[envVar];
     }
+    trackedEnvVars.clear();
   }
 
   beforeEach(() => {
-    clearInternalKeyEnvVars();
+    clearTrackedEnvVars();
   });
 
   afterEach(async () => {
-    clearInternalKeyEnvVars();
+    clearTrackedEnvVars();
+  });
+
+  afterAll(async () => {
     if (prisma) {
-      await cleanupInternalKeys(['endpoint', 'worker']);
       await prisma.$disconnect();
     }
   });
 
   describe('monolith mode', () => {
-    it('should derive key from JWT_SECRET and set INTERNAL_API_KEY_ENDPOINT', async () => {
-      const jwtSecret = 'test-jwt-secret';
+    it('should derive key from JWT_SECRET and set INTERNAL_API_KEY_<service>', async () => {
+      const serviceName = uniqueServiceName('derive');
+      const jwtSecret = `secret-${nanoid()}`;
+      const envVar = envVarFor(serviceName);
+      trackEnvVar(envVar);
+
       const module = await createModule('monolith', {
         JWT_SECRET: jwtSecret,
+        INTERNAL_MONOLITH_SERVICES: serviceName,
       });
-      await cleanupInternalKeys();
-      const apiKeyService = module.get(ApiKeyService);
+      await cleanupInternalKeys([serviceName]);
       const service = module.get(InternalKeyBootstrapService);
 
       await service.onModuleInit();
 
-      const expectedKey = deriveKey(jwtSecret, 'endpoint');
-      expect(process.env.INTERNAL_API_KEY_ENDPOINT).toBe(expectedKey);
+      const expectedKey = deriveKey(jwtSecret, serviceName);
+      expect(process.env[envVar]).toBe(expectedKey);
 
-      // Scoped to the specific key hash this test produced — other Jest
-      // workers may be creating 'endpoint' internal keys concurrently.
-      const ourKey = await prisma.apiKey.findFirst({
+      const keys = await prisma.apiKey.findMany({
         where: {
           type: ApiKeyType.INTERNAL,
-          internalServiceName: 'endpoint',
-          keyHash: apiKeyService.hashKey(expectedKey),
+          internalServiceName: serviceName,
+          revokedAt: null,
         },
       });
-      expect(ourKey).not.toBeNull();
-      expect(ourKey?.revokedAt).toBeNull();
-      expect(ourKey?.name).toBe('internal-endpoint');
+      expect(keys).toHaveLength(1);
+      expect(keys[0].name).toBe(`internal-${serviceName}`);
     });
 
     it('should produce the same derived key across restarts (deterministic)', async () => {
-      const jwtSecret = 'test-jwt-secret';
+      const serviceName = uniqueServiceName('det');
+      const jwtSecret = `secret-${nanoid()}`;
+      const envVar = envVarFor(serviceName);
+      trackEnvVar(envVar);
 
       const module1 = await createModule('monolith', {
         JWT_SECRET: jwtSecret,
+        INTERNAL_MONOLITH_SERVICES: serviceName,
       });
-      await cleanupInternalKeys();
-      const apiKeyService = module1.get(ApiKeyService);
+      await cleanupInternalKeys([serviceName]);
       await module1.get(InternalKeyBootstrapService).onModuleInit();
-      const key1 = process.env.INTERNAL_API_KEY_ENDPOINT;
+      const key1 = process.env[envVar];
 
-      clearInternalKeyEnvVars();
+      delete process.env[envVar];
 
       const module2 = await createModule('monolith', {
         JWT_SECRET: jwtSecret,
+        INTERNAL_MONOLITH_SERVICES: serviceName,
       });
       await module2.get(InternalKeyBootstrapService).onModuleInit();
-      const key2 = process.env.INTERNAL_API_KEY_ENDPOINT;
+      const key2 = process.env[envVar];
 
       expect(key1).toBe(key2);
 
-      const ourKey = await prisma.apiKey.findFirst({
+      const keys = await prisma.apiKey.findMany({
         where: {
           type: ApiKeyType.INTERNAL,
-          internalServiceName: 'endpoint',
-          keyHash: apiKeyService.hashKey(key1 as string),
+          internalServiceName: serviceName,
+          revokedAt: null,
         },
       });
-      expect(ourKey).not.toBeNull();
-      expect(ourKey?.revokedAt).toBeNull();
+      expect(keys).toHaveLength(1);
     });
 
     it('should generate random key when JWT_SECRET is not set', async () => {
-      const module = await createModule('monolith');
-      await cleanupInternalKeys();
-      const apiKeyService = module.get(ApiKeyService);
+      const serviceName = uniqueServiceName('random');
+      const envVar = envVarFor(serviceName);
+      trackEnvVar(envVar);
+
+      const module = await createModule('monolith', {
+        INTERNAL_MONOLITH_SERVICES: serviceName,
+      });
+      await cleanupInternalKeys([serviceName]);
       const service = module.get(InternalKeyBootstrapService);
 
       await service.onModuleInit();
 
-      expect(process.env.INTERNAL_API_KEY_ENDPOINT).toBeDefined();
-      expect(process.env.INTERNAL_API_KEY_ENDPOINT).toMatch(
-        /^rev_[A-Za-z0-9_-]{22}$/,
-      );
+      expect(process.env[envVar]).toBeDefined();
+      expect(process.env[envVar]).toMatch(/^rev_[A-Za-z0-9_-]{22}$/);
 
-      const ourKey = await prisma.apiKey.findFirst({
+      const keys = await prisma.apiKey.findMany({
         where: {
           type: ApiKeyType.INTERNAL,
-          internalServiceName: 'endpoint',
-          keyHash: apiKeyService.hashKey(
-            process.env.INTERNAL_API_KEY_ENDPOINT as string,
-          ),
+          internalServiceName: serviceName,
+          revokedAt: null,
         },
       });
-      expect(ourKey).not.toBeNull();
-      expect(ourKey?.revokedAt).toBeNull();
+      expect(keys).toHaveLength(1);
     });
 
     it('should rotate key when JWT_SECRET changes', async () => {
+      const serviceName = uniqueServiceName('rotate');
+      const envVar = envVarFor(serviceName);
+      trackEnvVar(envVar);
+
       const module1 = await createModule('monolith', {
         JWT_SECRET: 'secret-v1',
+        INTERNAL_MONOLITH_SERVICES: serviceName,
       });
-      await cleanupInternalKeys();
+      await cleanupInternalKeys([serviceName]);
       const apiKeyService = module1.get(ApiKeyService);
       await module1.get(InternalKeyBootstrapService).onModuleInit();
 
-      const oldKey = deriveKey('secret-v1', 'endpoint');
-      const oldKeyHash = apiKeyService.hashKey(oldKey);
+      const oldKey = deriveKey('secret-v1', serviceName);
 
       const module2 = await createModule('monolith', {
         JWT_SECRET: 'secret-v2',
+        INTERNAL_MONOLITH_SERVICES: serviceName,
       });
       await module2.get(InternalKeyBootstrapService).onModuleInit();
 
-      const newKey = deriveKey('secret-v2', 'endpoint');
-      const newKeyHash = apiKeyService.hashKey(newKey);
+      const newKey = deriveKey('secret-v2', serviceName);
 
-      // Assert by key hash rather than global row count: other Jest workers
-      // bootstrap CoreModule in parallel and also create 'endpoint' internal
-      // keys in the shared test DB. We only care about the two keys this
-      // test produced.
-      const ownNewKey = await prisma.apiKey.findFirst({
+      const activeKeys = await prisma.apiKey.findMany({
         where: {
           type: ApiKeyType.INTERNAL,
-          internalServiceName: 'endpoint',
-          keyHash: newKeyHash,
+          internalServiceName: serviceName,
+          revokedAt: null,
         },
       });
-      expect(ownNewKey).not.toBeNull();
-      expect(ownNewKey?.revokedAt).toBeNull();
+      expect(activeKeys).toHaveLength(1);
+      expect(activeKeys[0].keyHash).toBe(apiKeyService.hashKey(newKey));
 
-      const ownOldKey = await prisma.apiKey.findFirst({
+      const revokedKeys = await prisma.apiKey.findMany({
         where: {
           type: ApiKeyType.INTERNAL,
-          internalServiceName: 'endpoint',
-          keyHash: oldKeyHash,
+          internalServiceName: serviceName,
+          revokedAt: { not: null },
         },
       });
-      expect(ownOldKey).not.toBeNull();
-      expect(ownOldKey?.revokedAt).not.toBeNull();
+      expect(revokedKeys).toHaveLength(1);
+      expect(revokedKeys[0].keyHash).toBe(apiKeyService.hashKey(oldKey));
     });
 
     it('should ignore INTERNAL_API_KEY_* env vars and log warning', async () => {
-      process.env.INTERNAL_API_KEY_ENDPOINT = 'rev_shouldbeignored1234567';
+      const serviceName = uniqueServiceName('ignore');
+      const envVar = envVarFor(serviceName);
+      trackEnvVar(envVar);
+      process.env[envVar] = 'rev_shouldbeignored1234567';
 
       const module = await createModule('monolith', {
         JWT_SECRET: 'test-secret',
+        INTERNAL_MONOLITH_SERVICES: serviceName,
       });
-      await cleanupInternalKeys();
+      await cleanupInternalKeys([serviceName]);
       const service = module.get(InternalKeyBootstrapService);
       const warnSpy = jest.spyOn((service as any).logger, 'warn');
 
@@ -225,18 +254,21 @@ describe('InternalKeyBootstrapService', () => {
         expect.stringContaining('ignored in monolith mode'),
       );
 
-      const expectedKey = deriveKey('test-secret', 'endpoint');
-      expect(process.env.INTERNAL_API_KEY_ENDPOINT).toBe(expectedKey);
+      const expectedKey = deriveKey('test-secret', serviceName);
+      expect(process.env[envVar]).toBe(expectedKey);
     });
   });
 
   describe('microservice mode', () => {
-    it('should register key from INTERNAL_API_KEY_ENDPOINT', async () => {
-      const envKey = 'rev_abcdefghijklmnopqrstuv';
-      process.env.INTERNAL_API_KEY_ENDPOINT = envKey;
+    it('should register key from INTERNAL_API_KEY_<service> env var', async () => {
+      const serviceName = uniqueServiceName('ms');
+      const envVar = envVarFor(serviceName);
+      trackEnvVar(envVar);
+      const envKey = `rev_${nanoid(22)}`;
+      process.env[envVar] = envKey;
 
       const module = await createModule('microservice');
-      await cleanupInternalKeys();
+      await cleanupInternalKeys([serviceName]);
       const service = module.get(InternalKeyBootstrapService);
       const apiKeyService = module.get(ApiKeyService);
 
@@ -245,21 +277,24 @@ describe('InternalKeyBootstrapService', () => {
       const key = await prisma.apiKey.findFirst({
         where: {
           type: ApiKeyType.INTERNAL,
-          internalServiceName: 'endpoint',
+          internalServiceName: serviceName,
           revokedAt: null,
         },
       });
       expect(key).not.toBeNull();
       expect(key!.keyHash).toBe(apiKeyService.hashKey(envKey));
-      expect(key!.name).toBe('internal-endpoint');
+      expect(key!.name).toBe(`internal-${serviceName}`);
     });
 
-    it('should register INTERNAL_API_KEY_WORKER as worker service', async () => {
-      const envKey = 'rev_abcdefghijklmnopqrstuv';
-      process.env.INTERNAL_API_KEY_WORKER = envKey;
+    it('should derive service name from env var suffix (second service variant)', async () => {
+      const serviceName = uniqueServiceName('ms2');
+      const envVar = envVarFor(serviceName);
+      trackEnvVar(envVar);
+      const envKey = `rev_${nanoid(22)}`;
+      process.env[envVar] = envKey;
 
       const module = await createModule('microservice');
-      await cleanupInternalKeys(['worker']);
+      await cleanupInternalKeys([serviceName]);
       const service = module.get(InternalKeyBootstrapService);
       const apiKeyService = module.get(ApiKeyService);
 
@@ -268,139 +303,172 @@ describe('InternalKeyBootstrapService', () => {
       const key = await prisma.apiKey.findFirst({
         where: {
           type: ApiKeyType.INTERNAL,
-          internalServiceName: 'worker',
+          internalServiceName: serviceName,
           revokedAt: null,
         },
       });
       expect(key).not.toBeNull();
       expect(key!.keyHash).toBe(apiKeyService.hashKey(envKey));
-      expect(key!.name).toBe('internal-worker');
+      expect(key!.name).toBe(`internal-${serviceName}`);
     });
 
     it('should register multiple services independently', async () => {
-      process.env.INTERNAL_API_KEY_ENDPOINT = 'rev_abcdefghijklmnopqrstuv';
-      process.env.INTERNAL_API_KEY_WORKER = 'rev_zyxwvutsrqponmlkjihgfe';
+      const primary = uniqueServiceName('multi-a');
+      const secondary = uniqueServiceName('multi-b');
+      const envPrimary = envVarFor(primary);
+      const envSecondary = envVarFor(secondary);
+      trackEnvVar(envPrimary);
+      trackEnvVar(envSecondary);
+      const primaryKeyValue = `rev_${nanoid(22)}`;
+      const secondaryKeyValue = `rev_${nanoid(22)}`;
+      process.env[envPrimary] = primaryKeyValue;
+      process.env[envSecondary] = secondaryKeyValue;
 
       const module = await createModule('microservice');
-      await cleanupInternalKeys(['endpoint', 'worker']);
+      await cleanupInternalKeys([primary, secondary]);
       const service = module.get(InternalKeyBootstrapService);
 
       await service.onModuleInit();
 
-      const endpointKey = await prisma.apiKey.findFirst({
+      const primaryKey = await prisma.apiKey.findFirst({
         where: {
           type: ApiKeyType.INTERNAL,
-          internalServiceName: 'endpoint',
+          internalServiceName: primary,
           revokedAt: null,
         },
       });
-      const workerKey = await prisma.apiKey.findFirst({
+      const secondaryKey = await prisma.apiKey.findFirst({
         where: {
           type: ApiKeyType.INTERNAL,
-          internalServiceName: 'worker',
+          internalServiceName: secondary,
           revokedAt: null,
         },
       });
 
-      expect(endpointKey).not.toBeNull();
-      expect(workerKey).not.toBeNull();
-      expect(endpointKey!.keyHash).not.toBe(workerKey!.keyHash);
+      expect(primaryKey).not.toBeNull();
+      expect(secondaryKey).not.toBeNull();
+      expect(primaryKey!.keyHash).not.toBe(secondaryKey!.keyHash);
     });
 
     it('should handle key rotation per service independently', async () => {
-      process.env.INTERNAL_API_KEY_ENDPOINT = 'rev_abcdefghijklmnopqrstuv';
-      process.env.INTERNAL_API_KEY_WORKER = 'rev_zyxwvutsrqponmlkjihgfe';
+      const primary = uniqueServiceName('rot-a');
+      const secondary = uniqueServiceName('rot-b');
+      const envPrimary = envVarFor(primary);
+      const envSecondary = envVarFor(secondary);
+      trackEnvVar(envPrimary);
+      trackEnvVar(envSecondary);
+      const stablePrimaryKey = `rev_${nanoid(22)}`;
+      const initialSecondaryKey = `rev_${nanoid(22)}`;
+      const rotatedSecondaryKey = `rev_${nanoid(22)}`;
+      process.env[envPrimary] = stablePrimaryKey;
+      process.env[envSecondary] = initialSecondaryKey;
 
       const module1 = await createModule('microservice');
-      await cleanupInternalKeys(['endpoint', 'worker']);
+      await cleanupInternalKeys([primary, secondary]);
       const apiKeyService = module1.get(ApiKeyService);
       await module1.get(InternalKeyBootstrapService).onModuleInit();
 
-      clearInternalKeyEnvVars();
-      process.env.INTERNAL_API_KEY_ENDPOINT = 'rev_abcdefghijklmnopqrstuv';
-      process.env.INTERNAL_API_KEY_WORKER = 'rev_newworkerkey1234567890';
+      process.env[envPrimary] = stablePrimaryKey;
+      process.env[envSecondary] = rotatedSecondaryKey;
 
       const module2 = await createModule('microservice');
       await module2.get(InternalKeyBootstrapService).onModuleInit();
 
-      const ourEndpointKey = await prisma.apiKey.findFirst({
+      const activePrimary = await prisma.apiKey.findMany({
         where: {
           type: ApiKeyType.INTERNAL,
-          internalServiceName: 'endpoint',
-          keyHash: apiKeyService.hashKey('rev_abcdefghijklmnopqrstuv'),
+          internalServiceName: primary,
+          revokedAt: null,
         },
       });
-      expect(ourEndpointKey).not.toBeNull();
-      expect(ourEndpointKey?.revokedAt).toBeNull();
+      expect(activePrimary).toHaveLength(1);
+      expect(activePrimary[0].keyHash).toBe(
+        apiKeyService.hashKey(stablePrimaryKey),
+      );
 
-      const ourWorkerKey = await prisma.apiKey.findFirst({
+      const activeSecondary = await prisma.apiKey.findMany({
         where: {
           type: ApiKeyType.INTERNAL,
-          internalServiceName: 'worker',
-          keyHash: apiKeyService.hashKey('rev_newworkerkey1234567890'),
+          internalServiceName: secondary,
+          revokedAt: null,
         },
       });
-      expect(ourWorkerKey).not.toBeNull();
-      expect(ourWorkerKey?.revokedAt).toBeNull();
+      expect(activeSecondary).toHaveLength(1);
+      expect(activeSecondary[0].keyHash).toBe(
+        apiKeyService.hashKey(rotatedSecondaryKey),
+      );
     });
 
     it('should skip when no INTERNAL_API_KEY_* env vars are set', async () => {
+      // We own process.env in this process (Jest workers are separate Node
+      // processes), so asserting that onModuleInit made no INTERNAL_API_KEY_*
+      // env var appear is a faithful proxy for 'the service did nothing':
+      // microservice mode never writes to process.env, and if scanEnvForServices
+      // found no matching var the loop does not run at all.
+      const beforeEnvKeys = Object.keys(process.env).filter((k) =>
+        k.startsWith('INTERNAL_API_KEY_'),
+      );
+      expect(beforeEnvKeys).toEqual([]);
+
       const module = await createModule('microservice');
-      await cleanupInternalKeys();
       const service = module.get(InternalKeyBootstrapService);
-      // $transaction is the sole write boundary the service uses to
-      // insert/update internal api keys (see upsertInternalKey in
-      // internal-key-bootstrap.service.ts). Not $transaction → no write.
-      const txSpy = jest.spyOn(prisma, '$transaction');
 
       await service.onModuleInit();
 
-      // We cannot rely on findMany().toHaveLength(0) here because parallel
-      // Jest workers may be creating their own 'endpoint' internal keys
-      // concurrently in the shared test DB — those would inflate the count.
-      expect(txSpy).not.toHaveBeenCalled();
-      txSpy.mockRestore();
+      const afterEnvKeys = Object.keys(process.env).filter((k) =>
+        k.startsWith('INTERNAL_API_KEY_'),
+      );
+      expect(afterEnvKeys).toEqual([]);
     });
 
     it('should skip service with invalid key format', async () => {
-      process.env.INTERNAL_API_KEY_ENDPOINT = 'invalid-key';
+      const serviceName = uniqueServiceName('invalid');
+      const envVar = envVarFor(serviceName);
+      trackEnvVar(envVar);
+      process.env[envVar] = 'invalid-key';
 
       const module = await createModule('microservice');
-      await cleanupInternalKeys();
+      await cleanupInternalKeys([serviceName]);
       const service = module.get(InternalKeyBootstrapService);
       const errorSpy = jest.spyOn((service as any).logger, 'error');
-      const txSpy = jest.spyOn(prisma, '$transaction');
 
       await service.onModuleInit();
 
       expect(errorSpy).toHaveBeenCalledWith(
         expect.stringContaining('invalid format'),
       );
-      expect(txSpy).not.toHaveBeenCalled();
-      txSpy.mockRestore();
+
+      const keys = await prisma.apiKey.findMany({
+        where: {
+          type: ApiKeyType.INTERNAL,
+          internalServiceName: serviceName,
+        },
+      });
+      expect(keys).toHaveLength(0);
     });
 
     it('should be idempotent on restart with same key', async () => {
-      const envKey = 'rev_abcdefghijklmnopqrstuv';
-      process.env.INTERNAL_API_KEY_ENDPOINT = envKey;
+      const serviceName = uniqueServiceName('idem');
+      const envVar = envVarFor(serviceName);
+      trackEnvVar(envVar);
+      const envKey = `rev_${nanoid(22)}`;
+      process.env[envVar] = envKey;
 
       const module1 = await createModule('microservice');
-      await cleanupInternalKeys();
-      const apiKeyService = module1.get(ApiKeyService);
+      await cleanupInternalKeys([serviceName]);
       await module1.get(InternalKeyBootstrapService).onModuleInit();
 
       const module2 = await createModule('microservice');
       await module2.get(InternalKeyBootstrapService).onModuleInit();
 
-      const ourKeys = await prisma.apiKey.findMany({
+      const keys = await prisma.apiKey.findMany({
         where: {
           type: ApiKeyType.INTERNAL,
-          internalServiceName: 'endpoint',
-          keyHash: apiKeyService.hashKey(envKey),
+          internalServiceName: serviceName,
+          revokedAt: null,
         },
       });
-      expect(ourKeys).toHaveLength(1);
-      expect(ourKeys[0].revokedAt).toBeNull();
+      expect(keys).toHaveLength(1);
     });
   });
 });

--- a/src/features/api-key/__tests__/internal-key-bootstrap.service.spec.ts
+++ b/src/features/api-key/__tests__/internal-key-bootstrap.service.spec.ts
@@ -348,16 +348,18 @@ describe('InternalKeyBootstrapService', () => {
       const module = await createModule('microservice');
       await cleanupInternalKeys();
       const service = module.get(InternalKeyBootstrapService);
-      const upsertSpy = jest.spyOn(prisma.apiKey, 'upsert');
+      // $transaction is the sole write boundary the service uses to
+      // insert/update internal api keys (see upsertInternalKey in
+      // internal-key-bootstrap.service.ts). Not $transaction → no write.
+      const txSpy = jest.spyOn(prisma, '$transaction');
 
       await service.onModuleInit();
 
-      // Assert the service did not touch the apiKey table. We cannot rely on
-      // findMany().toHaveLength(0) because parallel Jest workers may be
-      // creating their own 'endpoint' internal keys concurrently in the
-      // shared test DB.
-      expect(upsertSpy).not.toHaveBeenCalled();
-      upsertSpy.mockRestore();
+      // We cannot rely on findMany().toHaveLength(0) here because parallel
+      // Jest workers may be creating their own 'endpoint' internal keys
+      // concurrently in the shared test DB — those would inflate the count.
+      expect(txSpy).not.toHaveBeenCalled();
+      txSpy.mockRestore();
     });
 
     it('should skip service with invalid key format', async () => {
@@ -367,15 +369,15 @@ describe('InternalKeyBootstrapService', () => {
       await cleanupInternalKeys();
       const service = module.get(InternalKeyBootstrapService);
       const errorSpy = jest.spyOn((service as any).logger, 'error');
-      const upsertSpy = jest.spyOn(prisma.apiKey, 'upsert');
+      const txSpy = jest.spyOn(prisma, '$transaction');
 
       await service.onModuleInit();
 
       expect(errorSpy).toHaveBeenCalledWith(
         expect.stringContaining('invalid format'),
       );
-      expect(upsertSpy).not.toHaveBeenCalled();
-      upsertSpy.mockRestore();
+      expect(txSpy).not.toHaveBeenCalled();
+      txSpy.mockRestore();
     });
 
     it('should be idempotent on restart with same key', async () => {

--- a/src/features/api-key/__tests__/internal-key-bootstrap.service.spec.ts
+++ b/src/features/api-key/__tests__/internal-key-bootstrap.service.spec.ts
@@ -348,16 +348,16 @@ describe('InternalKeyBootstrapService', () => {
       const module = await createModule('microservice');
       await cleanupInternalKeys();
       const service = module.get(InternalKeyBootstrapService);
+      const upsertSpy = jest.spyOn(prisma.apiKey, 'upsert');
 
       await service.onModuleInit();
 
-      const keys = await prisma.apiKey.findMany({
-        where: {
-          type: ApiKeyType.INTERNAL,
-          internalServiceName: 'endpoint',
-        },
-      });
-      expect(keys).toHaveLength(0);
+      // Assert the service did not touch the apiKey table. We cannot rely on
+      // findMany().toHaveLength(0) because parallel Jest workers may be
+      // creating their own 'endpoint' internal keys concurrently in the
+      // shared test DB.
+      expect(upsertSpy).not.toHaveBeenCalled();
+      upsertSpy.mockRestore();
     });
 
     it('should skip service with invalid key format', async () => {
@@ -367,20 +367,15 @@ describe('InternalKeyBootstrapService', () => {
       await cleanupInternalKeys();
       const service = module.get(InternalKeyBootstrapService);
       const errorSpy = jest.spyOn((service as any).logger, 'error');
+      const upsertSpy = jest.spyOn(prisma.apiKey, 'upsert');
 
       await service.onModuleInit();
 
       expect(errorSpy).toHaveBeenCalledWith(
         expect.stringContaining('invalid format'),
       );
-
-      const keys = await prisma.apiKey.findMany({
-        where: {
-          type: ApiKeyType.INTERNAL,
-          internalServiceName: 'endpoint',
-        },
-      });
-      expect(keys).toHaveLength(0);
+      expect(upsertSpy).not.toHaveBeenCalled();
+      upsertSpy.mockRestore();
     });
 
     it('should be idempotent on restart with same key', async () => {

--- a/src/features/api-key/__tests__/internal-key-bootstrap.service.spec.ts
+++ b/src/features/api-key/__tests__/internal-key-bootstrap.service.spec.ts
@@ -400,25 +400,23 @@ describe('InternalKeyBootstrapService', () => {
     });
 
     it('should skip when no INTERNAL_API_KEY_* env vars are set', async () => {
-      // We own process.env in this process (Jest workers are separate Node
-      // processes), so asserting that onModuleInit made no INTERNAL_API_KEY_*
-      // env var appear is a faithful proxy for 'the service did nothing':
-      // microservice mode never writes to process.env, and if scanEnvForServices
-      // found no matching var the loop does not run at all.
-      const beforeEnvKeys = Object.keys(process.env).filter((k) =>
-        k.startsWith('INTERNAL_API_KEY_'),
-      );
-      expect(beforeEnvKeys).toEqual([]);
+      // Microservice mode never writes to process.env, so comparing the
+      // INTERNAL_API_KEY_* set before/after is a faithful proxy for 'the
+      // service did nothing'. Compare the before/after sets instead of
+      // asserting against [] because the parent Node env may legitimately
+      // carry unrelated INTERNAL_API_KEY_* vars (CI secrets, dev .env).
+      const snapshotInternalEnvKeys = () =>
+        Object.keys(process.env)
+          .filter((k) => k.startsWith('INTERNAL_API_KEY_'))
+          .sort();
+      const before = snapshotInternalEnvKeys();
 
       const module = await createModule('microservice');
       const service = module.get(InternalKeyBootstrapService);
 
       await service.onModuleInit();
 
-      const afterEnvKeys = Object.keys(process.env).filter((k) =>
-        k.startsWith('INTERNAL_API_KEY_'),
-      );
-      expect(afterEnvKeys).toEqual([]);
+      expect(snapshotInternalEnvKeys()).toEqual(before);
     });
 
     it('should skip service with invalid key format', async () => {

--- a/src/features/api-key/internal-key-bootstrap.service.ts
+++ b/src/features/api-key/internal-key-bootstrap.service.ts
@@ -31,12 +31,30 @@ export class InternalKeyBootstrapService implements OnModuleInit {
     }
   }
 
+  private resolveMonolithServices(): string[] {
+    // Allow the monolith services list to be overridden via env/config.
+    // Production falls back to DEFAULT_SERVICES. Tests use this hook to
+    // namespace each spec so parallel-worker writes to the shared DB do
+    // not collide with per-spec assertions.
+    const override = this.configService.get<string>(
+      'INTERNAL_MONOLITH_SERVICES',
+    );
+    if (!override) {
+      return DEFAULT_SERVICES;
+    }
+    const parsed = override
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
+    return parsed.length > 0 ? parsed : DEFAULT_SERVICES;
+  }
+
   private async bootstrapMonolith() {
     this.warnIfEnvVarsSet();
 
     const jwtSecret = this.configService.get<string>('JWT_SECRET');
 
-    for (const serviceName of DEFAULT_SERVICES) {
+    for (const serviceName of this.resolveMonolithServices()) {
       let key: string;
 
       if (jwtSecret) {

--- a/src/features/auth/commands/handlers/__tests__/create-user.handler.spec.ts
+++ b/src/features/auth/commands/handlers/__tests__/create-user.handler.spec.ts
@@ -2,7 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { BadRequestException } from '@nestjs/common';
 import { PrismaService } from 'src/infrastructure/database/prisma.service';
 import { AuthService } from 'src/features/auth/auth.service';
-import { IdService } from 'src/infrastructure/database/id.service';
+import { IdService } from '@revisium/engine';
 import { CreateUserHandler } from 'src/features/auth/commands/handlers/create-user.handler';
 import { CreateUserCommand } from 'src/features/auth/commands/impl';
 import { UserRole, UserSystemRoles } from 'src/features/auth/consts';

--- a/src/features/auth/commands/handlers/create-user.handler.ts
+++ b/src/features/auth/commands/handlers/create-user.handler.ts
@@ -7,7 +7,7 @@ import {
 } from 'src/features/auth/commands/impl';
 import { isValidSystemRole, UserRole } from 'src/features/auth/consts';
 import { validateUsername } from 'src/features/share/utils/validateUrlLikeId/validateUsername';
-import { IdService } from 'src/infrastructure/database/id.service';
+import { IdService } from '@revisium/engine';
 import { PrismaService } from 'src/infrastructure/database/prisma.service';
 import { Prisma } from 'src/__generated__/client';
 

--- a/src/features/organization/commands/handlers/add-user-to-organization.handler.ts
+++ b/src/features/organization/commands/handlers/add-user-to-organization.handler.ts
@@ -7,7 +7,7 @@ import {
 } from 'src/features/billing/limits.interface';
 import { LimitExceededException } from 'src/features/billing/limit-exceeded.exception';
 import { isValidOrganizationRole } from 'src/features/auth/consts';
-import { IdService } from 'src/infrastructure/database/id.service';
+import { IdService } from '@revisium/engine';
 import { PrismaService } from 'src/infrastructure/database/prisma.service';
 import {
   AddUserToOrganizationCommand,

--- a/src/features/project/commands/handlers/add-user-to-project.handler.ts
+++ b/src/features/project/commands/handlers/add-user-to-project.handler.ts
@@ -1,7 +1,7 @@
 import { BadRequestException } from '@nestjs/common';
 import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 import { isValidProjectRole, UserProjectRoles } from 'src/features/auth/consts';
-import { IdService } from 'src/infrastructure/database/id.service';
+import { IdService } from '@revisium/engine';
 import { PrismaService } from 'src/infrastructure/database/prisma.service';
 import {
   AddUserToProjectCommand,

--- a/src/features/project/commands/handlers/create-project.handler.ts
+++ b/src/features/project/commands/handlers/create-project.handler.ts
@@ -14,7 +14,7 @@ import {
 import { LimitExceededException } from 'src/features/billing/limit-exceeded.exception';
 import { validateBranchName } from 'src/features/share/utils/validateUrlLikeId/validateBranchName';
 import { validateUrlLikeId } from 'src/features/share/utils/validateUrlLikeId/validateUrlLikeId';
-import { IdService } from 'src/infrastructure/database/id.service';
+import { IdService } from '@revisium/engine';
 import { TransactionPrismaService } from 'src/infrastructure/database/transaction-prisma.service';
 import {
   CreateProjectCommand,

--- a/src/features/share/system-tables.service.ts
+++ b/src/features/share/system-tables.service.ts
@@ -5,7 +5,7 @@ import {
   SystemTables,
 } from 'src/features/share/system-tables.consts';
 import { FindTableInRevisionType } from 'src/features/share/queries/types';
-import { IdService } from 'src/infrastructure/database/id.service';
+import { IdService } from '@revisium/engine';
 import { TransactionPrismaService } from 'src/infrastructure/database/transaction-prisma.service';
 
 export type EnsureSystemTableResult = FindTableInRevisionType;

--- a/src/features/user/commands/handlers/__tests__/set-username.spec.ts
+++ b/src/features/user/commands/handlers/__tests__/set-username.spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { BadRequestException } from '@nestjs/common';
 import { PrismaService } from 'src/infrastructure/database/prisma.service';
-import { IdService } from 'src/infrastructure/database/id.service';
+import { IdService } from '@revisium/engine';
 import { SetUsernameHandler } from 'src/features/user/commands/handlers/set-username.handler';
 import { SetUsernameCommand } from 'src/features/user/commands/impl';
 

--- a/src/features/user/commands/handlers/set-username.handler.ts
+++ b/src/features/user/commands/handlers/set-username.handler.ts
@@ -2,7 +2,7 @@ import { BadRequestException } from '@nestjs/common';
 import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 import { UserRole } from 'src/features/auth/consts';
 import { validateUsername } from 'src/features/share/utils/validateUrlLikeId/validateUsername';
-import { IdService } from 'src/infrastructure/database/id.service';
+import { IdService } from '@revisium/engine';
 import { PrismaService } from 'src/infrastructure/database/prisma.service';
 import {
   SetUsernameCommand,

--- a/src/infrastructure/database/__tests__/hash.service.spec.ts
+++ b/src/infrastructure/database/__tests__/hash.service.spec.ts
@@ -1,4 +1,4 @@
-import { HashService } from 'src/infrastructure/database/hash.service';
+import { HashService } from '@revisium/engine';
 
 describe('HashService', () => {
   let hashService: HashService;

--- a/src/infrastructure/database/database.module.ts
+++ b/src/infrastructure/database/database.module.ts
@@ -1,7 +1,6 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
-import { HashService } from '@revisium/engine';
-import { IdService } from '@revisium/engine';
+import { HashService, IdService } from '@revisium/engine';
 import { PostgresqlNotificationService } from 'src/infrastructure/database/postgresql-notification.service';
 import { PrismaService } from 'src/infrastructure/database/prisma.service';
 import { TransactionPrismaService } from 'src/infrastructure/database/transaction-prisma.service';

--- a/src/infrastructure/database/database.module.ts
+++ b/src/infrastructure/database/database.module.ts
@@ -1,7 +1,7 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
-import { HashService } from 'src/infrastructure/database/hash.service';
-import { IdService } from 'src/infrastructure/database/id.service';
+import { HashService } from '@revisium/engine';
+import { IdService } from '@revisium/engine';
 import { PostgresqlNotificationService } from 'src/infrastructure/database/postgresql-notification.service';
 import { PrismaService } from 'src/infrastructure/database/prisma.service';
 import { TransactionPrismaService } from 'src/infrastructure/database/transaction-prisma.service';

--- a/src/infrastructure/database/hash.service.ts
+++ b/src/infrastructure/database/hash.service.ts
@@ -1,7 +1,0 @@
-import objectHash from 'object-hash';
-
-export class HashService {
-  public async hashObject(data: objectHash.NotUndefined) {
-    return objectHash(data);
-  }
-}

--- a/src/infrastructure/database/id.service.ts
+++ b/src/infrastructure/database/id.service.ts
@@ -1,9 +1,0 @@
-import { Injectable } from '@nestjs/common';
-import { nanoid } from 'nanoid';
-
-@Injectable()
-export class IdService {
-  public generate(size?: number) {
-    return nanoid(size);
-  }
-}

--- a/src/testing/utils/implementIdService.ts
+++ b/src/testing/utils/implementIdService.ts
@@ -1,6 +1,6 @@
 import { DeepMockProxy } from 'jest-mock-extended';
 import { nanoid } from 'nanoid';
-import { IdService } from 'src/infrastructure/database/id.service';
+import { IdService } from '@revisium/engine';
 
 export const implementIdService = (
   idService: DeepMockProxy<IdService>,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Deduplicates `IdService` and `HashService` by importing from `@revisium/engine`. Stabilizes internal-key bootstrap tests under parallel workers with a monolith services override and per-test namespaces.

- **Refactors**
  - Removed local `IdService` and `HashService`; all imports now use `@revisium/engine`.
  - `DatabaseModule` registers the engine classes; DI behavior is unchanged.

- **Bug Fixes**
  - `InternalKeyBootstrapService` now accepts `INTERNAL_MONOLITH_SERVICES` to override default services; tests pass unique service names to avoid cross-worker DB collisions.
  - Specs use real DB assertions with unique service names and keys; the microservice “no env vars” case now compares before/after `INTERNAL_API_KEY_*` env snapshots instead of assuming a clean env.

<sup>Written for commit c3ec5b677e8f325dcbc3e5b0c15369d85a9114ef. Summary will update on new commits. <a href="https://cubic.dev/pr/revisium/revisium-core/pull/504">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

