### PR TITLE
test: gqlKit + auth matrix + shared readonly fixture

### DIFF
--- a/src/api/graphql-api/__tests__/branch/branch.readonly.spec.ts
+++ b/src/api/graphql-api/__tests__/branch/branch.readonly.spec.ts
@@ -1,292 +1,205 @@
 import { INestApplication } from '@nestjs/common';
 import { gql } from 'src/testing/utils/gql';
 import {
-  createFreshTestApp,
+  describeAuthMatrix,
+  getTestApp,
   getReadonlyFixture,
   getPublicProjectFixture,
-  gqlQuery,
-  gqlQueryExpectError,
+  gqlKit,
+  PRIVATE_RESOURCE_MATRIX,
+  type GqlKit,
   type PrepareDataReturnType,
 } from 'src/testing/e2e';
 
+const branchQuery = gql`
+  query branch($data: GetBranchInput!) {
+    branch(data: $data) {
+      id
+      name
+      isRoot
+      createdAt
+    }
+  }
+`;
+
+const branchesQuery = gql`
+  query branches($data: GetBranchesInput!) {
+    branches(data: $data) {
+      totalCount
+      edges {
+        node {
+          id
+          name
+        }
+      }
+    }
+  }
+`;
+
+const branchVars = (f: PrepareDataReturnType) => ({
+  data: {
+    organizationId: f.project.organizationId,
+    projectName: f.project.projectName,
+    branchName: f.project.branchName,
+  },
+});
+
+const branchesVars = (f: PrepareDataReturnType) => ({
+  data: {
+    organizationId: f.project.organizationId,
+    projectName: f.project.projectName,
+    first: 10,
+  },
+});
+
 describe('graphql - branch (readonly)', () => {
   let app: INestApplication;
+  let kit: GqlKit;
   let fixture: PrepareDataReturnType;
   let publicFixture: PrepareDataReturnType;
 
   beforeAll(async () => {
-    app = await createFreshTestApp();
+    app = await getTestApp();
+    kit = gqlKit(app);
     fixture = await getReadonlyFixture(app);
     publicFixture = await getPublicProjectFixture(app);
   });
 
-  afterAll(async () => {
-    await app.close();
-  });
-
-  const getBranchData = (f: PrepareDataReturnType) => ({
-    organizationId: f.project.organizationId,
-    projectName: f.project.projectName,
-    branchName: f.project.branchName,
-  });
-
-  const getBranchesData = (f: PrepareDataReturnType) => ({
-    organizationId: f.project.organizationId,
-    projectName: f.project.projectName,
-    first: 10,
-  });
-
   describe('branch query', () => {
-    const getQuery = (data: {
-      organizationId: string;
-      projectName: string;
-      branchName: string;
-    }) => ({
-      query: gql`
-        query branch($data: GetBranchInput!) {
-          branch(data: $data) {
-            id
-            name
-            isRoot
-            createdAt
-          }
+    describeAuthMatrix(
+      'private project access',
+      PRIVATE_RESOURCE_MATRIX,
+      async ({ role, outcome }) => {
+        const actor = kit.roleFor(fixture, role);
+        if (outcome === 'ok') {
+          const result = await actor.expectOk<{
+            branch: { id: string; name: string; isRoot: boolean };
+          }>(branchQuery, branchVars(fixture));
+          expect(result.branch.id).toBe(fixture.project.branchId);
+          expect(result.branch.name).toBe(fixture.project.branchName);
+          expect(result.branch.isRoot).toBe(true);
+        } else {
+          await actor.expectForbidden(branchQuery, branchVars(fixture));
         }
-      `,
-      variables: { data },
-    });
+      },
+    );
 
-    it('owner can get branch', async () => {
-      const result = await gqlQuery({
-        app,
-        token: fixture.owner.token,
-        ...getQuery(getBranchData(fixture)),
-      });
-
-      expect(result.branch.id).toBe(fixture.project.branchId);
-      expect(result.branch.name).toBe(fixture.project.branchName);
-      expect(result.branch.isRoot).toBe(true);
-    });
-
-    it('cross-owner cannot get branch from private project', async () => {
-      await gqlQueryExpectError(
-        {
-          app,
-          token: fixture.anotherOwner.token,
-          ...getQuery(getBranchData(fixture)),
-        },
-        /You are not allowed to read on Project/,
-      );
-    });
-
-    it('unauthenticated cannot get branch from private project', async () => {
-      await gqlQueryExpectError(
-        {
-          app,
-          ...getQuery(getBranchData(fixture)),
-        },
-        /You are not allowed to read on Project/,
-      );
-    });
-
-    describe('public project', () => {
-      it('unauthenticated can get branch from public project', async () => {
-        const result = await gqlQuery({
-          app,
-          ...getQuery(getBranchData(publicFixture)),
-        });
-
-        expect(result.branch.id).toBe(publicFixture.project.branchId);
-      });
+    it('anon can get branch from public project', async () => {
+      const result = await kit.anon().expectOk<{
+        branch: { id: string };
+      }>(branchQuery, branchVars(publicFixture));
+      expect(result.branch.id).toBe(publicFixture.project.branchId);
     });
   });
 
   describe('branches query', () => {
-    const getQuery = (data: {
-      organizationId: string;
-      projectName: string;
-      first: number;
-    }) => ({
-      query: gql`
-        query branches($data: GetBranchesInput!) {
-          branches(data: $data) {
-            totalCount
-            edges {
-              node {
-                id
-                name
-              }
-            }
-          }
-        }
-      `,
-      variables: { data },
-    });
-
-    it('owner can get branches', async () => {
-      const result = await gqlQuery({
-        app,
-        token: fixture.owner.token,
-        ...getQuery(getBranchesData(fixture)),
-      });
-
+    it('owner can list branches', async () => {
+      const result = await kit.owner(fixture).expectOk<{
+        branches: { totalCount: number; edges: unknown[] };
+      }>(branchesQuery, branchesVars(fixture));
       expect(result.branches.totalCount).toBeGreaterThanOrEqual(1);
       expect(result.branches.edges).toBeDefined();
     });
 
-    it('cross-owner cannot get branches from private project', async () => {
-      await gqlQueryExpectError(
-        {
-          app,
-          token: fixture.anotherOwner.token,
-          ...getQuery(getBranchesData(fixture)),
-        },
-        /You are not allowed to read on Project/,
-      );
+    it('cross-owner is forbidden from listing branches on private project', async () => {
+      await kit
+        .crossOwner(fixture)
+        .expectForbidden(branchesQuery, branchesVars(fixture));
     });
   });
 
-  describe('branch with @ResolveField', () => {
-    describe('project field', () => {
-      const getQuery = (data: {
-        organizationId: string;
-        projectName: string;
-        branchName: string;
-      }) => ({
-        query: gql`
-          query branch($data: GetBranchInput!) {
-            branch(data: $data) {
+  describe('@ResolveField', () => {
+    it('resolves project', async () => {
+      const query = gql`
+        query branch($data: GetBranchInput!) {
+          branch(data: $data) {
+            id
+            project {
               id
-              project {
-                id
-                name
-              }
+              name
             }
           }
-        `,
-        variables: { data },
-      });
-
-      it('resolves project field', async () => {
-        const result = await gqlQuery({
-          app,
-          token: fixture.owner.token,
-          ...getQuery(getBranchData(fixture)),
-        });
-
-        expect(result.branch.project).toBeDefined();
-        expect(result.branch.project.id).toBe(fixture.project.projectId);
-      });
+        }
+      `;
+      const result = await kit.owner(fixture).expectOk<{
+        branch: { project: { id: string } };
+      }>(query, branchVars(fixture));
+      expect(result.branch.project.id).toBe(fixture.project.projectId);
     });
 
-    describe('start/head/draft revisions', () => {
-      const getQuery = (data: {
-        organizationId: string;
-        projectName: string;
-        branchName: string;
-      }) => ({
-        query: gql`
-          query branch($data: GetBranchInput!) {
-            branch(data: $data) {
+    it('resolves start/head/draft revisions', async () => {
+      const query = gql`
+        query branch($data: GetBranchInput!) {
+          branch(data: $data) {
+            id
+            start {
               id
-              start {
-                id
-                isStart
-              }
-              head {
-                id
-                isHead
-              }
-              draft {
-                id
-                isDraft
-              }
+              isStart
+            }
+            head {
+              id
+              isHead
+            }
+            draft {
+              id
+              isDraft
             }
           }
-        `,
-        variables: { data },
-      });
-
-      it('resolves start/head/draft fields', async () => {
-        const result = await gqlQuery({
-          app,
-          token: fixture.owner.token,
-          ...getQuery(getBranchData(fixture)),
-        });
-
-        expect(result.branch.start).toBeDefined();
-        expect(result.branch.start.isStart).toBe(true);
-        expect(result.branch.head).toBeDefined();
-        expect(result.branch.head.isHead).toBe(true);
-        expect(result.branch.draft).toBeDefined();
-        expect(result.branch.draft.isDraft).toBe(true);
-      });
+        }
+      `;
+      const result = await kit.owner(fixture).expectOk<{
+        branch: {
+          start: { isStart: boolean };
+          head: { isHead: boolean };
+          draft: { isDraft: boolean };
+        };
+      }>(query, branchVars(fixture));
+      expect(result.branch.start.isStart).toBe(true);
+      expect(result.branch.head.isHead).toBe(true);
+      expect(result.branch.draft.isDraft).toBe(true);
     });
 
-    describe('revisions field', () => {
-      const getQuery = (data: {
-        organizationId: string;
-        projectName: string;
-        branchName: string;
-      }) => ({
-        query: gql`
-          query branch(
-            $data: GetBranchInput!
-            $revisionsData: GetBranchRevisionsInput!
-          ) {
-            branch(data: $data) {
-              id
-              revisions(data: $revisionsData) {
-                totalCount
-                edges {
-                  node {
-                    id
-                  }
+    it('resolves revisions', async () => {
+      const query = gql`
+        query branch(
+          $data: GetBranchInput!
+          $revisionsData: GetBranchRevisionsInput!
+        ) {
+          branch(data: $data) {
+            id
+            revisions(data: $revisionsData) {
+              totalCount
+              edges {
+                node {
+                  id
                 }
               }
             }
           }
-        `,
-        variables: { data, revisionsData: { first: 10 } },
+        }
+      `;
+      const result = await kit.owner(fixture).expectOk<{
+        branch: { revisions: { totalCount: number } };
+      }>(query, {
+        ...branchVars(fixture),
+        revisionsData: { first: 10 },
       });
-
-      it('resolves revisions field', async () => {
-        const result = await gqlQuery({
-          app,
-          token: fixture.owner.token,
-          ...getQuery(getBranchData(fixture)),
-        });
-
-        expect(result.branch.revisions).toBeDefined();
-        expect(result.branch.revisions.totalCount).toBeGreaterThanOrEqual(1);
-      });
+      expect(result.branch.revisions.totalCount).toBeGreaterThanOrEqual(1);
     });
 
-    describe('touched field', () => {
-      const getQuery = (data: {
-        organizationId: string;
-        projectName: string;
-        branchName: string;
-      }) => ({
-        query: gql`
-          query branch($data: GetBranchInput!) {
-            branch(data: $data) {
-              id
-              touched
-            }
+    it('resolves touched', async () => {
+      const query = gql`
+        query branch($data: GetBranchInput!) {
+          branch(data: $data) {
+            id
+            touched
           }
-        `,
-        variables: { data },
-      });
-
-      it('resolves touched field', async () => {
-        const result = await gqlQuery({
-          app,
-          token: fixture.owner.token,
-          ...getQuery(getBranchData(fixture)),
-        });
-
-        expect(result.branch).toHaveProperty('touched');
-      });
+        }
+      `;
+      const result = await kit.owner(fixture).expectOk<{
+        branch: { touched: unknown };
+      }>(query, branchVars(fixture));
+      expect(result.branch).toHaveProperty('touched');
     });
   });
 });

--- a/src/api/graphql-api/__tests__/organization/organization.readonly.spec.ts
+++ b/src/api/graphql-api/__tests__/organization/organization.readonly.spec.ts
@@ -1,71 +1,64 @@
 import { INestApplication } from '@nestjs/common';
 import { gql } from 'src/testing/utils/gql';
 import {
-  createFreshTestApp,
+  getTestApp,
   getReadonlyFixture,
-  gqlQuery,
+  gqlKit,
+  type GqlKit,
   type PrepareDataReturnType,
 } from 'src/testing/e2e';
 
+const projectsQuery = gql`
+  query projects($data: GetProjectsInput!) {
+    projects(data: $data) {
+      totalCount
+      edges {
+        node {
+          id
+          name
+        }
+      }
+    }
+  }
+`;
+
+const projectsVars = (organizationId: string) => ({
+  data: { organizationId, first: 10 },
+});
+
 describe('graphql - organization (readonly)', () => {
   let app: INestApplication;
+  let kit: GqlKit;
   let fixture: PrepareDataReturnType;
 
   beforeAll(async () => {
-    app = await createFreshTestApp();
+    app = await getTestApp();
+    kit = gqlKit(app);
     fixture = await getReadonlyFixture(app);
   });
 
-  afterAll(async () => {
-    await app.close();
-  });
-
   describe('projects query', () => {
-    const getQuery = (organizationId: string) => ({
-      query: gql`
-        query projects($data: GetProjectsInput!) {
-          projects(data: $data) {
-            totalCount
-            edges {
-              node {
-                id
-                name
-              }
-            }
-          }
-        }
-      `,
-      variables: {
-        data: { organizationId, first: 10 },
-      },
-    });
-
-    it('owner can get projects', async () => {
-      const result = await gqlQuery({
-        app,
-        token: fixture.owner.token,
-        ...getQuery(fixture.project.organizationId),
-      });
+    it('owner lists own-org projects', async () => {
+      const result = await kit.owner(fixture).expectOk<{
+        projects: { totalCount: number; edges: unknown[] };
+      }>(projectsQuery, projectsVars(fixture.project.organizationId));
 
       expect(result.projects.totalCount).toBeGreaterThanOrEqual(1);
       expect(result.projects.edges).toBeDefined();
     });
 
-    it('cross-owner can only see own organization projects', async () => {
-      const result = await gqlQuery({
-        app,
-        token: fixture.anotherOwner.token,
-        ...getQuery(fixture.anotherProject.organizationId),
-      });
+    it('cross-owner only sees own-org projects', async () => {
+      const result = await kit.crossOwner(fixture).expectOk<{
+        projects: { totalCount: number };
+      }>(projectsQuery, projectsVars(fixture.anotherProject.organizationId));
 
       expect(result.projects.totalCount).toBeGreaterThanOrEqual(1);
     });
 
-    it('unauthenticated gets empty list (no user access)', async () => {
-      const result = await gqlQuery({
-        app,
-        ...getQuery(fixture.project.organizationId),
-      });
+    it('anon sees empty list', async () => {
+      const result = await kit.anon().expectOk<{
+        projects: { totalCount: number };
+      }>(projectsQuery, projectsVars(fixture.project.organizationId));
 
       expect(result.projects.totalCount).toBe(0);
     });

--- a/src/api/graphql-api/__tests__/project/project.readonly.spec.ts
+++ b/src/api/graphql-api/__tests__/project/project.readonly.spec.ts
@@ -1,174 +1,146 @@
 import { INestApplication } from '@nestjs/common';
 import { gql } from 'src/testing/utils/gql';
 import {
-  createFreshTestApp,
+  describeAuthMatrix,
+  getTestApp,
   getReadonlyFixture,
   getPublicProjectFixture,
-  gqlQuery,
-  gqlQueryExpectError,
-  expectGraphQLFields,
+  gqlKit,
+  PRIVATE_RESOURCE_MATRIX,
+  type GqlKit,
   type PrepareDataReturnType,
 } from 'src/testing/e2e';
 
+const projectQuery = gql`
+  query project($data: GetProjectInput!) {
+    project(data: $data) {
+      id
+      name
+      isPublic
+      createdAt
+      organizationId
+    }
+  }
+`;
+
+const projectVars = (organizationId: string, projectName: string) => ({
+  data: { organizationId, projectName },
+});
+
 describe('graphql - project (readonly)', () => {
   let app: INestApplication;
+  let kit: GqlKit;
   let fixture: PrepareDataReturnType;
   let publicFixture: PrepareDataReturnType;
 
   beforeAll(async () => {
-    app = await createFreshTestApp();
+    app = await getTestApp();
+    kit = gqlKit(app);
     fixture = await getReadonlyFixture(app);
     publicFixture = await getPublicProjectFixture(app);
   });
 
-  afterAll(async () => {
-    await app.close();
-  });
-
   describe('project query', () => {
-    const getQuery = (organizationId: string, projectName: string) => ({
-      query: gql`
-        query project($data: GetProjectInput!) {
-          project(data: $data) {
-            id
-            name
-            isPublic
-            createdAt
-            organizationId
-          }
+    const varsFor = (f: PrepareDataReturnType) =>
+      projectVars(f.project.organizationId, f.project.projectName);
+
+    describeAuthMatrix(
+      'private project access',
+      PRIVATE_RESOURCE_MATRIX,
+      async ({ role, outcome }) => {
+        const actor = kit.roleFor(fixture, role);
+        if (outcome === 'ok') {
+          const result = await actor.expectOk<{
+            project: { id: string };
+          }>(projectQuery, varsFor(fixture));
+          expect(result.project.id).toBe(fixture.project.projectId);
+        } else {
+          await actor.expectForbidden(projectQuery, varsFor(fixture));
         }
-      `,
-      variables: {
-        data: { organizationId, projectName },
       },
-    });
+    );
 
-    it('owner can get project', async () => {
-      const result = await gqlQuery({
-        app,
-        token: fixture.owner.token,
-        ...getQuery(
-          fixture.project.organizationId,
-          fixture.project.projectName,
-        ),
-      });
+    it('owner sees all requested fields', async () => {
+      const result = await kit.owner(fixture).expectOk<{
+        project: Record<string, unknown>;
+      }>(projectQuery, varsFor(fixture));
 
-      expectGraphQLFields(result, 'project', [
-        'id',
-        'name',
-        'isPublic',
-        'createdAt',
-        'organizationId',
-      ]);
-      expect(result.project.id).toBe(fixture.project.projectId);
-    });
-
-    it('cross-owner cannot get private project', async () => {
-      await gqlQueryExpectError(
-        {
-          app,
-          token: fixture.anotherOwner.token,
-          ...getQuery(
-            fixture.project.organizationId,
-            fixture.project.projectName,
-          ),
-        },
-        /You are not allowed to read on Project/,
+      expect(result.project).toEqual(
+        expect.objectContaining({
+          id: fixture.project.projectId,
+          name: fixture.project.projectName,
+          isPublic: false,
+          organizationId: fixture.project.organizationId,
+          createdAt: expect.any(String),
+        }),
       );
     });
 
-    it('unauthenticated cannot get private project', async () => {
-      await gqlQueryExpectError(
-        {
-          app,
-          ...getQuery(
-            fixture.project.organizationId,
-            fixture.project.projectName,
-          ),
-        },
-        /You are not allowed to read on Project/,
-      );
+    it('owner hitting a non-existent project returns not found', async () => {
+      await kit
+        .owner(fixture)
+        .expectNotFound(
+          projectQuery,
+          projectVars(fixture.project.organizationId, 'non-existent-project'),
+        );
     });
 
-    it('non-existent project returns not found error', async () => {
-      await gqlQueryExpectError(
-        {
-          app,
-          token: fixture.owner.token,
-          ...getQuery(fixture.project.organizationId, 'non-existent-project'),
-        },
-        /Project not found/,
-      );
-    });
-
-    it('unauthenticated non-existent project returns not found error', async () => {
-      await gqlQueryExpectError(
-        {
-          app,
-          ...getQuery(fixture.project.organizationId, 'non-existent-project'),
-        },
-        /Project not found/,
-      );
+    it('anon hitting a non-existent project returns not found', async () => {
+      await kit
+        .anon()
+        .expectNotFound(
+          projectQuery,
+          projectVars(fixture.project.organizationId, 'non-existent-project'),
+        );
     });
 
     describe('public project', () => {
-      it('unauthenticated can get public project', async () => {
-        const result = await gqlQuery({
-          app,
-          ...getQuery(
-            publicFixture.project.organizationId,
-            publicFixture.project.projectName,
-          ),
-        });
+      it('anon can read', async () => {
+        const result = await kit.anon().expectOk<{
+          project: { id: string; isPublic: boolean };
+        }>(projectQuery, varsFor(publicFixture));
 
         expect(result.project.id).toBe(publicFixture.project.projectId);
         expect(result.project.isPublic).toBe(true);
       });
 
-      it('unauthenticated gets null userProject on public project', async () => {
-        const result = await gqlQuery({
-          app,
-          ...{
-            query: gql`
-              query project($data: GetProjectInput!) {
-                project(data: $data) {
+      it('anon sees null userProject and userOrganization', async () => {
+        const result = await kit.anon().expectOk<{
+          project: {
+            id: string;
+            userProject: unknown;
+            organization: { userOrganization: unknown };
+          };
+        }>(
+          gql`
+            query project($data: GetProjectInput!) {
+              project(data: $data) {
+                id
+                isPublic
+                userProject {
                   id
-                  isPublic
-                  userProject {
+                }
+                organization {
+                  id
+                  userOrganization {
                     id
-                  }
-                  organization {
-                    id
-                    userOrganization {
-                      id
-                    }
                   }
                 }
               }
-            `,
-            variables: {
-              data: {
-                organizationId: publicFixture.project.organizationId,
-                projectName: publicFixture.project.projectName,
-              },
-            },
-          },
-        });
+            }
+          `,
+          varsFor(publicFixture),
+        );
 
         expect(result.project.id).toBe(publicFixture.project.projectId);
         expect(result.project.userProject).toBeNull();
         expect(result.project.organization.userOrganization).toBeNull();
       });
 
-      it('cross-owner can get public project', async () => {
-        const result = await gqlQuery({
-          app,
-          token: fixture.anotherOwner.token,
-          ...getQuery(
-            publicFixture.project.organizationId,
-            publicFixture.project.projectName,
-          ),
-        });
+      it('cross-owner can read', async () => {
+        const result = await kit.crossOwner(fixture).expectOk<{
+          project: { id: string; isPublic: boolean };
+        }>(projectQuery, varsFor(publicFixture));
 
         expect(result.project.id).toBe(publicFixture.project.projectId);
         expect(result.project.isPublic).toBe(true);
@@ -176,9 +148,9 @@ describe('graphql - project (readonly)', () => {
     });
   });
 
-  describe('project with rootBranch @ResolveField', () => {
-    const getQuery = (organizationId: string, projectName: string) => ({
-      query: gql`
+  describe('@ResolveField', () => {
+    it('resolves rootBranch', async () => {
+      const query = gql`
         query project($data: GetProjectInput!) {
           project(data: $data) {
             id
@@ -189,31 +161,17 @@ describe('graphql - project (readonly)', () => {
             }
           }
         }
-      `,
-      variables: {
-        data: { organizationId, projectName },
-      },
-    });
+      `;
+      const result = await kit.owner(fixture).expectOk<{
+        project: { rootBranch: { id: string; isRoot: boolean } };
+      }>(query, projectVars(fixture.project.organizationId, fixture.project.projectName));
 
-    it('resolves rootBranch field', async () => {
-      const result = await gqlQuery({
-        app,
-        token: fixture.owner.token,
-        ...getQuery(
-          fixture.project.organizationId,
-          fixture.project.projectName,
-        ),
-      });
-
-      expect(result.project.rootBranch).toBeDefined();
       expect(result.project.rootBranch.id).toBe(fixture.project.branchId);
       expect(result.project.rootBranch.isRoot).toBe(true);
     });
-  });
 
-  describe('project with organization @ResolveField', () => {
-    const getQuery = (organizationId: string, projectName: string) => ({
-      query: gql`
+    it('resolves organization', async () => {
+      const query = gql`
         query project($data: GetProjectInput!) {
           project(data: $data) {
             id
@@ -222,32 +180,18 @@ describe('graphql - project (readonly)', () => {
             }
           }
         }
-      `,
-      variables: {
-        data: { organizationId, projectName },
-      },
-    });
+      `;
+      const result = await kit.owner(fixture).expectOk<{
+        project: { organization: { id: string } };
+      }>(query, projectVars(fixture.project.organizationId, fixture.project.projectName));
 
-    it('resolves organization field', async () => {
-      const result = await gqlQuery({
-        app,
-        token: fixture.owner.token,
-        ...getQuery(
-          fixture.project.organizationId,
-          fixture.project.projectName,
-        ),
-      });
-
-      expect(result.project.organization).toBeDefined();
       expect(result.project.organization.id).toBe(
         fixture.project.organizationId,
       );
     });
-  });
 
-  describe('project with allBranches @ResolveField', () => {
-    const getQuery = (organizationId: string, projectName: string) => ({
-      query: gql`
+    it('resolves allBranches', async () => {
+      const query = gql`
         query project(
           $data: GetProjectInput!
           $branchesData: GetProjectBranchesInput!
@@ -265,24 +209,19 @@ describe('graphql - project (readonly)', () => {
             }
           }
         }
-      `,
-      variables: {
-        data: { organizationId, projectName },
+      `;
+      const result = await kit.owner(fixture).expectOk<{
+        project: {
+          allBranches: { totalCount: number; edges: unknown[] };
+        };
+      }>(query, {
+        data: {
+          organizationId: fixture.project.organizationId,
+          projectName: fixture.project.projectName,
+        },
         branchesData: { first: 10 },
-      },
-    });
-
-    it('resolves allBranches field', async () => {
-      const result = await gqlQuery({
-        app,
-        token: fixture.owner.token,
-        ...getQuery(
-          fixture.project.organizationId,
-          fixture.project.projectName,
-        ),
       });
 
-      expect(result.project.allBranches).toBeDefined();
       expect(result.project.allBranches.totalCount).toBeGreaterThanOrEqual(1);
       expect(result.project.allBranches.edges).toBeDefined();
     });

--- a/src/api/graphql-api/__tests__/revision/revision.readonly.spec.ts
+++ b/src/api/graphql-api/__tests__/revision/revision.readonly.spec.ts
@@ -1,217 +1,150 @@
 import { INestApplication } from '@nestjs/common';
 import { gql } from 'src/testing/utils/gql';
 import {
-  createFreshTestApp,
+  describeAuthMatrix,
+  getTestApp,
   getReadonlyFixture,
   getPublicProjectFixture,
-  gqlQuery,
-  gqlQueryExpectError,
+  gqlKit,
+  PRIVATE_RESOURCE_MATRIX,
+  type GqlKit,
   type PrepareDataReturnType,
 } from 'src/testing/e2e';
 
+const revisionQuery = gql`
+  query revision($data: GetRevisionInput!) {
+    revision(data: $data) {
+      id
+      createdAt
+      isHead
+      isDraft
+      isStart
+    }
+  }
+`;
+
+const revisionVars = (revisionId: string) => ({ data: { revisionId } });
+
 describe('graphql - revision (readonly)', () => {
   let app: INestApplication;
+  let kit: GqlKit;
   let fixture: PrepareDataReturnType;
   let publicFixture: PrepareDataReturnType;
 
   beforeAll(async () => {
-    app = await createFreshTestApp();
+    app = await getTestApp();
+    kit = gqlKit(app);
     fixture = await getReadonlyFixture(app);
     publicFixture = await getPublicProjectFixture(app);
   });
 
-  afterAll(async () => {
-    await app.close();
+  describe('revision query', () => {
+    describeAuthMatrix(
+      'private project access',
+      PRIVATE_RESOURCE_MATRIX,
+      async ({ role, outcome }) => {
+        const actor = kit.roleFor(fixture, role);
+        const vars = revisionVars(fixture.project.draftRevisionId);
+        if (outcome === 'ok') {
+          const result = await actor.expectOk<{
+            revision: { id: string; isDraft: boolean };
+          }>(revisionQuery, vars);
+          expect(result.revision.id).toBe(fixture.project.draftRevisionId);
+          expect(result.revision.isDraft).toBe(true);
+        } else {
+          await actor.expectForbidden(revisionQuery, vars);
+        }
+      },
+    );
+
+    it('anon can read revision from public project', async () => {
+      const result = await kit.anon().expectOk<{
+        revision: { id: string };
+      }>(revisionQuery, revisionVars(publicFixture.project.draftRevisionId));
+      expect(result.revision.id).toBe(publicFixture.project.draftRevisionId);
+    });
   });
 
-  describe('revision query', () => {
-    const getQuery = (revisionId: string) => ({
-      query: gql`
+  describe('@ResolveField', () => {
+    it('resolves branch', async () => {
+      const query = gql`
         query revision($data: GetRevisionInput!) {
           revision(data: $data) {
             id
-            createdAt
-            isHead
-            isDraft
-            isStart
+            branch {
+              id
+              name
+            }
           }
         }
-      `,
-      variables: {
-        data: { revisionId },
-      },
+      `;
+      const result = await kit.owner(fixture).expectOk<{
+        revision: { branch: { id: string } };
+      }>(query, revisionVars(fixture.project.draftRevisionId));
+      expect(result.revision.branch.id).toBe(fixture.project.branchId);
     });
 
-    it('owner can get revision', async () => {
-      const result = await gqlQuery({
-        app,
-        token: fixture.owner.token,
-        ...getQuery(fixture.project.draftRevisionId),
-      });
-
-      expect(result.revision.id).toBe(fixture.project.draftRevisionId);
-      expect(result.revision.isDraft).toBe(true);
-    });
-
-    it('cross-owner cannot get revision from private project', async () => {
-      await gqlQueryExpectError(
-        {
-          app,
-          token: fixture.anotherOwner.token,
-          ...getQuery(fixture.project.draftRevisionId),
-        },
-        /You are not allowed to read on Project/,
-      );
-    });
-
-    it('unauthenticated cannot get revision from private project', async () => {
-      await gqlQueryExpectError(
-        {
-          app,
-          ...getQuery(fixture.project.draftRevisionId),
-        },
-        /You are not allowed to read on Project/,
-      );
-    });
-
-    describe('public project', () => {
-      it('unauthenticated can get revision from public project', async () => {
-        const result = await gqlQuery({
-          app,
-          ...getQuery(publicFixture.project.draftRevisionId),
-        });
-
-        expect(result.revision.id).toBe(publicFixture.project.draftRevisionId);
-      });
-    });
-  });
-
-  describe('revision with @ResolveField', () => {
-    describe('branch field', () => {
-      const getQuery = (revisionId: string) => ({
-        query: gql`
-          query revision($data: GetRevisionInput!) {
-            revision(data: $data) {
+    it('resolves parent', async () => {
+      const query = gql`
+        query revision($data: GetRevisionInput!) {
+          revision(data: $data) {
+            id
+            parent {
               id
-              branch {
-                id
-                name
-              }
             }
           }
-        `,
-        variables: {
-          data: { revisionId },
-        },
-      });
-
-      it('resolves branch field', async () => {
-        const result = await gqlQuery({
-          app,
-          token: fixture.owner.token,
-          ...getQuery(fixture.project.draftRevisionId),
-        });
-
-        expect(result.revision.branch).toBeDefined();
-        expect(result.revision.branch.id).toBe(fixture.project.branchId);
-      });
+        }
+      `;
+      const result = await kit.owner(fixture).expectOk<{
+        revision: { parent: { id: string } };
+      }>(query, revisionVars(fixture.project.draftRevisionId));
+      expect(result.revision.parent.id).toBe(fixture.project.headRevisionId);
     });
 
-    describe('parent field', () => {
-      const getQuery = (revisionId: string) => ({
-        query: gql`
-          query revision($data: GetRevisionInput!) {
-            revision(data: $data) {
-              id
-              parent {
-                id
-              }
-            }
-          }
-        `,
-        variables: {
-          data: { revisionId },
-        },
-      });
-
-      it('resolves parent field', async () => {
-        const result = await gqlQuery({
-          app,
-          token: fixture.owner.token,
-          ...getQuery(fixture.project.draftRevisionId),
-        });
-
-        expect(result.revision.parent).toBeDefined();
-        expect(result.revision.parent.id).toBe(fixture.project.headRevisionId);
-      });
-    });
-
-    describe('tables field', () => {
-      const getQuery = (revisionId: string) => ({
-        query: gql`
-          query revision(
-            $data: GetRevisionInput!
-            $tablesData: GetRevisionTablesInput!
-          ) {
-            revision(data: $data) {
-              id
-              tables(data: $tablesData) {
-                totalCount
-                edges {
-                  node {
-                    id
-                  }
+    it('resolves tables', async () => {
+      const query = gql`
+        query revision(
+          $data: GetRevisionInput!
+          $tablesData: GetRevisionTablesInput!
+        ) {
+          revision(data: $data) {
+            id
+            tables(data: $tablesData) {
+              totalCount
+              edges {
+                node {
+                  id
                 }
               }
             }
           }
-        `,
-        variables: {
-          data: { revisionId },
-          tablesData: { first: 10 },
-        },
+        }
+      `;
+      const result = await kit.owner(fixture).expectOk<{
+        revision: { tables: { totalCount: number } };
+      }>(query, {
+        ...revisionVars(fixture.project.draftRevisionId),
+        tablesData: { first: 10 },
       });
-
-      it('resolves tables field', async () => {
-        const result = await gqlQuery({
-          app,
-          token: fixture.owner.token,
-          ...getQuery(fixture.project.draftRevisionId),
-        });
-
-        expect(result.revision.tables).toBeDefined();
-        expect(result.revision.tables.totalCount).toBeGreaterThanOrEqual(1);
-      });
+      expect(result.revision.tables.totalCount).toBeGreaterThanOrEqual(1);
     });
 
-    describe('endpoints field', () => {
-      const getQuery = (revisionId: string) => ({
-        query: gql`
-          query revision($data: GetRevisionInput!) {
-            revision(data: $data) {
+    it('resolves endpoints', async () => {
+      const query = gql`
+        query revision($data: GetRevisionInput!) {
+          revision(data: $data) {
+            id
+            endpoints {
               id
-              endpoints {
-                id
-                type
-              }
+              type
             }
           }
-        `,
-        variables: {
-          data: { revisionId },
-        },
-      });
-
-      it('resolves endpoints field', async () => {
-        const result = await gqlQuery({
-          app,
-          token: fixture.owner.token,
-          ...getQuery(fixture.project.draftRevisionId),
-        });
-
-        expect(result.revision.endpoints).toBeDefined();
-        expect(Array.isArray(result.revision.endpoints)).toBe(true);
-      });
+        }
+      `;
+      const result = await kit.owner(fixture).expectOk<{
+        revision: { endpoints: unknown[] };
+      }>(query, revisionVars(fixture.project.draftRevisionId));
+      expect(Array.isArray(result.revision.endpoints)).toBe(true);
     });
   });
 });

--- a/src/api/graphql-api/__tests__/row/row.readonly.spec.ts
+++ b/src/api/graphql-api/__tests__/row/row.readonly.spec.ts
@@ -1,352 +1,222 @@
 import { INestApplication } from '@nestjs/common';
 import { gql } from 'src/testing/utils/gql';
 import {
-  createFreshTestApp,
+  describeAuthMatrix,
+  getTestApp,
   getReadonlyFixture,
   getPublicProjectFixture,
-  gqlQuery,
-  gqlQueryExpectError,
+  gqlKit,
+  PRIVATE_RESOURCE_MATRIX,
+  type GqlKit,
   type PrepareDataReturnType,
 } from 'src/testing/e2e';
 
+const rowQuery = gql`
+  query row($data: GetRowInput!) {
+    row(data: $data) {
+      id
+      versionId
+      createdAt
+      updatedAt
+      readonly
+    }
+  }
+`;
+
+const rowsQuery = gql`
+  query rows($data: GetRowsInput!) {
+    rows(data: $data) {
+      totalCount
+      edges {
+        node {
+          id
+          versionId
+        }
+      }
+    }
+  }
+`;
+
+const rowVars = (f: PrepareDataReturnType) => ({
+  data: {
+    revisionId: f.project.draftRevisionId,
+    tableId: f.project.tableId,
+    rowId: f.project.rowId,
+  },
+});
+
+const rowsVars = (f: PrepareDataReturnType) => ({
+  data: {
+    revisionId: f.project.draftRevisionId,
+    tableId: f.project.tableId,
+    first: 10,
+  },
+});
+
 describe('graphql - row (readonly)', () => {
   let app: INestApplication;
+  let kit: GqlKit;
   let fixture: PrepareDataReturnType;
   let publicFixture: PrepareDataReturnType;
 
   beforeAll(async () => {
-    app = await createFreshTestApp();
+    app = await getTestApp();
+    kit = gqlKit(app);
     fixture = await getReadonlyFixture(app);
     publicFixture = await getPublicProjectFixture(app);
-  });
-
-  afterAll(async () => {
-    await app.close();
+    if (!fixture.project.linkedTable) {
+      throw new Error(
+        'Readonly fixture missing linkedTable; row foreign-key resolver tests depend on it.',
+      );
+    }
   });
 
   describe('row query', () => {
-    const getQuery = (revisionId: string, tableId: string, rowId: string) => ({
-      query: gql`
-        query row($data: GetRowInput!) {
-          row(data: $data) {
-            id
-            versionId
-            createdAt
-            updatedAt
-            readonly
-          }
+    describeAuthMatrix(
+      'private project access',
+      PRIVATE_RESOURCE_MATRIX,
+      async ({ role, outcome }) => {
+        const actor = kit.roleFor(fixture, role);
+        const vars = rowVars(fixture);
+        if (outcome === 'ok') {
+          const result = await actor.expectOk<{ row: { id: string } }>(
+            rowQuery,
+            vars,
+          );
+          expect(result.row.id).toBe(fixture.project.rowId);
+        } else {
+          await actor.expectForbidden(rowQuery, vars);
         }
-      `,
-      variables: {
-        data: { revisionId, tableId, rowId },
       },
-    });
+    );
 
-    it('owner can get row', async () => {
-      const result = await gqlQuery({
-        app,
-        token: fixture.owner.token,
-        ...getQuery(
-          fixture.project.draftRevisionId,
-          fixture.project.tableId,
-          fixture.project.rowId,
-        ),
-      });
-
-      expect(result.row.id).toBe(fixture.project.rowId);
-    });
-
-    it('cross-owner cannot get row from private project', async () => {
-      await gqlQueryExpectError(
-        {
-          app,
-          token: fixture.anotherOwner.token,
-          ...getQuery(
-            fixture.project.draftRevisionId,
-            fixture.project.tableId,
-            fixture.project.rowId,
-          ),
-        },
-        /You are not allowed to read on Project/,
-      );
-    });
-
-    it('unauthenticated cannot get row from private project', async () => {
-      await gqlQueryExpectError(
-        {
-          app,
-          ...getQuery(
-            fixture.project.draftRevisionId,
-            fixture.project.tableId,
-            fixture.project.rowId,
-          ),
-        },
-        /You are not allowed to read on Project/,
-      );
-    });
-
-    describe('public project', () => {
-      it('unauthenticated can get row from public project', async () => {
-        const result = await gqlQuery({
-          app,
-          ...getQuery(
-            publicFixture.project.draftRevisionId,
-            publicFixture.project.tableId,
-            publicFixture.project.rowId,
-          ),
-        });
-
-        expect(result.row.id).toBe(publicFixture.project.rowId);
-      });
+    it('anon can read row from public project', async () => {
+      const result = await kit
+        .anon()
+        .expectOk<{ row: { id: string } }>(rowQuery, rowVars(publicFixture));
+      expect(result.row.id).toBe(publicFixture.project.rowId);
     });
   });
 
   describe('rows query', () => {
-    const getQuery = (revisionId: string, tableId: string) => ({
-      query: gql`
-        query rows($data: GetRowsInput!) {
-          rows(data: $data) {
-            totalCount
-            edges {
-              node {
-                id
-                versionId
+    it('owner can list rows', async () => {
+      const result = await kit.owner(fixture).expectOk<{
+        rows: { totalCount: number };
+      }>(rowsQuery, rowsVars(fixture));
+      expect(result.rows.totalCount).toBeGreaterThanOrEqual(1);
+    });
+
+    it('cross-owner is forbidden from listing rows', async () => {
+      await kit
+        .crossOwner(fixture)
+        .expectForbidden(rowsQuery, rowsVars(fixture));
+    });
+  });
+
+  describe('@ResolveField', () => {
+    it('resolves data', async () => {
+      const query = gql`
+        query row($data: GetRowInput!) {
+          row(data: $data) {
+            id
+            data
+          }
+        }
+      `;
+      const result = await kit.owner(fixture).expectOk<{
+        row: { data: unknown };
+      }>(query, rowVars(fixture));
+      expect(result.row).toHaveProperty('data');
+    });
+
+    it('resolves countForeignKeysTo', async () => {
+      const query = gql`
+        query row($data: GetRowInput!) {
+          row(data: $data) {
+            id
+            countForeignKeysTo
+          }
+        }
+      `;
+      const result = await kit.owner(fixture).expectOk<{
+        row: { countForeignKeysTo: number };
+      }>(query, rowVars(fixture));
+      expect(typeof result.row.countForeignKeysTo).toBe('number');
+    });
+
+    it('resolves rowForeignKeysBy', async () => {
+      const query = gql`
+        query row($data: GetRowInput!, $by: GetRowForeignKeysInput!) {
+          row(data: $data) {
+            id
+            rowForeignKeysBy(data: $by) {
+              totalCount
+              edges {
+                node {
+                  id
+                }
               }
             }
           }
         }
-      `,
-      variables: {
-        data: { revisionId, tableId, first: 10 },
-      },
-    });
-
-    it('owner can get rows', async () => {
-      const result = await gqlQuery({
-        app,
-        token: fixture.owner.token,
-        ...getQuery(fixture.project.draftRevisionId, fixture.project.tableId),
-      });
-
-      expect(result.rows.totalCount).toBeGreaterThanOrEqual(1);
-    });
-
-    it('cross-owner cannot get rows from private project', async () => {
-      await gqlQueryExpectError(
-        {
-          app,
-          token: fixture.anotherOwner.token,
-          ...getQuery(fixture.project.draftRevisionId, fixture.project.tableId),
-        },
-        /You are not allowed to read on Project/,
-      );
-    });
-  });
-
-  describe('row with @ResolveField', () => {
-    describe('data field', () => {
-      const getQuery = (
-        revisionId: string,
-        tableId: string,
-        rowId: string,
-      ) => ({
-        query: gql`
-          query row($data: GetRowInput!) {
-            row(data: $data) {
-              id
-              data
-            }
-          }
-        `,
-        variables: {
-          data: { revisionId, tableId, rowId },
+      `;
+      const result = await kit.owner(fixture).expectOk<{
+        row: { rowForeignKeysBy: { totalCount: number } };
+      }>(query, {
+        ...rowVars(fixture),
+        by: {
+          first: 10,
+          foreignKeyTableId: fixture.project.linkedTable!.tableId,
         },
       });
-
-      it('resolves data field', async () => {
-        const result = await gqlQuery({
-          app,
-          token: fixture.owner.token,
-          ...getQuery(
-            fixture.project.draftRevisionId,
-            fixture.project.tableId,
-            fixture.project.rowId,
-          ),
-        });
-
-        expect(result.row).toHaveProperty('data');
-      });
+      expect(result.row.rowForeignKeysBy.totalCount).toBeGreaterThanOrEqual(0);
     });
 
-    describe('countForeignKeysTo field', () => {
-      const getQuery = (
-        revisionId: string,
-        tableId: string,
-        rowId: string,
-      ) => ({
-        query: gql`
-          query row($data: GetRowInput!) {
-            row(data: $data) {
-              id
-              countForeignKeysTo
-            }
-          }
-        `,
-        variables: {
-          data: { revisionId, tableId, rowId },
-        },
-      });
-
-      it('resolves countForeignKeysTo field', async () => {
-        const result = await gqlQuery({
-          app,
-          token: fixture.owner.token,
-          ...getQuery(
-            fixture.project.draftRevisionId,
-            fixture.project.tableId,
-            fixture.project.rowId,
-          ),
-        });
-
-        expect(result.row).toHaveProperty('countForeignKeysTo');
-        expect(typeof result.row.countForeignKeysTo).toBe('number');
-      });
-    });
-
-    describe('rowForeignKeysBy field', () => {
-      const getQuery = (
-        revisionId: string,
-        tableId: string,
-        rowId: string,
-        foreignKeyTableId: string,
-      ) => ({
-        query: gql`
-          query row($data: GetRowInput!, $by: GetRowForeignKeysInput!) {
-            row(data: $data) {
-              id
-              rowForeignKeysBy(data: $by) {
-                totalCount
-                edges {
-                  node {
-                    id
-                  }
+    it('resolves rowForeignKeysTo', async () => {
+      const query = gql`
+        query row($data: GetRowInput!, $to: GetRowForeignKeysInput!) {
+          row(data: $data) {
+            id
+            rowForeignKeysTo(data: $to) {
+              totalCount
+              edges {
+                node {
+                  id
                 }
               }
             }
           }
-        `,
-        variables: {
-          data: { revisionId, tableId, rowId },
-          by: { first: 10, foreignKeyTableId },
+        }
+      `;
+      const result = await kit.owner(fixture).expectOk<{
+        row: { rowForeignKeysTo: { totalCount: number } };
+      }>(query, {
+        ...rowVars(fixture),
+        to: {
+          first: 10,
+          foreignKeyTableId: fixture.project.linkedTable!.tableId,
         },
       });
-
-      it('resolves rowForeignKeysBy field', async () => {
-        const result = await gqlQuery({
-          app,
-          token: fixture.owner.token,
-          ...getQuery(
-            fixture.project.draftRevisionId,
-            fixture.project.tableId,
-            fixture.project.rowId,
-            fixture.project.linkedTable?.tableId ?? '',
-          ),
-        });
-
-        expect(result.row.rowForeignKeysBy).toBeDefined();
-        expect(result.row.rowForeignKeysBy.totalCount).toBeGreaterThanOrEqual(
-          0,
-        );
-      });
-    });
-
-    describe('rowForeignKeysTo field', () => {
-      const getQuery = (
-        revisionId: string,
-        tableId: string,
-        rowId: string,
-        foreignKeyTableId: string,
-      ) => ({
-        query: gql`
-          query row($data: GetRowInput!, $to: GetRowForeignKeysInput!) {
-            row(data: $data) {
-              id
-              rowForeignKeysTo(data: $to) {
-                totalCount
-                edges {
-                  node {
-                    id
-                  }
-                }
-              }
-            }
-          }
-        `,
-        variables: {
-          data: { revisionId, tableId, rowId },
-          to: { first: 10, foreignKeyTableId },
-        },
-      });
-
-      it('resolves rowForeignKeysTo field', async () => {
-        const result = await gqlQuery({
-          app,
-          token: fixture.owner.token,
-          ...getQuery(
-            fixture.project.draftRevisionId,
-            fixture.project.tableId,
-            fixture.project.rowId,
-            fixture.project.linkedTable?.tableId ?? '',
-          ),
-        });
-
-        expect(result.row.rowForeignKeysTo).toBeDefined();
-        expect(result.row.rowForeignKeysTo.totalCount).toBeGreaterThanOrEqual(
-          0,
-        );
-      });
+      expect(result.row.rowForeignKeysTo.totalCount).toBeGreaterThanOrEqual(0);
     });
   });
 
   describe('getRowCountForeignKeysTo query', () => {
-    const getQuery = (revisionId: string, tableId: string, rowId: string) => ({
-      query: gql`
-        query getRowCountForeignKeysTo($data: GetRowCountForeignKeysByInput!) {
-          getRowCountForeignKeysTo(data: $data)
-        }
-      `,
-      variables: {
-        data: { revisionId, tableId, rowId },
-      },
-    });
+    const query = gql`
+      query getRowCountForeignKeysTo($data: GetRowCountForeignKeysByInput!) {
+        getRowCountForeignKeysTo(data: $data)
+      }
+    `;
 
     it('owner can get count', async () => {
-      const result = await gqlQuery({
-        app,
-        token: fixture.owner.token,
-        ...getQuery(
-          fixture.project.draftRevisionId,
-          fixture.project.tableId,
-          fixture.project.rowId,
-        ),
-      });
-
+      const result = await kit.owner(fixture).expectOk<{
+        getRowCountForeignKeysTo: number;
+      }>(query, rowVars(fixture));
       expect(typeof result.getRowCountForeignKeysTo).toBe('number');
     });
 
-    it('cross-owner cannot get count from private project', async () => {
-      await gqlQueryExpectError(
-        {
-          app,
-          token: fixture.anotherOwner.token,
-          ...getQuery(
-            fixture.project.draftRevisionId,
-            fixture.project.tableId,
-            fixture.project.rowId,
-          ),
-        },
-        /You are not allowed to read on Project/,
-      );
+    it('cross-owner is forbidden', async () => {
+      await kit.crossOwner(fixture).expectForbidden(query, rowVars(fixture));
     });
   });
 });

--- a/src/api/graphql-api/__tests__/sub-schema/sub-schema.readonly.spec.ts
+++ b/src/api/graphql-api/__tests__/sub-schema/sub-schema.readonly.spec.ts
@@ -7,9 +7,11 @@ import { FileStatus } from 'src/features/plugin/file/consts';
 import { metaSchema, tableMigrationsSchema } from '@revisium/engine';
 import { gql } from 'src/testing/utils/gql';
 import {
-  createFreshTestApp,
-  gqlQuery,
-  gqlQueryExpectError,
+  describeAuthMatrix,
+  getTestApp,
+  gqlKit,
+  PRIVATE_RESOURCE_MATRIX,
+  type GqlKit,
 } from 'src/testing/e2e';
 import { prepareData, prepareRow } from 'src/testing/utils/prepareProject';
 import { PrismaService } from 'src/infrastructure/database/prisma.service';
@@ -38,44 +40,41 @@ const createFileData = (
   height: 100,
 });
 
-describe('graphql - subSchemaItems (readonly)', () => {
-  let app: INestApplication;
-
-  beforeAll(async () => {
-    app = await createFreshTestApp();
-  });
-
-  afterAll(async () => {
-    await app.close();
-  });
-
-  const getSubSchemaItemsQuery = (revisionId: string, schemaId: string) => ({
-    query: gql`
-      query subSchemaItems($data: GetSubSchemaItemsInput!) {
-        subSchemaItems(data: $data) {
-          totalCount
-          pageInfo {
-            hasNextPage
-            hasPreviousPage
+const subSchemaItemsQuery = gql`
+  query subSchemaItems($data: GetSubSchemaItemsInput!) {
+    subSchemaItems(data: $data) {
+      totalCount
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+      }
+      edges {
+        node {
+          fieldPath
+          data
+          row {
+            id
           }
-          edges {
-            node {
-              fieldPath
-              data
-              row {
-                id
-              }
-              table {
-                id
-              }
-            }
+          table {
+            id
           }
         }
       }
-    `,
-    variables: {
-      data: { revisionId, schemaId, first: 100 },
-    },
+    }
+  }
+`;
+
+const subSchemaVars = (revisionId: string, schemaId: string) => ({
+  data: { revisionId, schemaId, first: 100 },
+});
+
+describe('graphql - subSchemaItems (readonly)', () => {
+  let app: INestApplication;
+  let kit: GqlKit;
+
+  beforeAll(async () => {
+    app = await getTestApp();
+    kit = gqlKit(app);
   });
 
   describe('private project access', () => {
@@ -85,52 +84,41 @@ describe('graphql - subSchemaItems (readonly)', () => {
       fixture = await prepareFixtureWithFiles(app);
     });
 
-    it('owner can query subSchemaItems', async () => {
-      const result = await gqlQuery({
-        app,
-        token: fixture.owner.token,
-        ...getSubSchemaItemsQuery(
+    describeAuthMatrix(
+      'private project',
+      PRIVATE_RESOURCE_MATRIX,
+      async ({ role, outcome }) => {
+        const actor = kit.roleFor(fixture, role);
+        const vars = subSchemaVars(
           fixture.project.draftRevisionId,
           FILE_SCHEMA_ID,
-        ),
-      });
-
-      expect(result.subSchemaItems.totalCount).toBe(1);
-      expect(result.subSchemaItems.edges[0].node.fieldPath).toBe('file');
-      expect(result.subSchemaItems.edges[0].node.table.id).toBe(
-        fixture.project.tableId,
-      );
-      expect(result.subSchemaItems.edges[0].node.row.id).toBe(
-        fixture.project.rowId,
-      );
-    });
-
-    it('cross-owner cannot query subSchemaItems from private project', async () => {
-      await gqlQueryExpectError(
-        {
-          app,
-          token: fixture.anotherOwner.token,
-          ...getSubSchemaItemsQuery(
-            fixture.project.draftRevisionId,
-            FILE_SCHEMA_ID,
-          ),
-        },
-        /You are not allowed to read on Project/,
-      );
-    });
-
-    it('unauthenticated cannot query subSchemaItems from private project', async () => {
-      await gqlQueryExpectError(
-        {
-          app,
-          ...getSubSchemaItemsQuery(
-            fixture.project.draftRevisionId,
-            FILE_SCHEMA_ID,
-          ),
-        },
-        /You are not allowed to read on Project/,
-      );
-    });
+        );
+        if (outcome === 'ok') {
+          const result = await actor.expectOk<{
+            subSchemaItems: {
+              totalCount: number;
+              edges: Array<{
+                node: {
+                  fieldPath: string;
+                  row: { id: string };
+                  table: { id: string };
+                };
+              }>;
+            };
+          }>(subSchemaItemsQuery, vars);
+          expect(result.subSchemaItems.totalCount).toBe(1);
+          expect(result.subSchemaItems.edges[0].node.fieldPath).toBe('file');
+          expect(result.subSchemaItems.edges[0].node.table.id).toBe(
+            fixture.project.tableId,
+          );
+          expect(result.subSchemaItems.edges[0].node.row.id).toBe(
+            fixture.project.rowId,
+          );
+        } else {
+          await actor.expectForbidden(subSchemaItemsQuery, vars);
+        }
+      },
+    );
   });
 
   describe('public project access', () => {
@@ -145,28 +133,17 @@ describe('graphql - subSchemaItems (readonly)', () => {
       });
     });
 
-    it('unauthenticated can query subSchemaItems from public project', async () => {
-      const result = await gqlQuery({
-        app,
-        ...getSubSchemaItemsQuery(
-          fixture.project.draftRevisionId,
-          FILE_SCHEMA_ID,
-        ),
-      });
-
+    it('anon can query subSchemaItems', async () => {
+      const result = await kit.anon().expectOk<{
+        subSchemaItems: { totalCount: number };
+      }>(subSchemaItemsQuery, subSchemaVars(fixture.project.draftRevisionId, FILE_SCHEMA_ID));
       expect(result.subSchemaItems.totalCount).toBe(1);
     });
 
-    it('cross-owner can query subSchemaItems from public project', async () => {
-      const result = await gqlQuery({
-        app,
-        token: fixture.anotherOwner.token,
-        ...getSubSchemaItemsQuery(
-          fixture.project.draftRevisionId,
-          FILE_SCHEMA_ID,
-        ),
-      });
-
+    it('cross-owner can query subSchemaItems', async () => {
+      const result = await kit.crossOwner(fixture).expectOk<{
+        subSchemaItems: { totalCount: number };
+      }>(subSchemaItemsQuery, subSchemaVars(fixture.project.draftRevisionId, FILE_SCHEMA_ID));
       expect(result.subSchemaItems.totalCount).toBe(1);
     });
   });
@@ -282,14 +259,14 @@ describe('graphql - subSchemaItems (readonly)', () => {
         },
       });
 
-      const result = await gqlQuery({
-        app,
-        token: baseFixture.owner.token,
-        ...getSubSchemaItemsQuery(
-          baseFixture.project.draftRevisionId,
-          FILE_SCHEMA_ID,
-        ),
-      });
+      const result = await kit.actor(baseFixture.owner.token).expectOk<{
+        subSchemaItems: {
+          totalCount: number;
+          edges: Array<{
+            node: { row: { id: string }; table: { id: string } };
+          }>;
+        };
+      }>(subSchemaItemsQuery, subSchemaVars(baseFixture.project.draftRevisionId, FILE_SCHEMA_ID));
 
       expect(result.subSchemaItems.totalCount).toBe(1);
       expect(result.subSchemaItems.edges.length).toBe(1);

--- a/src/api/graphql-api/__tests__/table/table.readonly.spec.ts
+++ b/src/api/graphql-api/__tests__/table/table.readonly.spec.ts
@@ -1,220 +1,164 @@
 import { INestApplication } from '@nestjs/common';
 import { gql } from 'src/testing/utils/gql';
 import {
-  createFreshTestApp,
+  describeAuthMatrix,
+  getTestApp,
   getReadonlyFixture,
   getPublicProjectFixture,
-  gqlQuery,
-  gqlQueryExpectError,
+  gqlKit,
+  PRIVATE_RESOURCE_MATRIX,
+  type GqlKit,
   type PrepareDataReturnType,
 } from 'src/testing/e2e';
 
+const tableQuery = gql`
+  query table($data: GetTableInput!) {
+    table(data: $data) {
+      id
+      versionId
+      createdAt
+      readonly
+    }
+  }
+`;
+
+const tablesQuery = gql`
+  query tables($data: GetTablesInput!) {
+    tables(data: $data) {
+      totalCount
+      edges {
+        node {
+          id
+        }
+      }
+    }
+  }
+`;
+
+const tableVars = (revisionId: string, tableId: string) => ({
+  data: { revisionId, tableId },
+});
+
+const tablesVars = (revisionId: string) => ({
+  data: { revisionId, first: 10 },
+});
+
 describe('graphql - table (readonly)', () => {
   let app: INestApplication;
+  let kit: GqlKit;
   let fixture: PrepareDataReturnType;
   let publicFixture: PrepareDataReturnType;
 
   beforeAll(async () => {
-    app = await createFreshTestApp();
+    app = await getTestApp();
+    kit = gqlKit(app);
     fixture = await getReadonlyFixture(app);
     publicFixture = await getPublicProjectFixture(app);
   });
 
-  afterAll(async () => {
-    await app.close();
-  });
-
   describe('table query', () => {
-    const getQuery = (revisionId: string, tableId: string) => ({
-      query: gql`
-        query table($data: GetTableInput!) {
-          table(data: $data) {
-            id
-            versionId
-            createdAt
-            readonly
-          }
+    describeAuthMatrix(
+      'private project access',
+      PRIVATE_RESOURCE_MATRIX,
+      async ({ role, outcome }) => {
+        const actor = kit.roleFor(fixture, role);
+        const vars = tableVars(
+          fixture.project.draftRevisionId,
+          fixture.project.tableId,
+        );
+        if (outcome === 'ok') {
+          const result = await actor.expectOk<{ table: { id: string } }>(
+            tableQuery,
+            vars,
+          );
+          expect(result.table.id).toBe(fixture.project.tableId);
+        } else {
+          await actor.expectForbidden(tableQuery, vars);
         }
-      `,
-      variables: {
-        data: { revisionId, tableId },
       },
-    });
+    );
 
-    it('owner can get table', async () => {
-      const result = await gqlQuery({
-        app,
-        token: fixture.owner.token,
-        ...getQuery(fixture.project.draftRevisionId, fixture.project.tableId),
-      });
-
-      expect(result.table.id).toBe(fixture.project.tableId);
-    });
-
-    it('cross-owner cannot get table from private project', async () => {
-      await gqlQueryExpectError(
-        {
-          app,
-          token: fixture.anotherOwner.token,
-          ...getQuery(fixture.project.draftRevisionId, fixture.project.tableId),
-        },
-        /You are not allowed to read on Project/,
-      );
-    });
-
-    it('unauthenticated cannot get table from private project', async () => {
-      await gqlQueryExpectError(
-        {
-          app,
-          ...getQuery(fixture.project.draftRevisionId, fixture.project.tableId),
-        },
-        /You are not allowed to read on Project/,
-      );
-    });
-
-    describe('public project', () => {
-      it('unauthenticated can get table from public project', async () => {
-        const result = await gqlQuery({
-          app,
-          ...getQuery(
-            publicFixture.project.draftRevisionId,
-            publicFixture.project.tableId,
-          ),
-        });
-
-        expect(result.table.id).toBe(publicFixture.project.tableId);
-      });
+    it('anon can read table from public project', async () => {
+      const result = await kit.anon().expectOk<{
+        table: { id: string };
+      }>(tableQuery, tableVars(publicFixture.project.draftRevisionId, publicFixture.project.tableId));
+      expect(result.table.id).toBe(publicFixture.project.tableId);
     });
   });
 
   describe('tables query', () => {
-    const getQuery = (revisionId: string) => ({
-      query: gql`
-        query tables($data: GetTablesInput!) {
-          tables(data: $data) {
-            totalCount
-            edges {
-              node {
-                id
-              }
-            }
-          }
-        }
-      `,
-      variables: {
-        data: { revisionId, first: 10 },
-      },
-    });
-
-    it('owner can get tables', async () => {
-      const result = await gqlQuery({
-        app,
-        token: fixture.owner.token,
-        ...getQuery(fixture.project.draftRevisionId),
-      });
-
+    it('owner can list tables', async () => {
+      const result = await kit.owner(fixture).expectOk<{
+        tables: { totalCount: number };
+      }>(tablesQuery, tablesVars(fixture.project.draftRevisionId));
       expect(result.tables.totalCount).toBeGreaterThanOrEqual(1);
     });
 
-    it('cross-owner cannot get tables from private project', async () => {
-      await gqlQueryExpectError(
-        {
-          app,
-          token: fixture.anotherOwner.token,
-          ...getQuery(fixture.project.draftRevisionId),
-        },
-        /You are not allowed to read on Project/,
-      );
+    it('cross-owner is forbidden from listing tables', async () => {
+      await kit
+        .crossOwner(fixture)
+        .expectForbidden(
+          tablesQuery,
+          tablesVars(fixture.project.draftRevisionId),
+        );
     });
   });
 
-  describe('table with @ResolveField', () => {
-    describe('rows field', () => {
-      const getQuery = (revisionId: string, tableId: string) => ({
-        query: gql`
-          query table($data: GetTableInput!, $rowsData: GetTableRowsInput!) {
-            table(data: $data) {
-              id
-              rows(data: $rowsData) {
-                totalCount
-                edges {
-                  node {
-                    id
-                    versionId
-                  }
+  describe('@ResolveField', () => {
+    it('resolves rows', async () => {
+      const query = gql`
+        query table($data: GetTableInput!, $rowsData: GetTableRowsInput!) {
+          table(data: $data) {
+            id
+            rows(data: $rowsData) {
+              totalCount
+              edges {
+                node {
+                  id
+                  versionId
                 }
               }
             }
           }
-        `,
-        variables: {
-          data: { revisionId, tableId },
-          rowsData: { first: 10 },
-        },
+        }
+      `;
+      const result = await kit.owner(fixture).expectOk<{
+        table: { rows: { totalCount: number } };
+      }>(query, {
+        ...tableVars(fixture.project.draftRevisionId, fixture.project.tableId),
+        rowsData: { first: 10 },
       });
-
-      it('resolves rows field', async () => {
-        const result = await gqlQuery({
-          app,
-          token: fixture.owner.token,
-          ...getQuery(fixture.project.draftRevisionId, fixture.project.tableId),
-        });
-
-        expect(result.table.rows).toBeDefined();
-        expect(result.table.rows.totalCount).toBeGreaterThanOrEqual(1);
-      });
+      expect(result.table.rows.totalCount).toBeGreaterThanOrEqual(1);
     });
 
-    describe('schema field', () => {
-      const getQuery = (revisionId: string, tableId: string) => ({
-        query: gql`
-          query table($data: GetTableInput!) {
-            table(data: $data) {
-              id
-              schema
-            }
+    it('resolves schema', async () => {
+      const query = gql`
+        query table($data: GetTableInput!) {
+          table(data: $data) {
+            id
+            schema
           }
-        `,
-        variables: {
-          data: { revisionId, tableId },
-        },
-      });
-
-      it('resolves schema field', async () => {
-        const result = await gqlQuery({
-          app,
-          token: fixture.owner.token,
-          ...getQuery(fixture.project.draftRevisionId, fixture.project.tableId),
-        });
-
-        expect(result.table).toHaveProperty('schema');
-      });
+        }
+      `;
+      const result = await kit.owner(fixture).expectOk<{
+        table: { schema: unknown };
+      }>(query, tableVars(fixture.project.draftRevisionId, fixture.project.tableId));
+      expect(result.table).toHaveProperty('schema');
     });
 
-    describe('count field', () => {
-      const getQuery = (revisionId: string, tableId: string) => ({
-        query: gql`
-          query table($data: GetTableInput!) {
-            table(data: $data) {
-              id
-              count
-            }
+    it('resolves count', async () => {
+      const query = gql`
+        query table($data: GetTableInput!) {
+          table(data: $data) {
+            id
+            count
           }
-        `,
-        variables: {
-          data: { revisionId, tableId },
-        },
-      });
-
-      it('resolves count field', async () => {
-        const result = await gqlQuery({
-          app,
-          token: fixture.owner.token,
-          ...getQuery(fixture.project.draftRevisionId, fixture.project.tableId),
-        });
-
-        expect(result.table.count).toBeGreaterThanOrEqual(1);
-      });
+        }
+      `;
+      const result = await kit.owner(fixture).expectOk<{
+        table: { count: number };
+      }>(query, tableVars(fixture.project.draftRevisionId, fixture.project.tableId));
+      expect(result.table.count).toBeGreaterThanOrEqual(1);
     });
   });
 });

--- a/src/api/graphql-api/__tests__/user/admin-user.readonly.spec.ts
+++ b/src/api/graphql-api/__tests__/user/admin-user.readonly.spec.ts
@@ -6,28 +6,73 @@ import { UserSystemRoles } from 'src/features/auth/consts';
 import { AuthService } from 'src/features/auth/auth.service';
 import { PrismaService } from 'src/infrastructure/database/prisma.service';
 import {
-  createFreshTestApp,
+  getTestApp,
   getReadonlyFixture,
-  gqlQuery,
-  gqlQueryRaw,
+  gqlKit,
+  type GqlKit,
   type PrepareDataReturnType,
 } from 'src/testing/e2e';
 
+const NOT_ALLOWED = /not allowed/i;
+const UNAUTHORIZED = /Unauthorized/i;
+
+const adminUsersQuery = gql`
+  query adminUsers($data: SearchUsersInput!) {
+    adminUsers(data: $data) {
+      totalCount
+      edges {
+        node {
+          id
+          username
+          email
+          roleId
+        }
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+    }
+  }
+`;
+
+const adminUserQuery = gql`
+  query adminUser($data: AdminUserInput!) {
+    adminUser(data: $data) {
+      id
+      username
+      email
+      roleId
+    }
+  }
+`;
+
+const adminUserWithRoleQuery = gql`
+  query adminUser($data: AdminUserInput!) {
+    adminUser(data: $data) {
+      id
+      roleId
+      role {
+        id
+        name
+      }
+    }
+  }
+`;
+
 describe('graphql - admin user (readonly)', () => {
   let app: INestApplication;
+  let kit: GqlKit;
   let fixture: PrepareDataReturnType;
   let prismaService: PrismaService;
   let authService: AuthService;
 
   beforeAll(async () => {
-    app = await createFreshTestApp();
+    app = await getTestApp();
+    kit = gqlKit(app);
     fixture = await getReadonlyFixture(app);
     prismaService = app.get(PrismaService);
     authService = app.get(AuthService);
-  });
-
-  afterAll(async () => {
-    await app.close();
   });
 
   const createAdminUser = async () => {
@@ -46,206 +91,88 @@ describe('graphql - admin user (readonly)', () => {
   };
 
   describe('adminUsers query', () => {
-    const getQuery = (search?: string) => ({
-      query: gql`
-        query adminUsers($data: SearchUsersInput!) {
-          adminUsers(data: $data) {
-            totalCount
-            edges {
-              node {
-                id
-                username
-                email
-                roleId
-              }
-            }
-            pageInfo {
-              hasNextPage
-              endCursor
-            }
-          }
-        }
-      `,
-      variables: {
-        data: { search, first: 10 },
-      },
+    const listVars = (search?: string) => ({
+      data: { search, first: 10 },
     });
 
-    it('admin user can list all users', async () => {
+    it('admin lists all users', async () => {
       const admin = await createAdminUser();
+      const result = await kit.actor(admin.token).expectOk<{
+        adminUsers: { totalCount: number; edges: unknown[] };
+      }>(adminUsersQuery, listVars());
 
-      const result = await gqlQuery({
-        app,
-        token: admin.token,
-        ...getQuery(),
-      });
-
-      expect(result.adminUsers).toHaveProperty('totalCount');
+      expect(result.adminUsers.totalCount).toBeGreaterThanOrEqual(1);
       expect(result.adminUsers).toHaveProperty('edges');
-      expect(result.adminUsers.totalCount).toBeGreaterThanOrEqual(1);
     });
 
-    it('admin user can search users', async () => {
+    it('admin can search users and sees roleId', async () => {
       const admin = await createAdminUser();
-
-      const result = await gqlQuery({
-        app,
-        token: admin.token,
-        ...getQuery(admin.user.username ?? undefined),
-      });
+      const result = await kit.actor(admin.token).expectOk<{
+        adminUsers: {
+          totalCount: number;
+          edges: Array<{ node: { id: string; roleId: string } }>;
+        };
+      }>(adminUsersQuery, listVars(admin.user.username ?? undefined));
 
       expect(result.adminUsers.totalCount).toBeGreaterThanOrEqual(1);
-      const foundUser = result.adminUsers.edges.find(
-        (edge: { node: { id: string } }) => edge.node.id === admin.user.id,
+      const found = result.adminUsers.edges.find(
+        (e) => e.node.id === admin.user.id,
       );
-      expect(foundUser).toBeDefined();
+      expect(found?.node.roleId).toBe(UserSystemRoles.systemAdmin);
     });
 
-    it('includes roleId field in response', async () => {
-      const admin = await createAdminUser();
-
-      const result = await gqlQuery({
-        app,
-        token: admin.token,
-        ...getQuery(admin.user.username ?? undefined),
-      });
-
-      const foundUser = result.adminUsers.edges.find(
-        (edge: { node: { id: string } }) => edge.node.id === admin.user.id,
-      );
-      expect(foundUser?.node.roleId).toBe(UserSystemRoles.systemAdmin);
+    it('regular user is not allowed', async () => {
+      await kit
+        .owner(fixture)
+        .expectError(adminUsersQuery, listVars(), NOT_ALLOWED);
     });
 
-    it('regular user cannot access adminUsers', async () => {
-      const result = await gqlQueryRaw({
-        app,
-        token: fixture.owner.token,
-        ...getQuery(),
-      });
-
-      expect(result.errors).toBeDefined();
-      expect(result.errors?.[0].message).toMatch(/not allowed/i);
-    });
-
-    it('unauthenticated cannot access adminUsers', async () => {
-      const result = await gqlQueryRaw({
-        app,
-        ...getQuery(),
-      });
-
-      expect(result.errors).toBeDefined();
-      expect(result.errors?.[0].message).toMatch(/Unauthorized/i);
+    it('anon is unauthorized', async () => {
+      await kit.anon().expectError(adminUsersQuery, listVars(), UNAUTHORIZED);
     });
   });
 
   describe('adminUser query', () => {
-    const getQuery = (userId: string) => ({
-      query: gql`
-        query adminUser($data: AdminUserInput!) {
-          adminUser(data: $data) {
-            id
-            username
-            email
-            roleId
-          }
-        }
-      `,
-      variables: {
-        data: { userId },
-      },
-    });
+    const vars = (userId: string) => ({ data: { userId } });
 
-    it('admin user can get user by id', async () => {
+    it('admin gets user by id', async () => {
       const admin = await createAdminUser();
+      const result = await kit.actor(admin.token).expectOk<{
+        adminUser: { id: string; username: string; roleId: string };
+      }>(adminUserQuery, vars(admin.user.id));
 
-      const result = await gqlQuery({
-        app,
-        token: admin.token,
-        ...getQuery(admin.user.id),
-      });
-
-      expect(result.adminUser).toBeDefined();
       expect(result.adminUser.id).toBe(admin.user.id);
       expect(result.adminUser.username).toBe(admin.user.username);
-    });
-
-    it('includes roleId field in response', async () => {
-      const admin = await createAdminUser();
-
-      const result = await gqlQuery({
-        app,
-        token: admin.token,
-        ...getQuery(admin.user.id),
-      });
-
       expect(result.adminUser.roleId).toBe(UserSystemRoles.systemAdmin);
     });
 
-    it('throws error for non-existent user', async () => {
+    it('admin hitting non-existent user gets not-found', async () => {
       const admin = await createAdminUser();
-      const nonExistentUserId = nanoid();
-
-      const result = await gqlQueryRaw({
-        app,
-        token: admin.token,
-        ...getQuery(nonExistentUserId),
-      });
-
-      expect(result.errors).toBeDefined();
-      expect(result.errors?.[0].message).toMatch(/Not found user/i);
+      await kit
+        .actor(admin.token)
+        .expectError(adminUserQuery, vars(nanoid()), /Not found user/i);
     });
 
-    it('regular user cannot access adminUser', async () => {
-      const result = await gqlQueryRaw({
-        app,
-        token: fixture.owner.token,
-        ...getQuery(fixture.owner.user.id),
-      });
-
-      expect(result.errors).toBeDefined();
-      expect(result.errors?.[0].message).toMatch(/not allowed/i);
+    it('regular user is not allowed', async () => {
+      await kit
+        .owner(fixture)
+        .expectError(adminUserQuery, vars(fixture.owner.user.id), NOT_ALLOWED);
     });
 
-    it('unauthenticated cannot access adminUser', async () => {
-      const result = await gqlQueryRaw({
-        app,
-        ...getQuery(fixture.owner.user.id),
-      });
-
-      expect(result.errors).toBeDefined();
-      expect(result.errors?.[0].message).toMatch(/Unauthorized/i);
+    it('anon is unauthorized', async () => {
+      await kit
+        .anon()
+        .expectError(adminUserQuery, vars(fixture.owner.user.id), UNAUTHORIZED);
     });
   });
 
   describe('role field resolution via adminUser', () => {
-    const getQueryWithRole = (userId: string) => ({
-      query: gql`
-        query adminUser($data: AdminUserInput!) {
-          adminUser(data: $data) {
-            id
-            roleId
-            role {
-              id
-              name
-            }
-          }
-        }
-      `,
-      variables: {
-        data: { userId },
-      },
-    });
-
     it('resolves role field for admin user', async () => {
       const admin = await createAdminUser();
+      const result = await kit.actor(admin.token).expectOk<{
+        adminUser: { role: { id: string } };
+      }>(adminUserWithRoleQuery, { data: { userId: admin.user.id } });
 
-      const result = await gqlQuery({
-        app,
-        token: admin.token,
-        ...getQueryWithRole(admin.user.id),
-      });
-
-      expect(result.adminUser.role).toBeDefined();
       expect(result.adminUser.role.id).toBe(UserSystemRoles.systemAdmin);
     });
   });

--- a/src/api/graphql-api/__tests__/user/user.readonly.spec.ts
+++ b/src/api/graphql-api/__tests__/user/user.readonly.spec.ts
@@ -1,192 +1,142 @@
 import { INestApplication } from '@nestjs/common';
 import { gql } from 'src/testing/utils/gql';
 import {
-  createFreshTestApp,
+  getTestApp,
   getReadonlyFixture,
-  gqlQuery,
-  gqlQueryExpectError,
+  gqlKit,
+  type GqlKit,
   type PrepareDataReturnType,
 } from 'src/testing/e2e';
 
+const UNAUTHORIZED = /Unauthorized/;
+
+const meQuery = gql`
+  query me {
+    me {
+      id
+      username
+      email
+    }
+  }
+`;
+
+const meProjectsQuery = gql`
+  query meProjects($data: GetMeProjectsInput!) {
+    meProjects(data: $data) {
+      totalCount
+      edges {
+        node {
+          id
+          name
+        }
+      }
+    }
+  }
+`;
+
+const searchUsersQuery = gql`
+  query searchUsers($data: SearchUsersInput!) {
+    searchUsers(data: $data) {
+      totalCount
+      edges {
+        node {
+          id
+          username
+        }
+      }
+    }
+  }
+`;
+
 describe('graphql - user (readonly)', () => {
   let app: INestApplication;
+  let kit: GqlKit;
   let fixture: PrepareDataReturnType;
 
   beforeAll(async () => {
-    app = await createFreshTestApp();
+    app = await getTestApp();
+    kit = gqlKit(app);
     fixture = await getReadonlyFixture(app);
   });
 
-  afterAll(async () => {
-    await app.close();
-  });
-
   describe('me query', () => {
-    const getQuery = () => ({
-      query: gql`
-        query me {
-          me {
-            id
-            username
-            email
-          }
-        }
-      `,
-    });
-
-    it('authenticated user can get own info', async () => {
-      const result = await gqlQuery({
-        app,
-        token: fixture.owner.token,
-        ...getQuery(),
-      });
+    it('owner gets own info', async () => {
+      const result = await kit.owner(fixture).expectOk<{
+        me: { id: string; username: string };
+      }>(meQuery);
 
       expect(result.me.id).toBe(fixture.owner.user.id);
       expect(result.me.username).toBe(fixture.owner.user.username);
     });
 
-    it('unauthenticated cannot get me', async () => {
-      await gqlQueryExpectError(
-        {
-          app,
-          ...getQuery(),
-        },
-        /Unauthorized/,
-      );
+    it('anon is unauthorized', async () => {
+      await kit.anon().expectError(meQuery, undefined, UNAUTHORIZED);
     });
   });
 
-  describe('me with @ResolveField', () => {
-    describe('organizationId field', () => {
-      const getQuery = () => ({
-        query: gql`
-          query me {
-            me {
-              id
-              organizationId
-            }
+  describe('@ResolveField on me', () => {
+    it('resolves organizationId', async () => {
+      const query = gql`
+        query me {
+          me {
+            id
+            organizationId
           }
-        `,
-      });
-
-      it('resolves organizationId field', async () => {
-        const result = await gqlQuery({
-          app,
-          token: fixture.owner.token,
-          ...getQuery(),
-        });
-
-        expect(result.me).toHaveProperty('organizationId');
-      });
+        }
+      `;
+      const result = await kit.owner(fixture).expectOk<{
+        me: { organizationId: string };
+      }>(query);
+      expect(result.me).toHaveProperty('organizationId');
     });
 
-    describe('role field', () => {
-      const getQuery = () => ({
-        query: gql`
-          query me {
-            me {
+    it('resolves role', async () => {
+      const query = gql`
+        query me {
+          me {
+            id
+            role {
               id
-              role {
-                id
-                name
-              }
+              name
             }
           }
-        `,
-      });
-
-      it('resolves role field', async () => {
-        const result = await gqlQuery({
-          app,
-          token: fixture.owner.token,
-          ...getQuery(),
-        });
-
-        expect(result.me).toHaveProperty('role');
-      });
+        }
+      `;
+      const result = await kit.owner(fixture).expectOk<{
+        me: { role: { id: string; name: string } };
+      }>(query);
+      expect(result.me).toHaveProperty('role');
     });
   });
 
   describe('meProjects query', () => {
-    const getQuery = () => ({
-      query: gql`
-        query meProjects($data: GetMeProjectsInput!) {
-          meProjects(data: $data) {
-            totalCount
-            edges {
-              node {
-                id
-                name
-              }
-            }
-          }
-        }
-      `,
-      variables: {
-        data: { first: 10 },
-      },
-    });
+    const vars = { data: { first: 10 } };
 
-    it('authenticated user can get own projects', async () => {
-      const result = await gqlQuery({
-        app,
-        token: fixture.owner.token,
-        ...getQuery(),
-      });
-
+    it('owner lists own projects', async () => {
+      const result = await kit.owner(fixture).expectOk<{
+        meProjects: { totalCount: number };
+      }>(meProjectsQuery, vars);
       expect(result.meProjects.totalCount).toBeGreaterThanOrEqual(1);
     });
 
-    it('unauthenticated cannot get meProjects', async () => {
-      await gqlQueryExpectError(
-        {
-          app,
-          ...getQuery(),
-        },
-        /Unauthorized/,
-      );
+    it('anon is unauthorized', async () => {
+      await kit.anon().expectError(meProjectsQuery, vars, UNAUTHORIZED);
     });
   });
 
   describe('searchUsers query', () => {
-    const getQuery = (search: string) => ({
-      query: gql`
-        query searchUsers($data: SearchUsersInput!) {
-          searchUsers(data: $data) {
-            totalCount
-            edges {
-              node {
-                id
-                username
-              }
-            }
-          }
-        }
-      `,
-      variables: {
-        data: { search, first: 10 },
-      },
-    });
+    const vars = { data: { search: 'user', first: 10 } };
 
-    it('authenticated user can search users', async () => {
-      const result = await gqlQuery({
-        app,
-        token: fixture.owner.token,
-        ...getQuery('user'),
-      });
-
+    it('owner can search users', async () => {
+      const result = await kit.owner(fixture).expectOk<{
+        searchUsers: { totalCount: number; edges: unknown[] };
+      }>(searchUsersQuery, vars);
       expect(result.searchUsers).toHaveProperty('totalCount');
       expect(result.searchUsers).toHaveProperty('edges');
     });
 
-    it('unauthenticated cannot search users', async () => {
-      await gqlQueryExpectError(
-        {
-          app,
-          ...getQuery('user'),
-        },
-        /Unauthorized/,
-      );
+    it('anon is unauthorized', async () => {
+      await kit.anon().expectError(searchUsersQuery, vars, UNAUTHORIZED);
     });
   });
 });

--- a/src/testing/e2e/auth-matrix.ts
+++ b/src/testing/e2e/auth-matrix.ts
@@ -1,0 +1,74 @@
+import type { ActorRole } from './gql-query-kit';
+
+export type AuthOutcome = 'ok' | 'forbidden' | 'notFound';
+
+export interface AuthMatrixCase {
+  role: ActorRole;
+  outcome: AuthOutcome;
+  label?: string;
+}
+
+export interface AuthMatrixOptions {
+  /**
+   * Override the default label for each case. Defaults to something like
+   * "owner can access" / "cross-owner is forbidden" / "anon is forbidden".
+   */
+  label?: (c: AuthMatrixCase) => string;
+}
+
+const DEFAULT_LABELS: Record<ActorRole, Record<AuthOutcome, string>> = {
+  owner: {
+    ok: 'owner can access',
+    forbidden: 'owner is forbidden',
+    notFound: 'owner gets not found',
+  },
+  crossOwner: {
+    ok: 'cross-owner can access',
+    forbidden: 'cross-owner is forbidden',
+    notFound: 'cross-owner gets not found',
+  },
+  anon: {
+    ok: 'anon can access',
+    forbidden: 'anon is forbidden',
+    notFound: 'anon gets not found',
+  },
+};
+
+function defaultLabel(c: AuthMatrixCase): string {
+  return c.label ?? DEFAULT_LABELS[c.role][c.outcome];
+}
+
+/**
+ * Declarative auth matrix runner. Each case describes an (actor, expected
+ * outcome) pair; `runCase` receives the role and outcome so it can dispatch
+ * through a `gqlKit` actor. Lives here (not in kit) so REST / other transports
+ * can reuse the same matrix shape.
+ */
+export function describeAuthMatrix(
+  label: string,
+  cases: AuthMatrixCase[],
+  runCase: (c: AuthMatrixCase) => Promise<void>,
+  options: AuthMatrixOptions = {},
+): void {
+  const labelFor = options.label ?? defaultLabel;
+
+  describe(label, () => {
+    for (const c of cases) {
+      it(labelFor(c), () => runCase(c));
+    }
+  });
+}
+
+/** Standard private-resource matrix: owner OK, cross-owner forbidden, anon forbidden. */
+export const PRIVATE_RESOURCE_MATRIX: AuthMatrixCase[] = [
+  { role: 'owner', outcome: 'ok' },
+  { role: 'crossOwner', outcome: 'forbidden' },
+  { role: 'anon', outcome: 'forbidden' },
+];
+
+/** Standard public-resource matrix: everyone can read. */
+export const PUBLIC_RESOURCE_MATRIX: AuthMatrixCase[] = [
+  { role: 'owner', outcome: 'ok' },
+  { role: 'crossOwner', outcome: 'ok' },
+  { role: 'anon', outcome: 'ok' },
+];

--- a/src/testing/e2e/gql-query-kit.ts
+++ b/src/testing/e2e/gql-query-kit.ts
@@ -1,0 +1,79 @@
+import { INestApplication } from '@nestjs/common';
+import {
+  gqlQuery,
+  gqlQueryExpectError,
+  gqlQueryRaw,
+  type GraphQLErrorResponse,
+} from './graphql-helpers';
+
+type Vars = Record<string, unknown> | undefined;
+
+export interface GqlActor {
+  expectOk: <T = Record<string, any>>(
+    query: string,
+    variables?: Vars,
+  ) => Promise<T>;
+  expectError: (
+    query: string,
+    variables: Vars,
+    errorPattern: RegExp,
+  ) => Promise<void>;
+  expectForbidden: (query: string, variables?: Vars) => Promise<void>;
+  expectNotFound: (query: string, variables?: Vars) => Promise<void>;
+  raw: (query: string, variables?: Vars) => Promise<GraphQLErrorResponse>;
+}
+
+export interface AuthFixture {
+  owner: { token: string };
+  anotherOwner: { token: string };
+}
+
+export type ActorRole = 'owner' | 'crossOwner' | 'anon';
+
+export interface GqlKit {
+  actor: (token?: string) => GqlActor;
+  owner: (fixture: AuthFixture) => GqlActor;
+  crossOwner: (fixture: AuthFixture) => GqlActor;
+  anon: () => GqlActor;
+  roleFor: (fixture: AuthFixture, role: ActorRole) => GqlActor;
+}
+
+const FORBIDDEN_PATTERN = /You are not allowed/i;
+const NOT_FOUND_PATTERN = /not found/i;
+
+export function gqlKit(app: INestApplication): GqlKit {
+  const actor = (token?: string): GqlActor => ({
+    expectOk: <T = Record<string, any>>(query: string, variables?: Vars) =>
+      gqlQuery<T>({ app, token, query, variables }),
+    expectError: (query, variables, errorPattern) =>
+      gqlQueryExpectError({ app, token, query, variables }, errorPattern),
+    expectForbidden: (query, variables) =>
+      gqlQueryExpectError({ app, token, query, variables }, FORBIDDEN_PATTERN),
+    expectNotFound: (query, variables) =>
+      gqlQueryExpectError({ app, token, query, variables }, NOT_FOUND_PATTERN),
+    raw: (query, variables) => gqlQueryRaw({ app, token, query, variables }),
+  });
+
+  const roleFor = (fixture: AuthFixture, role: ActorRole): GqlActor => {
+    switch (role) {
+      case 'owner':
+        return actor(fixture.owner.token);
+      case 'crossOwner':
+        return actor(fixture.anotherOwner.token);
+      case 'anon':
+        return actor(undefined);
+      default: {
+        const exhaustive: never = role;
+        throw new Error(`Unknown actor role: ${String(exhaustive)}`);
+      }
+    }
+  };
+
+  return {
+    actor,
+    owner: (fixture) => actor(fixture.owner.token),
+    crossOwner: (fixture) => actor(fixture.anotherOwner.token),
+    anon: () => actor(undefined),
+    roleFor,
+  };
+}

--- a/src/testing/e2e/index.ts
+++ b/src/testing/e2e/index.ts
@@ -31,3 +31,20 @@ export {
   type GraphQLQueryOptions,
   type GraphQLErrorResponse,
 } from './graphql-helpers';
+
+export {
+  gqlKit,
+  type GqlKit,
+  type GqlActor,
+  type ActorRole,
+  type AuthFixture,
+} from './gql-query-kit';
+
+export {
+  describeAuthMatrix,
+  PRIVATE_RESOURCE_MATRIX,
+  PUBLIC_RESOURCE_MATRIX,
+  type AuthMatrixCase,
+  type AuthMatrixOptions,
+  type AuthOutcome,
+} from './auth-matrix';


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Refactors readonly GraphQL e2e tests onto a declarative query kit and a per-worker cached app to cut boilerplate and speed up runs. Adds `gqlKit` actors and `describeAuthMatrix`; switches specs to `getTestApp()` for ~3% faster Jest runs with fewer lines per test.

- **New Features**
  - `gqlKit(app)` returns per-actor runners (`.owner`, `.crossOwner`, `.anon`, `.actor(token)`, `.roleFor`) with `expectOk` / `expectForbidden` / `expectNotFound` / `expectError` / `raw`.
  - `describeAuthMatrix` with `PRIVATE_RESOURCE_MATRIX` and `PUBLIC_RESOURCE_MATRIX` to standardize auth tests.

- **Refactors**
  - All 9 `*.readonly.spec.ts` migrated to `gqlKit` + auth matrix; removed repeated `{ app, token, ... }` query wiring.
  - Replaced per-file `createFreshTestApp()` with `getTestApp()` (worker-cached); dropped per-file `app.close()`.
  - `row.readonly.spec.ts` now asserts `linkedTable` exists and uses strict `linkedTable!.tableId` to fail fast.
  - Net result: same coverage with fewer lines; ~3% wall-time improvement.

<sup>Written for commit 8326ac74ec1405b5e3b057ae26e6636f3b637664. Summary will update on new commits. <a href="https://cubic.dev/pr/revisium/revisium-core/pull/506">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



