### PR TITLE
test: auth-permission kit + 65 cross-transport auth e2e specs

### DIFF
--- a/docs/testing-architecture.md
+++ b/docs/testing-architecture.md
@@ -199,19 +199,154 @@ Shared helpers should absorb repeated operational detail:
 - common database assertions
 - polling/waiting for async feature work when needed
 
+## Auth / permission matrix tests
+
+Auth and permission rules are shared across transports (REST, GraphQL, and later
+MCP) but enforced by separate guards and resolvers. The same rule can drift
+silently between transports when tested twice, so auth coverage follows a single
+shared pattern.
+
+### Goal
+
+Describe each endpoint's auth contract once and run it against every transport
+it is exposed on.
+
+### Layers
+
+Four layers, each replaceable in isolation:
+
+- **Operation** — what is being called, per transport. An operation defines a
+  `rest` and/or `gql` call signature taking a typed params object. An operation
+  may declare only one transport when the endpoint is transport-exclusive.
+- **Actor** — who is calling. `actors.anonymous()`, `actors.user({ orgRole,
+  inOrg })`, `actors.apiKey({ scopes, inOrg, branches, ... })`. Actors return a
+  transport-agnostic token/header bundle. They wrap existing `prepareData`
+  primitives rather than reseeding from scratch.
+- **Outcome** — what correct means, normalized per transport:
+  `unauthorized`, `forbidden`, `not_found`, `allowed`. REST status codes and
+  GraphQL `errors[0].extensions.code` are mapped inside the kit. Tests never
+  branch on transport.
+- **Matrix** — `describe.each(op.transports)` over `it.each(cases)`. Rows
+  describe *actor → expected* in business terms.
+
+### Kit location
+
+- kit code: `src/testing/kit/auth-permission/`
+- test files: co-located with the subject as `*.auth.e2e.spec.ts`
+- one shared spec per feature when both REST and GraphQL expose the operation,
+  transport-exclusive spec when only one transport does
+
+No shared support files under `__tests__`; imports go to
+`src/testing/kit/auth-permission/*` (consistent with the rule above).
+
+### Customization
+
+Transport coverage is not uniform. The kit must express that honestly:
+
+- **Endpoint exists on one transport only** — omit the missing transport on the
+  operation. The matrix auto-skips it. No `describe.skip` needed.
+- **Rule differs by transport** — add `transports: ['rest']` or `['gql']` to a
+  row. Rows without `transports:` run on all transports the operation supports.
+  Asymmetric rules stay explicit at the row level, not hidden in setup.
+- **Outcome differs by transport** — two rows with different `expected` and
+  disjoint `transports:`. Link an ADR when the asymmetry is intentional.
+- **Content assertions on the `allowed` path** — per-transport `assert:`
+  callbacks on a row. Only run when `expected === 'allowed'`. Never attach
+  content assertions to forbidden/not_found rows; content leakage lives in a
+  separate spec.
+- **Per-row params override** — `authCase` accepts a partial `params:` that
+  merges over the matrix defaults. Useful for scope-violation cases (API key
+  scoped to a different branch or project).
+
+### When this kit is not a fit
+
+- CASL ability rules → `casl-ability-factory.spec.ts`
+- Guard scope resolution → `permission-guard-scope.spec.ts`
+- Request-body / DTO validation → dedicated DTO specs
+- Multi-step business flows → regular feature integration or e2e tests
+
+The kit verifies that the decision is wired to every transport correctly. It is
+not a replacement for unit-testing the decision itself.
+
+### Example shape
+
+```ts
+// src/api/__tests__/project.auth.e2e.spec.ts
+const updateProject = operation({
+  id: 'project.update',
+  rest: {
+    method: 'patch',
+    url:    ({ org, project }) => `/-/organization/${org}/projects/${project}`,
+    body:   ({ newName }) => ({ name: newName }),
+  },
+  gql: {
+    query:     UPDATE_PROJECT_GQL,
+    variables: ({ org, project, newName }) => ({
+      data: { organizationId: org, projectName: project, name: newName },
+    }),
+  },
+});
+
+describe('updateProject auth', () => {
+  const ctx = buildAuthTestApp();
+  const org = 'acme';
+  const project = 'website';
+  const params = { org, project, newName: 'Renamed' };
+
+  beforeEach(() => ctx.givenProject({ org, project }));
+
+  const cases = [
+    authCase('anonymous → unauthorized',       { actor: actors.anonymous(),                                   expected: 'unauthorized' }),
+    authCase('outsider → forbidden',           { actor: actors.user({ orgRole: 'owner',  inOrg: 'other' }),   expected: 'forbidden' }),
+    authCase('viewer in org → forbidden',      { actor: actors.user({ orgRole: 'viewer', inOrg: org }),       expected: 'forbidden' }),
+    authCase('editor in org → allowed',        { actor: actors.user({ orgRole: 'editor', inOrg: org }),       expected: 'allowed' }),
+    authCase('read-only api key → forbidden',  { actor: actors.apiKey({ inOrg: org, scopes: ['project:read'] }),  expected: 'forbidden' }),
+    authCase('write api key → allowed',        { actor: actors.apiKey({ inOrg: org, scopes: ['project:write'] }), expected: 'allowed' }),
+  ];
+
+  describe.each(updateProject.transports)('via %s', (transport) => {
+    it.each(cases.filter((c) => !c.transports || c.transports.includes(transport)))(
+      '$name',
+      async ({ actor, expected, assert }) =>
+        expectAccess({ ctx, transport, actor, op: updateProject, params, expected, assert }),
+    );
+  });
+});
+```
+
+### Migration from current supertest/GraphQL specs
+
+Current e2e specs (`endpoint-by-id.controller.spec.ts`, `api-key.e2e.spec.ts`,
+`branch.resolver.spec.ts`, and similar) already use `createFreshTestApp` and
+`prepareData`. Migration is mechanical:
+
+1. Identify the auth-only cases: those whose only assertion is a status code
+   plus the auth header.
+2. Extract them into a new `*.auth.e2e.spec.ts` using the matrix form.
+3. Leave content-level assertions in the original spec. Those specs become
+   smaller and focused on business behavior.
+4. When REST and GraphQL cover the same policy, merge into one shared spec that
+   fans out over both transports.
+
 ## Current Direction
 
-The first refactor slice is `draft-revision` handler specs.
+Two parallel refactor slices:
 
-Why this area first:
+- `draft-revision` handler specs — feature-integration kit pattern
+- auth/permission matrix — transport-layer pattern, introducing
+  `src/testing/kit/auth-permission/`
+
+Why these two first:
 
 - many tests rebuild the same Nest module
 - the current setup is primitive-heavy
-- the feature is central enough to establish naming and boundaries for later suites
+- auth rules duplicated between REST and GraphQL specs risk silent drift
+- both areas are central enough to establish naming and boundaries for later suites
 
 The intended steady state is:
 
 - new DB-backed feature tests start from shared kits and scenarios by default
+- new auth tests go through the auth-permission matrix from the start
 - old tests are migrated opportunistically when touched
 - direct low-level setup stays only where it makes the subject clearer
 

--- a/docs/testing-architecture.md
+++ b/docs/testing-architecture.md
@@ -218,10 +218,19 @@ Four layers, each replaceable in isolation:
 - **Operation** — what is being called, per transport. An operation defines a
   `rest` and/or `gql` call signature taking a typed params object. An operation
   may declare only one transport when the endpoint is transport-exclusive.
-- **Actor** — who is calling. `actors.anonymous()`, `actors.user({ orgRole,
-  inOrg })`, `actors.apiKey({ scopes, inOrg, branches, ... })`. Actors return a
-  transport-agnostic token/header bundle. They wrap existing `prepareData`
-  primitives rather than reseeding from scratch.
+- **Actor** — who is calling. Current kit exports:
+  - `actors.anonymous()` — no token.
+  - `actors.fromToken(token, label?)` — wrap an arbitrary token.
+  - `actors.owner(fixture)` / `actors.crossOwner(fixture)` — resolve the
+    owner / anotherOwner tokens out of a `prepareData`-backed fixture.
+  - `actors.resolveRole(fixture, role)` — dispatch a `'owner' | 'crossOwner'
+    | 'anonymous'` matrix row to the right helper.
+  - `actors.admin(app)` — seed a systemAdmin on demand for admin endpoints.
+
+  Actors return a transport-agnostic `{ token, label? }` bundle. Richer
+  variants (`actors.user({ orgRole, inOrg, projectRole? })`,
+  `actors.apiKey({ scopes, readOnly, ... })`) land when the first spec
+  actually needs them.
 - **Outcome** — what correct means, normalized per transport:
   `unauthorized`, `forbidden`, `not_found`, `allowed`. REST status codes and
   GraphQL `errors[0].extensions.code` are mapped inside the kit. Tests never
@@ -254,9 +263,10 @@ Transport coverage is not uniform. The kit must express that honestly:
   callbacks on a row. Only run when `expected === 'allowed'`. Never attach
   content assertions to forbidden/not_found rows; content leakage lives in a
   separate spec.
-- **Per-row params override** — `authCase` accepts a partial `params:` that
-  merges over the matrix defaults. Useful for scope-violation cases (API key
-  scoped to a different branch or project).
+- **Per-row extras** — extend `AuthMatrixCaseBase` with extra columns via
+  intersection (e.g. `AuthMatrixCaseBase & { project: 'private' | 'public' }`)
+  and branch inside the `build(c)` callback. Keeps asymmetric inputs explicit
+  at the row level, not hidden in setup.
 
 ### When this kit is not a fit
 
@@ -271,48 +281,75 @@ not a replacement for unit-testing the decision itself.
 ### Example shape
 
 ```ts
-// src/api/__tests__/project.auth.e2e.spec.ts
-const updateProject = operation({
+// src/api/__tests__/project/update-project.auth.e2e.spec.ts
+import { gql } from 'src/testing/utils/gql';
+import {
+  booleanMutationAssert,
+  operation,
+  runAuthMatrix,
+  PROJECT_MUTATION_MATRIX,
+} from 'src/testing/kit/auth-permission';
+import { usingFreshProject } from 'src/testing/scenarios/using-fresh-project';
+
+const updateProject = operation<{
+  organizationId: string;
+  projectName: string;
+  isPublic: boolean;
+}>({
   id: 'project.update',
   rest: {
-    method: 'patch',
-    url:    ({ org, project }) => `/-/organization/${org}/projects/${project}`,
-    body:   ({ newName }) => ({ name: newName }),
+    method: 'put',
+    url: ({ organizationId, projectName }) =>
+      `/api/organization/${organizationId}/projects/${projectName}`,
+    body: ({ isPublic }) => ({ isPublic }),
   },
   gql: {
-    query:     UPDATE_PROJECT_GQL,
-    variables: ({ org, project, newName }) => ({
-      data: { organizationId: org, projectName: project, name: newName },
-    }),
+    query: gql`
+      mutation updateProject($data: UpdateProjectInput!) {
+        updateProject(data: $data)
+      }
+    `,
+    variables: (params) => ({ data: params }),
   },
 });
 
-describe('updateProject auth', () => {
-  const ctx = buildAuthTestApp();
-  const org = 'acme';
-  const project = 'website';
-  const params = { org, project, newName: 'Renamed' };
+describe('update project auth', () => {
+  const fresh = usingFreshProject();
 
-  beforeEach(() => ctx.givenProject({ org, project }));
-
-  const cases = [
-    authCase('anonymous → unauthorized',       { actor: actors.anonymous(),                                   expected: 'unauthorized' }),
-    authCase('outsider → forbidden',           { actor: actors.user({ orgRole: 'owner',  inOrg: 'other' }),   expected: 'forbidden' }),
-    authCase('viewer in org → forbidden',      { actor: actors.user({ orgRole: 'viewer', inOrg: org }),       expected: 'forbidden' }),
-    authCase('editor in org → allowed',        { actor: actors.user({ orgRole: 'editor', inOrg: org }),       expected: 'allowed' }),
-    authCase('read-only api key → forbidden',  { actor: actors.apiKey({ inOrg: org, scopes: ['project:read'] }),  expected: 'forbidden' }),
-    authCase('write api key → allowed',        { actor: actors.apiKey({ inOrg: org, scopes: ['project:write'] }), expected: 'allowed' }),
-  ];
-
-  describe.each(updateProject.transports)('via %s', (transport) => {
-    it.each(cases.filter((c) => !c.transports || c.transports.includes(transport)))(
-      '$name',
-      async ({ actor, expected, assert }) =>
-        expectAccess({ ctx, transport, actor, op: updateProject, params, expected, assert }),
-    );
+  runAuthMatrix({
+    op: updateProject,
+    cases: PROJECT_MUTATION_MATRIX,
+    build: () => ({
+      fixture: fresh.fixture,
+      params: {
+        organizationId: fresh.fixture.project.organizationId,
+        projectName: fresh.fixture.project.projectName,
+        isPublic: true,
+      },
+      assert: booleanMutationAssert('updateProject'),
+    }),
   });
 });
 ```
+
+The `runAuthMatrix` helper wraps
+`describe.each(op.transports).it.each(cases)` and dispatches through
+`actors.resolveRole(fixture, c.role)` internally; specs declare intent
+(operation + matrix + per-case params/assert), not the plumbing.
+
+Matrix presets shipped with the kit:
+
+- `PROJECT_MUTATION_MATRIX` / `ORG_MUTATION_MATRIX` — owner allowed,
+  cross-owner forbidden, anon unauthorized.
+- `PROJECT_VISIBILITY_MATRIX` — 6 cases: private × {owner, crossOwner,
+  anon} + public × {owner, crossOwner, anon}. For readonly endpoints
+  whose public-project path grants anon read.
+- `PROJECT_PII_READ_MATRIX` — same shape as the mutation matrix; used
+  for sub-resources (user lists, keys) where private/public visibility
+  does not relax membership.
+
+When none of these fit, declare an explicit `AuthMatrixCaseBase[]`
+inline and point `runAuthMatrix`'s `cases` at it.
 
 ### Migration from current supertest/GraphQL specs
 

--- a/src/api/__tests__/admin/admin-cache-stats.auth.e2e.spec.ts
+++ b/src/api/__tests__/admin/admin-cache-stats.auth.e2e.spec.ts
@@ -1,0 +1,70 @@
+import { INestApplication } from '@nestjs/common';
+import { gql } from 'src/testing/utils/gql';
+import { getTestApp } from 'src/testing/e2e';
+import {
+  actors,
+  expectAccess,
+  operation,
+  type ActorDescriptor,
+} from 'src/testing/kit/auth-permission';
+import { usingFreshProject } from 'src/testing/scenarios/using-fresh-project';
+
+const adminCacheStats = operation<Record<string, never>>({
+  id: 'admin.cacheStats',
+  gql: {
+    query: gql`
+      query adminCacheStats {
+        adminCacheStats {
+          totalHits
+        }
+      }
+    `,
+    variables: () => ({}),
+  },
+});
+
+describe('admin cache stats auth', () => {
+  const fresh = usingFreshProject();
+  let app: INestApplication;
+  let adminActor: ActorDescriptor;
+
+  beforeEach(async () => {
+    app = await getTestApp();
+    adminActor = await actors.admin(app);
+  });
+
+  describe('via gql', () => {
+    it('admin allowed', async () => {
+      await expectAccess({
+        app,
+        transport: 'gql',
+        actor: adminActor,
+        op: adminCacheStats,
+        params: {},
+        expected: 'allowed',
+      });
+    });
+
+    it('regular user forbidden', async () => {
+      await expectAccess({
+        app,
+        transport: 'gql',
+        actor: actors.owner(fresh.fixture),
+        op: adminCacheStats,
+        params: {},
+        expected: 'forbidden',
+      });
+    });
+
+    it('anonymous unauthorized', async () => {
+      await expectAccess({
+        app,
+        transport: 'gql',
+        actor: actors.anonymous(),
+        op: adminCacheStats,
+        params: {},
+        expected: 'unauthorized',
+      });
+    });
+  });
+});

--- a/src/api/__tests__/admin/admin-reset-cache.auth.e2e.spec.ts
+++ b/src/api/__tests__/admin/admin-reset-cache.auth.e2e.spec.ts
@@ -1,0 +1,68 @@
+import { INestApplication } from '@nestjs/common';
+import { gql } from 'src/testing/utils/gql';
+import { getTestApp } from 'src/testing/e2e';
+import {
+  actors,
+  expectAccess,
+  operation,
+  type ActorDescriptor,
+} from 'src/testing/kit/auth-permission';
+import { usingFreshProject } from 'src/testing/scenarios/using-fresh-project';
+
+const adminResetAllCache = operation<Record<string, never>>({
+  id: 'admin.resetAllCache',
+  gql: {
+    query: gql`
+      mutation adminResetAllCache {
+        adminResetAllCache
+      }
+    `,
+    variables: () => ({}),
+  },
+});
+
+describe('admin reset all cache auth', () => {
+  const fresh = usingFreshProject();
+  let app: INestApplication;
+  let adminActor: ActorDescriptor;
+
+  beforeEach(async () => {
+    app = await getTestApp();
+    adminActor = await actors.admin(app);
+  });
+
+  describe('via gql', () => {
+    it('admin allowed', async () => {
+      await expectAccess({
+        app,
+        transport: 'gql',
+        actor: adminActor,
+        op: adminResetAllCache,
+        params: {},
+        expected: 'allowed',
+      });
+    });
+
+    it('regular user forbidden', async () => {
+      await expectAccess({
+        app,
+        transport: 'gql',
+        actor: actors.owner(fresh.fixture),
+        op: adminResetAllCache,
+        params: {},
+        expected: 'forbidden',
+      });
+    });
+
+    it('anonymous unauthorized', async () => {
+      await expectAccess({
+        app,
+        transport: 'gql',
+        actor: actors.anonymous(),
+        op: adminResetAllCache,
+        params: {},
+        expected: 'unauthorized',
+      });
+    });
+  });
+});

--- a/src/api/__tests__/admin/admin-user.auth.e2e.spec.ts
+++ b/src/api/__tests__/admin/admin-user.auth.e2e.spec.ts
@@ -1,0 +1,70 @@
+import { INestApplication } from '@nestjs/common';
+import { gql } from 'src/testing/utils/gql';
+import { getTestApp } from 'src/testing/e2e';
+import {
+  actors,
+  expectAccess,
+  operation,
+  type ActorDescriptor,
+} from 'src/testing/kit/auth-permission';
+import { usingFreshProject } from 'src/testing/scenarios/using-fresh-project';
+
+const adminUser = operation<{ userId: string }>({
+  id: 'user.adminUser',
+  gql: {
+    query: gql`
+      query adminUser($data: AdminUserInput!) {
+        adminUser(data: $data) {
+          id
+        }
+      }
+    `,
+    variables: ({ userId }) => ({ data: { userId } }),
+  },
+});
+
+describe('admin user query auth', () => {
+  const fresh = usingFreshProject();
+  let app: INestApplication;
+  let adminActor: ActorDescriptor;
+
+  beforeEach(async () => {
+    app = await getTestApp();
+    adminActor = await actors.admin(app);
+  });
+
+  describe('via gql', () => {
+    it('admin allowed', async () => {
+      await expectAccess({
+        app,
+        transport: 'gql',
+        actor: adminActor,
+        op: adminUser,
+        params: { userId: fresh.fixture.owner.user.id },
+        expected: 'allowed',
+      });
+    });
+
+    it('regular user forbidden', async () => {
+      await expectAccess({
+        app,
+        transport: 'gql',
+        actor: actors.owner(fresh.fixture),
+        op: adminUser,
+        params: { userId: fresh.fixture.owner.user.id },
+        expected: 'forbidden',
+      });
+    });
+
+    it('anonymous unauthorized', async () => {
+      await expectAccess({
+        app,
+        transport: 'gql',
+        actor: actors.anonymous(),
+        op: adminUser,
+        params: { userId: fresh.fixture.owner.user.id },
+        expected: 'unauthorized',
+      });
+    });
+  });
+});

--- a/src/api/__tests__/admin/admin-users.auth.e2e.spec.ts
+++ b/src/api/__tests__/admin/admin-users.auth.e2e.spec.ts
@@ -1,0 +1,70 @@
+import { INestApplication } from '@nestjs/common';
+import { gql } from 'src/testing/utils/gql';
+import { getTestApp } from 'src/testing/e2e';
+import {
+  actors,
+  expectAccess,
+  operation,
+  type ActorDescriptor,
+} from 'src/testing/kit/auth-permission';
+import { usingFreshProject } from 'src/testing/scenarios/using-fresh-project';
+
+const adminUsers = operation<Record<string, never>>({
+  id: 'user.adminUsers',
+  gql: {
+    query: gql`
+      query adminUsers($data: SearchUsersInput!) {
+        adminUsers(data: $data) {
+          totalCount
+        }
+      }
+    `,
+    variables: () => ({ data: { first: 10 } }),
+  },
+});
+
+describe('admin users query auth', () => {
+  const fresh = usingFreshProject();
+  let app: INestApplication;
+  let adminActor: ActorDescriptor;
+
+  beforeEach(async () => {
+    app = await getTestApp();
+    adminActor = await actors.admin(app);
+  });
+
+  describe('via gql', () => {
+    it('admin allowed', async () => {
+      await expectAccess({
+        app,
+        transport: 'gql',
+        actor: adminActor,
+        op: adminUsers,
+        params: {},
+        expected: 'allowed',
+      });
+    });
+
+    it('regular user forbidden', async () => {
+      await expectAccess({
+        app,
+        transport: 'gql',
+        actor: actors.owner(fresh.fixture),
+        op: adminUsers,
+        params: {},
+        expected: 'forbidden',
+      });
+    });
+
+    it('anonymous unauthorized', async () => {
+      await expectAccess({
+        app,
+        transport: 'gql',
+        actor: actors.anonymous(),
+        op: adminUsers,
+        params: {},
+        expected: 'unauthorized',
+      });
+    });
+  });
+});

--- a/src/api/__tests__/api-key/api-key-by-id.auth.e2e.spec.ts
+++ b/src/api/__tests__/api-key/api-key-by-id.auth.e2e.spec.ts
@@ -1,5 +1,8 @@
+import { INestApplication } from '@nestjs/common';
 import { nanoid } from 'nanoid';
 import { gql } from 'src/testing/utils/gql';
+import { getTestApp } from 'src/testing/e2e';
+import { ApiKeyApiService } from 'src/features/api-key/api-key-api.service';
 import {
   operation,
   runAuthMatrix,
@@ -21,25 +24,57 @@ const apiKeyById = operation<{ id: string }>({
   },
 });
 
-const cases: AuthMatrixCaseBase[] = [
-  { name: 'owner (non-existent)', role: 'owner', expected: 'not_found' },
-  {
-    name: 'cross-owner (non-existent)',
-    role: 'crossOwner',
-    expected: 'not_found',
-  },
-  { name: 'anonymous', role: 'anonymous', expected: 'unauthorized' },
-];
-
 describe('apiKeyById auth', () => {
   const fresh = usingFreshProject();
+  let app: INestApplication;
+  let ownerKeyId: string;
 
-  runAuthMatrix({
-    op: apiKeyById,
-    cases,
-    build: () => ({
-      fixture: fresh.fixture,
-      params: { id: nanoid() },
-    }),
+  beforeEach(async () => {
+    app = await getTestApp();
+    const apiKey = app.get(ApiKeyApiService);
+    const created = await apiKey.createPersonalApiKey({
+      name: `k-${nanoid()}`,
+      userId: fresh.fixture.owner.user.id,
+    });
+    ownerKeyId = created.id;
+  });
+
+  const realKeyCases: AuthMatrixCaseBase[] = [
+    { name: 'owner (own key)', role: 'owner', expected: 'allowed' },
+    {
+      name: 'cross-owner (foreign)',
+      role: 'crossOwner',
+      expected: 'not_found',
+    },
+    { name: 'anonymous', role: 'anonymous', expected: 'unauthorized' },
+  ];
+
+  describe('real key', () => {
+    runAuthMatrix({
+      op: apiKeyById,
+      cases: realKeyCases,
+      build: () => ({
+        fixture: fresh.fixture,
+        params: { id: ownerKeyId },
+      }),
+    });
+  });
+
+  describe('non-existent key', () => {
+    runAuthMatrix({
+      op: apiKeyById,
+      cases: [
+        { name: 'owner (missing)', role: 'owner', expected: 'not_found' },
+        {
+          name: 'cross-owner (missing)',
+          role: 'crossOwner',
+          expected: 'not_found',
+        },
+      ],
+      build: () => ({
+        fixture: fresh.fixture,
+        params: { id: nanoid() },
+      }),
+    });
   });
 });

--- a/src/api/__tests__/api-key/api-key-by-id.auth.e2e.spec.ts
+++ b/src/api/__tests__/api-key/api-key-by-id.auth.e2e.spec.ts
@@ -1,0 +1,45 @@
+import { nanoid } from 'nanoid';
+import { gql } from 'src/testing/utils/gql';
+import {
+  operation,
+  runAuthMatrix,
+  type AuthMatrixCaseBase,
+} from 'src/testing/kit/auth-permission';
+import { usingFreshProject } from 'src/testing/scenarios/using-fresh-project';
+
+const apiKeyById = operation<{ id: string }>({
+  id: 'apiKey.byId',
+  gql: {
+    query: gql`
+      query apiKeyById($id: ID!) {
+        apiKeyById(id: $id) {
+          id
+        }
+      }
+    `,
+    variables: ({ id }) => ({ id }),
+  },
+});
+
+const cases: AuthMatrixCaseBase[] = [
+  { name: 'owner (non-existent)', role: 'owner', expected: 'not_found' },
+  {
+    name: 'cross-owner (non-existent)',
+    role: 'crossOwner',
+    expected: 'not_found',
+  },
+  { name: 'anonymous', role: 'anonymous', expected: 'unauthorized' },
+];
+
+describe('apiKeyById auth', () => {
+  const fresh = usingFreshProject();
+
+  runAuthMatrix({
+    op: apiKeyById,
+    cases,
+    build: () => ({
+      fixture: fresh.fixture,
+      params: { id: nanoid() },
+    }),
+  });
+});

--- a/src/api/__tests__/api-key/create-personal-api-key.auth.e2e.spec.ts
+++ b/src/api/__tests__/api-key/create-personal-api-key.auth.e2e.spec.ts
@@ -1,0 +1,47 @@
+import { nanoid } from 'nanoid';
+import { gql } from 'src/testing/utils/gql';
+import {
+  operation,
+  runAuthMatrix,
+  type AuthMatrixCaseBase,
+} from 'src/testing/kit/auth-permission';
+import { usingFreshProject } from 'src/testing/scenarios/using-fresh-project';
+
+const createPersonalApiKey = operation<{ name: string; projectIds: string[] }>({
+  id: 'apiKey.createPersonal',
+  gql: {
+    query: gql`
+      mutation createPersonalApiKey($data: CreatePersonalApiKeyInput!) {
+        createPersonalApiKey(data: $data) {
+          apiKey {
+            id
+          }
+          secret
+        }
+      }
+    `,
+    variables: (p) => ({ data: p }),
+  },
+});
+
+const cases: AuthMatrixCaseBase[] = [
+  { name: 'owner', role: 'owner', expected: 'allowed' },
+  { name: 'cross-owner', role: 'crossOwner', expected: 'allowed' },
+  { name: 'anonymous', role: 'anonymous', expected: 'unauthorized' },
+];
+
+describe('createPersonalApiKey auth', () => {
+  const fresh = usingFreshProject();
+
+  runAuthMatrix({
+    op: createPersonalApiKey,
+    cases,
+    build: () => ({
+      fixture: fresh.fixture,
+      params: {
+        name: `key-${nanoid()}`,
+        projectIds: [fresh.fixture.project.projectId],
+      },
+    }),
+  });
+});

--- a/src/api/__tests__/api-key/create-service-api-key.auth.e2e.spec.ts
+++ b/src/api/__tests__/api-key/create-service-api-key.auth.e2e.spec.ts
@@ -1,0 +1,56 @@
+import { nanoid } from 'nanoid';
+import { gql } from 'src/testing/utils/gql';
+import {
+  operation,
+  runAuthMatrix,
+  type AuthMatrixCaseBase,
+} from 'src/testing/kit/auth-permission';
+import { usingFreshProject } from 'src/testing/scenarios/using-fresh-project';
+
+interface CreateServiceApiKeyParams {
+  name: string;
+  organizationId: string;
+  projectIds: string[];
+  permissions: { rules: Array<{ action: string[]; subject: string[] }> };
+}
+
+const createServiceApiKey = operation<CreateServiceApiKeyParams>({
+  id: 'apiKey.createService',
+  gql: {
+    query: gql`
+      mutation createServiceApiKey($data: CreateServiceApiKeyInput!) {
+        createServiceApiKey(data: $data) {
+          apiKey {
+            id
+          }
+          secret
+        }
+      }
+    `,
+    variables: (p) => ({ data: p }),
+  },
+});
+
+const cases: AuthMatrixCaseBase[] = [
+  { name: 'owner', role: 'owner', expected: 'allowed' },
+  { name: 'cross-owner', role: 'crossOwner', expected: 'forbidden' },
+  { name: 'anonymous', role: 'anonymous', expected: 'unauthorized' },
+];
+
+describe('createServiceApiKey auth', () => {
+  const fresh = usingFreshProject();
+
+  runAuthMatrix({
+    op: createServiceApiKey,
+    cases,
+    build: () => ({
+      fixture: fresh.fixture,
+      params: {
+        name: `svc-${nanoid()}`,
+        organizationId: fresh.fixture.project.organizationId,
+        projectIds: [fresh.fixture.project.projectId],
+        permissions: { rules: [{ action: ['read'], subject: ['all'] }] },
+      },
+    }),
+  });
+});

--- a/src/api/__tests__/api-key/my-api-keys.auth.e2e.spec.ts
+++ b/src/api/__tests__/api-key/my-api-keys.auth.e2e.spec.ts
@@ -1,0 +1,37 @@
+import { gql } from 'src/testing/utils/gql';
+import {
+  operation,
+  runAuthMatrix,
+  type AuthMatrixCaseBase,
+} from 'src/testing/kit/auth-permission';
+import { usingFreshProject } from 'src/testing/scenarios/using-fresh-project';
+
+const myApiKeys = operation<Record<string, never>>({
+  id: 'apiKey.myKeys',
+  gql: {
+    query: gql`
+      query myApiKeys {
+        myApiKeys {
+          id
+        }
+      }
+    `,
+    variables: () => ({}),
+  },
+});
+
+const cases: AuthMatrixCaseBase[] = [
+  { name: 'owner', role: 'owner', expected: 'allowed' },
+  { name: 'cross-owner', role: 'crossOwner', expected: 'allowed' },
+  { name: 'anonymous', role: 'anonymous', expected: 'unauthorized' },
+];
+
+describe('myApiKeys auth', () => {
+  const fresh = usingFreshProject();
+
+  runAuthMatrix({
+    op: myApiKeys,
+    cases,
+    build: () => ({ fixture: fresh.fixture, params: {} }),
+  });
+});

--- a/src/api/__tests__/api-key/revoke-api-key.auth.e2e.spec.ts
+++ b/src/api/__tests__/api-key/revoke-api-key.auth.e2e.spec.ts
@@ -1,0 +1,49 @@
+import { nanoid } from 'nanoid';
+import { gql } from 'src/testing/utils/gql';
+import {
+  operation,
+  runAuthMatrix,
+  type AuthMatrixCaseBase,
+} from 'src/testing/kit/auth-permission';
+import { usingFreshProject } from 'src/testing/scenarios/using-fresh-project';
+
+const revokeApiKey = operation<{ id: string }>({
+  id: 'apiKey.revoke',
+  gql: {
+    query: gql`
+      mutation revokeApiKey($id: ID!) {
+        revokeApiKey(id: $id) {
+          id
+        }
+      }
+    `,
+    variables: ({ id }) => ({ id }),
+  },
+});
+
+// Revoking an API key you don't own → not_found (resource scoped to userId).
+// Anon → unauthorized.
+// No "owner can revoke their own" here — that's covered by the create
+// spec + content tests in the dedicated api-key e2e suite.
+const cases: AuthMatrixCaseBase[] = [
+  { name: 'owner (non-existent key)', role: 'owner', expected: 'not_found' },
+  {
+    name: 'cross-owner (non-existent key)',
+    role: 'crossOwner',
+    expected: 'not_found',
+  },
+  { name: 'anonymous', role: 'anonymous', expected: 'unauthorized' },
+];
+
+describe('revokeApiKey auth', () => {
+  const fresh = usingFreshProject();
+
+  runAuthMatrix({
+    op: revokeApiKey,
+    cases,
+    build: () => ({
+      fixture: fresh.fixture,
+      params: { id: nanoid() },
+    }),
+  });
+});

--- a/src/api/__tests__/api-key/revoke-api-key.auth.e2e.spec.ts
+++ b/src/api/__tests__/api-key/revoke-api-key.auth.e2e.spec.ts
@@ -1,5 +1,8 @@
+import { INestApplication } from '@nestjs/common';
 import { nanoid } from 'nanoid';
 import { gql } from 'src/testing/utils/gql';
+import { getTestApp } from 'src/testing/e2e';
+import { ApiKeyApiService } from 'src/features/api-key/api-key-api.service';
 import {
   operation,
   runAuthMatrix,
@@ -21,29 +24,61 @@ const revokeApiKey = operation<{ id: string }>({
   },
 });
 
-// Revoking an API key you don't own → not_found (resource scoped to userId).
-// Anon → unauthorized.
-// No "owner can revoke their own" here — that's covered by the create
-// spec + content tests in the dedicated api-key e2e suite.
-const cases: AuthMatrixCaseBase[] = [
-  { name: 'owner (non-existent key)', role: 'owner', expected: 'not_found' },
-  {
-    name: 'cross-owner (non-existent key)',
-    role: 'crossOwner',
-    expected: 'not_found',
-  },
-  { name: 'anonymous', role: 'anonymous', expected: 'unauthorized' },
-];
-
 describe('revokeApiKey auth', () => {
   const fresh = usingFreshProject();
+  let app: INestApplication;
+  let ownerKeyId: string;
 
-  runAuthMatrix({
-    op: revokeApiKey,
-    cases,
-    build: () => ({
-      fixture: fresh.fixture,
-      params: { id: nanoid() },
-    }),
+  beforeEach(async () => {
+    app = await getTestApp();
+    const apiKey = app.get(ApiKeyApiService);
+    const created = await apiKey.createPersonalApiKey({
+      name: `k-${nanoid()}`,
+      userId: fresh.fixture.owner.user.id,
+    });
+    ownerKeyId = created.id;
+  });
+
+  // Owner can revoke their own key. Cross-owner hitting a foreign key's id
+  // gets not_found (IDOR check: the resolver scopes by userId before the
+  // resource lookup). Anon is gated at auth.
+  const realKeyCases: AuthMatrixCaseBase[] = [
+    { name: 'owner (own key)', role: 'owner', expected: 'allowed' },
+    {
+      name: 'cross-owner (foreign)',
+      role: 'crossOwner',
+      expected: 'not_found',
+    },
+    { name: 'anonymous', role: 'anonymous', expected: 'unauthorized' },
+  ];
+
+  describe('real key', () => {
+    runAuthMatrix({
+      op: revokeApiKey,
+      cases: realKeyCases,
+      build: () => ({
+        fixture: fresh.fixture,
+        params: { id: ownerKeyId },
+      }),
+    });
+  });
+
+  // Sanity: owner hitting a non-existent id also gets not_found.
+  describe('non-existent key', () => {
+    runAuthMatrix({
+      op: revokeApiKey,
+      cases: [
+        { name: 'owner (missing)', role: 'owner', expected: 'not_found' },
+        {
+          name: 'cross-owner (missing)',
+          role: 'crossOwner',
+          expected: 'not_found',
+        },
+      ],
+      build: () => ({
+        fixture: fresh.fixture,
+        params: { id: nanoid() },
+      }),
+    });
   });
 });

--- a/src/api/__tests__/api-key/service-api-keys.auth.e2e.spec.ts
+++ b/src/api/__tests__/api-key/service-api-keys.auth.e2e.spec.ts
@@ -1,0 +1,34 @@
+import { gql } from 'src/testing/utils/gql';
+import {
+  operation,
+  runAuthMatrix,
+  PROJECT_MUTATION_MATRIX,
+} from 'src/testing/kit/auth-permission';
+import { usingFreshProject } from 'src/testing/scenarios/using-fresh-project';
+
+const serviceApiKeys = operation<{ organizationId: string }>({
+  id: 'apiKey.serviceKeys',
+  gql: {
+    query: gql`
+      query serviceApiKeys($organizationId: String!) {
+        serviceApiKeys(organizationId: $organizationId) {
+          id
+        }
+      }
+    `,
+    variables: ({ organizationId }) => ({ organizationId }),
+  },
+});
+
+describe('serviceApiKeys auth', () => {
+  const fresh = usingFreshProject();
+
+  runAuthMatrix({
+    op: serviceApiKeys,
+    cases: PROJECT_MUTATION_MATRIX,
+    build: () => ({
+      fixture: fresh.fixture,
+      params: { organizationId: fresh.fixture.project.organizationId },
+    }),
+  });
+});

--- a/src/api/__tests__/api-key/service-api-keys.auth.e2e.spec.ts
+++ b/src/api/__tests__/api-key/service-api-keys.auth.e2e.spec.ts
@@ -2,7 +2,7 @@ import { gql } from 'src/testing/utils/gql';
 import {
   operation,
   runAuthMatrix,
-  PROJECT_MUTATION_MATRIX,
+  type AuthMatrixCaseBase,
 } from 'src/testing/kit/auth-permission';
 import { usingFreshProject } from 'src/testing/scenarios/using-fresh-project';
 
@@ -20,12 +20,23 @@ const serviceApiKeys = operation<{ organizationId: string }>({
   },
 });
 
+// serviceApiKeys scopes by organization membership role:
+// organizationOwner can list. Outsiders (cross-owner) are forbidden.
+// Anon is gated at auth. Finer-grained intra-org roles (developer allowed,
+// reader forbidden) require a projectMember / orgMember actor factory;
+// tracked as follow-up.
+const cases: AuthMatrixCaseBase[] = [
+  { name: 'organization-owner', role: 'owner', expected: 'allowed' },
+  { name: 'cross-org outsider', role: 'crossOwner', expected: 'forbidden' },
+  { name: 'anonymous', role: 'anonymous', expected: 'unauthorized' },
+];
+
 describe('serviceApiKeys auth', () => {
   const fresh = usingFreshProject();
 
   runAuthMatrix({
     op: serviceApiKeys,
-    cases: PROJECT_MUTATION_MATRIX,
+    cases,
     build: () => ({
       fixture: fresh.fixture,
       params: { organizationId: fresh.fixture.project.organizationId },

--- a/src/api/__tests__/branch/create-revision.auth.e2e.spec.ts
+++ b/src/api/__tests__/branch/create-revision.auth.e2e.spec.ts
@@ -1,0 +1,38 @@
+import {
+  operation,
+  runAuthMatrix,
+  PROJECT_MUTATION_MATRIX,
+} from 'src/testing/kit/auth-permission';
+import { usingFreshProject } from 'src/testing/scenarios/using-fresh-project';
+
+// REST-only here; GQL exposes branch.createRevision via the mutation
+// bound to CreateBranchInput (tested in create-branch spec).
+const createRevision = operation<{
+  organizationId: string;
+  projectName: string;
+  branchName: string;
+}>({
+  id: 'branch.createRevision',
+  rest: {
+    method: 'post',
+    url: ({ organizationId, projectName, branchName }) =>
+      `/api/organization/${organizationId}/projects/${projectName}/branches/${branchName}/create-revision`,
+  },
+});
+
+describe('create revision (commit) auth', () => {
+  const fresh = usingFreshProject();
+
+  runAuthMatrix({
+    op: createRevision,
+    cases: PROJECT_MUTATION_MATRIX,
+    build: () => ({
+      fixture: fresh.fixture,
+      params: {
+        organizationId: fresh.fixture.project.organizationId,
+        projectName: fresh.fixture.project.projectName,
+        branchName: fresh.fixture.project.branchName,
+      },
+    }),
+  });
+});

--- a/src/api/__tests__/branch/delete-branch.auth.e2e.spec.ts
+++ b/src/api/__tests__/branch/delete-branch.auth.e2e.spec.ts
@@ -1,0 +1,77 @@
+import { nanoid } from 'nanoid';
+import { gql } from 'src/testing/utils/gql';
+import { getTestApp } from 'src/testing/e2e';
+import { PrismaService } from 'src/infrastructure/database/prisma.service';
+import {
+  booleanMutationAssert,
+  operation,
+  runAuthMatrix,
+  type AuthMatrixCaseBase,
+} from 'src/testing/kit/auth-permission';
+import { usingFreshProject } from 'src/testing/scenarios/using-fresh-project';
+
+interface DeleteBranchParams {
+  organizationId: string;
+  projectName: string;
+  branchName: string;
+}
+
+const deleteBranch = operation<DeleteBranchParams>({
+  id: 'branch.delete',
+  rest: {
+    method: 'delete',
+    url: ({ organizationId, projectName, branchName }) =>
+      `/api/organization/${organizationId}/projects/${projectName}/branches/${branchName}`,
+  },
+  gql: {
+    query: gql`
+      mutation deleteBranch($data: DeleteBranchInput!) {
+        deleteBranch(data: $data)
+      }
+    `,
+    variables: (params) => ({ data: params }),
+  },
+});
+
+const cases: AuthMatrixCaseBase[] = [
+  { name: 'owner', role: 'owner', expected: 'allowed' },
+  { name: 'cross-owner', role: 'crossOwner', expected: 'forbidden' },
+  { name: 'anonymous', role: 'anonymous', expected: 'unauthorized' },
+];
+
+describe('delete branch auth', () => {
+  const fresh = usingFreshProject();
+  let secondaryBranchName: string;
+
+  beforeEach(async () => {
+    const app = await getTestApp();
+    const prisma = app.get(PrismaService);
+    // Root branch cannot be deleted; create a throwaway branch under the
+    // same project. It has no revisions here — delete is exercising auth,
+    // not the full delete semantics (the domain concern lives in the
+    // feature spec).
+    secondaryBranchName = `branch-${nanoid()}`;
+    await prisma.branch.create({
+      data: {
+        id: nanoid(),
+        name: secondaryBranchName,
+        projectId: fresh.fixture.project.projectId,
+        isRoot: false,
+      },
+    });
+  });
+
+  runAuthMatrix({
+    op: deleteBranch,
+    cases,
+    build: () => ({
+      fixture: fresh.fixture,
+      params: {
+        organizationId: fresh.fixture.project.organizationId,
+        projectName: fresh.fixture.project.projectName,
+        branchName: secondaryBranchName,
+      },
+      assert: booleanMutationAssert('deleteBranch'),
+    }),
+  });
+});

--- a/src/api/__tests__/branch/get-branch.auth.e2e.spec.ts
+++ b/src/api/__tests__/branch/get-branch.auth.e2e.spec.ts
@@ -1,0 +1,62 @@
+import { INestApplication } from '@nestjs/common';
+import { gql } from 'src/testing/utils/gql';
+import { getTestApp } from 'src/testing/e2e';
+import {
+  operation,
+  runAuthMatrix,
+  PROJECT_VISIBILITY_MATRIX,
+} from 'src/testing/kit/auth-permission';
+import {
+  givenProjectPair,
+  type ProjectPairScenario,
+} from 'src/testing/scenarios/given-project-pair';
+
+const getBranch = operation<{
+  organizationId: string;
+  projectName: string;
+  branchName: string;
+}>({
+  id: 'branch.get',
+  rest: {
+    method: 'get',
+    url: ({ organizationId, projectName, branchName }) =>
+      `/api/organization/${organizationId}/projects/${projectName}/branches/${branchName}`,
+  },
+  gql: {
+    query: gql`
+      query branch($data: GetBranchInput!) {
+        branch(data: $data) {
+          id
+          name
+        }
+      }
+    `,
+    variables: (params) => ({ data: params }),
+  },
+});
+
+describe('get branch auth', () => {
+  let app: INestApplication;
+  let projects: ProjectPairScenario;
+
+  beforeAll(async () => {
+    app = await getTestApp();
+    projects = await givenProjectPair(app);
+  });
+
+  runAuthMatrix({
+    op: getBranch,
+    cases: PROJECT_VISIBILITY_MATRIX,
+    build: (c) => {
+      const fixture = projects[c.project];
+      return {
+        fixture,
+        params: {
+          organizationId: fixture.project.organizationId,
+          projectName: fixture.project.projectName,
+          branchName: fixture.project.branchName,
+        },
+      };
+    },
+  });
+});

--- a/src/api/__tests__/branch/list-branches.auth.e2e.spec.ts
+++ b/src/api/__tests__/branch/list-branches.auth.e2e.spec.ts
@@ -1,0 +1,62 @@
+import { INestApplication } from '@nestjs/common';
+import { gql } from 'src/testing/utils/gql';
+import { getTestApp } from 'src/testing/e2e';
+import {
+  operation,
+  runAuthMatrix,
+  PROJECT_VISIBILITY_MATRIX,
+} from 'src/testing/kit/auth-permission';
+import {
+  givenProjectPair,
+  type ProjectPairScenario,
+} from 'src/testing/scenarios/given-project-pair';
+
+const listBranches = operation<{
+  organizationId: string;
+  projectName: string;
+}>({
+  id: 'project.branches',
+  rest: {
+    method: 'get',
+    url: ({ organizationId, projectName }) =>
+      `/api/organization/${organizationId}/projects/${projectName}/branches`,
+    query: () => ({ first: 10 }),
+  },
+  gql: {
+    query: gql`
+      query branches($data: GetBranchesInput!) {
+        branches(data: $data) {
+          totalCount
+        }
+      }
+    `,
+    variables: ({ organizationId, projectName }) => ({
+      data: { organizationId, projectName, first: 10 },
+    }),
+  },
+});
+
+describe('list branches auth', () => {
+  let app: INestApplication;
+  let projects: ProjectPairScenario;
+
+  beforeAll(async () => {
+    app = await getTestApp();
+    projects = await givenProjectPair(app);
+  });
+
+  runAuthMatrix({
+    op: listBranches,
+    cases: PROJECT_VISIBILITY_MATRIX,
+    build: (c) => {
+      const fixture = projects[c.project];
+      return {
+        fixture,
+        params: {
+          organizationId: fixture.project.organizationId,
+          projectName: fixture.project.projectName,
+        },
+      };
+    },
+  });
+});

--- a/src/api/__tests__/branch/revert-changes.auth.e2e.spec.ts
+++ b/src/api/__tests__/branch/revert-changes.auth.e2e.spec.ts
@@ -1,0 +1,47 @@
+import { gql } from 'src/testing/utils/gql';
+import {
+  operation,
+  runAuthMatrix,
+  PROJECT_MUTATION_MATRIX,
+} from 'src/testing/kit/auth-permission';
+import { usingFreshProject } from 'src/testing/scenarios/using-fresh-project';
+
+const revertChanges = operation<{
+  organizationId: string;
+  projectName: string;
+  branchName: string;
+}>({
+  id: 'branch.revertChanges',
+  rest: {
+    method: 'post',
+    url: ({ organizationId, projectName, branchName }) =>
+      `/api/organization/${organizationId}/projects/${projectName}/branches/${branchName}/revert-changes`,
+  },
+  gql: {
+    query: gql`
+      mutation revertChanges($data: RevertChangesInput!) {
+        revertChanges(data: $data) {
+          id
+        }
+      }
+    `,
+    variables: (params) => ({ data: params }),
+  },
+});
+
+describe('revert changes auth', () => {
+  const fresh = usingFreshProject();
+
+  runAuthMatrix({
+    op: revertChanges,
+    cases: PROJECT_MUTATION_MATRIX,
+    build: () => ({
+      fixture: fresh.fixture,
+      params: {
+        organizationId: fresh.fixture.project.organizationId,
+        projectName: fresh.fixture.project.projectName,
+        branchName: fresh.fixture.project.branchName,
+      },
+    }),
+  });
+});

--- a/src/api/__tests__/configuration.auth.e2e.spec.ts
+++ b/src/api/__tests__/configuration.auth.e2e.spec.ts
@@ -1,0 +1,42 @@
+import { gql } from 'src/testing/utils/gql';
+import {
+  operation,
+  runAuthMatrix,
+  type AuthMatrixCaseBase,
+} from 'src/testing/kit/auth-permission';
+import { usingFreshProject } from 'src/testing/scenarios/using-fresh-project';
+
+// Configuration is fully public — no guards at all. Everyone allowed.
+const getConfiguration = operation<Record<string, never>>({
+  id: 'configuration.get',
+  rest: {
+    method: 'get',
+    url: () => `/api/configuration`,
+  },
+  gql: {
+    query: gql`
+      query configuration {
+        configuration {
+          availableEmailSignUp
+        }
+      }
+    `,
+    variables: () => ({}),
+  },
+});
+
+const cases: AuthMatrixCaseBase[] = [
+  { name: 'owner', role: 'owner', expected: 'allowed' },
+  { name: 'cross-owner', role: 'crossOwner', expected: 'allowed' },
+  { name: 'anonymous', role: 'anonymous', expected: 'allowed' },
+];
+
+describe('configuration auth', () => {
+  const fresh = usingFreshProject();
+
+  runAuthMatrix({
+    op: getConfiguration,
+    cases,
+    build: () => ({ fixture: fresh.fixture, params: {} }),
+  });
+});

--- a/src/api/__tests__/endpoint/delete-endpoint.auth.e2e.spec.ts
+++ b/src/api/__tests__/endpoint/delete-endpoint.auth.e2e.spec.ts
@@ -1,0 +1,36 @@
+import { gql } from 'src/testing/utils/gql';
+import {
+  operation,
+  runAuthMatrix,
+  PROJECT_MUTATION_MATRIX,
+} from 'src/testing/kit/auth-permission';
+import { usingFreshProject } from 'src/testing/scenarios/using-fresh-project';
+
+const deleteEndpoint = operation<{ endpointId: string }>({
+  id: 'endpoint.delete',
+  rest: {
+    method: 'delete',
+    url: ({ endpointId }) => `/api/endpoints/${endpointId}`,
+  },
+  gql: {
+    query: gql`
+      mutation deleteEndpoint($data: DeleteEndpointInput!) {
+        deleteEndpoint(data: $data)
+      }
+    `,
+    variables: ({ endpointId }) => ({ data: { endpointId } }),
+  },
+});
+
+describe('delete endpoint auth', () => {
+  const fresh = usingFreshProject();
+
+  runAuthMatrix({
+    op: deleteEndpoint,
+    cases: PROJECT_MUTATION_MATRIX,
+    build: () => ({
+      fixture: fresh.fixture,
+      params: { endpointId: fresh.fixture.project.headEndpointId },
+    }),
+  });
+});

--- a/src/api/__tests__/endpoint/endpoint-relatives.auth.e2e.spec.ts
+++ b/src/api/__tests__/endpoint/endpoint-relatives.auth.e2e.spec.ts
@@ -1,0 +1,41 @@
+import { INestApplication } from '@nestjs/common';
+import { getTestApp } from 'src/testing/e2e';
+import {
+  operation,
+  runAuthMatrix,
+  PROJECT_VISIBILITY_MATRIX,
+} from 'src/testing/kit/auth-permission';
+import {
+  givenProjectPair,
+  type ProjectPairScenario,
+} from 'src/testing/scenarios/given-project-pair';
+
+const endpointRelatives = operation<{ endpointId: string }>({
+  id: 'endpoint.relatives',
+  rest: {
+    method: 'get',
+    url: ({ endpointId }) => `/api/endpoints/${endpointId}/relatives`,
+  },
+});
+
+describe('endpoint relatives auth', () => {
+  let app: INestApplication;
+  let projects: ProjectPairScenario;
+
+  beforeAll(async () => {
+    app = await getTestApp();
+    projects = await givenProjectPair(app);
+  });
+
+  runAuthMatrix({
+    op: endpointRelatives,
+    cases: PROJECT_VISIBILITY_MATRIX,
+    build: (c) => {
+      const fixture = projects[c.project];
+      return {
+        fixture,
+        params: { endpointId: fixture.project.headEndpointId },
+      };
+    },
+  });
+});

--- a/src/api/__tests__/endpoint/project-endpoints.auth.e2e.spec.ts
+++ b/src/api/__tests__/endpoint/project-endpoints.auth.e2e.spec.ts
@@ -1,0 +1,57 @@
+import { INestApplication } from '@nestjs/common';
+import { gql } from 'src/testing/utils/gql';
+import { getTestApp } from 'src/testing/e2e';
+import {
+  operation,
+  runAuthMatrix,
+  PROJECT_VISIBILITY_MATRIX,
+} from 'src/testing/kit/auth-permission';
+import {
+  givenProjectPair,
+  type ProjectPairScenario,
+} from 'src/testing/scenarios/given-project-pair';
+
+// GraphQL-only endpoint list (REST goes through revision/:r/endpoints).
+const projectEndpoints = operation<{
+  organizationId: string;
+  projectName: string;
+}>({
+  id: 'project.endpoints',
+  gql: {
+    query: gql`
+      query projectEndpoints($data: GetProjectEndpointsInput!) {
+        projectEndpoints(data: $data) {
+          totalCount
+        }
+      }
+    `,
+    variables: ({ organizationId, projectName }) => ({
+      data: { organizationId, projectName, first: 10 },
+    }),
+  },
+});
+
+describe('project endpoints (GQL) auth', () => {
+  let app: INestApplication;
+  let projects: ProjectPairScenario;
+
+  beforeAll(async () => {
+    app = await getTestApp();
+    projects = await givenProjectPair(app);
+  });
+
+  runAuthMatrix({
+    op: projectEndpoints,
+    cases: PROJECT_VISIBILITY_MATRIX,
+    build: (c) => {
+      const fixture = projects[c.project];
+      return {
+        fixture,
+        params: {
+          organizationId: fixture.project.organizationId,
+          projectName: fixture.project.projectName,
+        },
+      };
+    },
+  });
+});

--- a/src/api/__tests__/organization/add-user-to-organization.auth.e2e.spec.ts
+++ b/src/api/__tests__/organization/add-user-to-organization.auth.e2e.spec.ts
@@ -1,0 +1,65 @@
+import { INestApplication } from '@nestjs/common';
+import { gql } from 'src/testing/utils/gql';
+import { UserOrganizationRoles } from 'src/features/auth/consts';
+import { getTestApp } from 'src/testing/e2e';
+import {
+  booleanMutationAssert,
+  operation,
+  runAuthMatrix,
+  type AuthMatrixCaseBase,
+} from 'src/testing/kit/auth-permission';
+import { usingFreshProject } from 'src/testing/scenarios/using-fresh-project';
+import { givenStandaloneUser } from 'src/testing/scenarios/given-standalone-user';
+
+interface AddUserToOrgParams {
+  organizationId: string;
+  userId: string;
+  roleId: UserOrganizationRoles;
+}
+
+const addUserToOrganization = operation<AddUserToOrgParams>({
+  id: 'organization.addUser',
+  rest: {
+    method: 'post',
+    url: ({ organizationId }) => `/api/organization/${organizationId}/users`,
+    body: ({ userId, roleId }) => ({ userId, roleId }),
+  },
+  gql: {
+    query: gql`
+      mutation addUserToOrganization($data: AddUserToOrganizationInput!) {
+        addUserToOrganization(data: $data)
+      }
+    `,
+    variables: (params) => ({ data: params }),
+  },
+});
+
+const cases: AuthMatrixCaseBase[] = [
+  { name: 'owner', role: 'owner', expected: 'allowed' },
+  { name: 'cross-owner', role: 'crossOwner', expected: 'forbidden' },
+  { name: 'anonymous', role: 'anonymous', expected: 'unauthorized' },
+];
+
+describe('add-user-to-organization auth', () => {
+  const fresh = usingFreshProject();
+  let targetUserId: string;
+
+  beforeEach(async () => {
+    const app: INestApplication = await getTestApp();
+    ({ userId: targetUserId } = await givenStandaloneUser(app));
+  });
+
+  runAuthMatrix({
+    op: addUserToOrganization,
+    cases,
+    build: () => ({
+      fixture: fresh.fixture,
+      params: {
+        organizationId: fresh.fixture.project.organizationId,
+        userId: targetUserId,
+        roleId: UserOrganizationRoles.organizationAdmin,
+      },
+      assert: booleanMutationAssert('addUserToOrganization'),
+    }),
+  });
+});

--- a/src/api/__tests__/organization/get-organization.auth.e2e.spec.ts
+++ b/src/api/__tests__/organization/get-organization.auth.e2e.spec.ts
@@ -1,0 +1,53 @@
+import { gql } from 'src/testing/utils/gql';
+import {
+  operation,
+  runAuthMatrix,
+  type AuthMatrixCaseBase,
+} from 'src/testing/kit/auth-permission';
+import { usingFreshProject } from 'src/testing/scenarios/using-fresh-project';
+
+interface GetOrganizationParams {
+  organizationId: string;
+}
+
+// GraphQL-only — REST has no plain GET /organization/:id endpoint.
+const getOrganization = operation<GetOrganizationParams>({
+  id: 'organization.get',
+  gql: {
+    query: gql`
+      query organization($data: GetOrganizationInput!) {
+        organization(data: $data) {
+          id
+        }
+      }
+    `,
+    variables: ({ organizationId }) => ({ data: { organizationId } }),
+  },
+});
+
+// Owner is in the org → allowed. Cross-owner is outside → forbidden.
+// Anon short-circuits at authentication → unauthorized.
+const cases: AuthMatrixCaseBase[] = [
+  { name: 'owner', role: 'owner', expected: 'allowed' },
+  { name: 'cross-owner', role: 'crossOwner', expected: 'forbidden' },
+  { name: 'anonymous', role: 'anonymous', expected: 'unauthorized' },
+];
+
+describe('get organization auth', () => {
+  const fresh = usingFreshProject();
+
+  runAuthMatrix({
+    op: getOrganization,
+    cases,
+    build: () => ({
+      fixture: fresh.fixture,
+      params: { organizationId: fresh.fixture.project.organizationId },
+      assert: {
+        gql: (data) => {
+          const r = data as { organization: { id: string } };
+          expect(r.organization.id).toBe(fresh.fixture.project.organizationId);
+        },
+      },
+    }),
+  });
+});

--- a/src/api/__tests__/organization/list-org-projects.auth.e2e.spec.ts
+++ b/src/api/__tests__/organization/list-org-projects.auth.e2e.spec.ts
@@ -1,0 +1,91 @@
+import { gql } from 'src/testing/utils/gql';
+import {
+  operation,
+  runAuthMatrix,
+  type AuthMatrixCaseBase,
+} from 'src/testing/kit/auth-permission';
+import { usingFreshProject } from 'src/testing/scenarios/using-fresh-project';
+
+interface ListOrgProjectsParams {
+  organizationId: string;
+}
+
+const listOrgProjects = operation<ListOrgProjectsParams>({
+  id: 'organization.listProjects',
+  rest: {
+    method: 'get',
+    url: ({ organizationId }) => `/api/organization/${organizationId}/projects`,
+    query: () => ({ first: 10 }),
+  },
+  gql: {
+    query: gql`
+      query projects($data: GetProjectsInput!) {
+        projects(data: $data) {
+          totalCount
+          edges {
+            node {
+              id
+            }
+          }
+        }
+      }
+    `,
+    variables: ({ organizationId }) => ({
+      data: { organizationId, first: 10 },
+    }),
+  },
+});
+
+// `projects` uses OptionalAuthGuard and filters by caller visibility —
+// it does NOT authorize, it scopes. Every caller gets 200 / no errors;
+// owner sees their own project (totalCount >= 1), others see 0.
+type MatrixCase = AuthMatrixCaseBase & { expectedCount: number };
+
+const cases: MatrixCase[] = [
+  { name: 'owner', role: 'owner', expected: 'allowed', expectedCount: 1 },
+  {
+    name: 'cross-owner',
+    role: 'crossOwner',
+    expected: 'allowed',
+    expectedCount: 0,
+  },
+  {
+    name: 'anonymous',
+    role: 'anonymous',
+    expected: 'allowed',
+    expectedCount: 0,
+  },
+];
+
+describe('list org projects auth', () => {
+  const fresh = usingFreshProject();
+
+  runAuthMatrix({
+    op: listOrgProjects,
+    cases,
+    build: (c) => ({
+      fixture: fresh.fixture,
+      params: { organizationId: fresh.fixture.project.organizationId },
+      assert: {
+        gql: (data) => {
+          const r = data as { projects: { totalCount: number } };
+          if (c.expectedCount === 0) {
+            expect(r.projects.totalCount).toBe(0);
+          } else {
+            expect(r.projects.totalCount).toBeGreaterThanOrEqual(
+              c.expectedCount,
+            );
+          }
+        },
+        rest: (body) => {
+          const r = body as { totalCount: number };
+          if (c.expectedCount === 0) {
+            expect(r.totalCount).toBe(0);
+          } else {
+            expect(r.totalCount).toBeGreaterThanOrEqual(c.expectedCount);
+          }
+        },
+      },
+    }),
+  });
+});

--- a/src/api/__tests__/organization/remove-user-from-organization.auth.e2e.spec.ts
+++ b/src/api/__tests__/organization/remove-user-from-organization.auth.e2e.spec.ts
@@ -1,0 +1,75 @@
+import { INestApplication } from '@nestjs/common';
+import { gql } from 'src/testing/utils/gql';
+import { UserOrganizationRoles } from 'src/features/auth/consts';
+import { getTestApp } from 'src/testing/e2e';
+import { testAddUserToOrganization } from 'src/testing/factories/create-models';
+import { PrismaService } from 'src/infrastructure/database/prisma.service';
+import {
+  booleanMutationAssert,
+  operation,
+  runAuthMatrix,
+  type AuthMatrixCaseBase,
+} from 'src/testing/kit/auth-permission';
+import { usingFreshProject } from 'src/testing/scenarios/using-fresh-project';
+import { givenStandaloneUser } from 'src/testing/scenarios/given-standalone-user';
+
+interface RemoveUserFromOrgParams {
+  organizationId: string;
+  userId: string;
+}
+
+const removeUserFromOrganization = operation<RemoveUserFromOrgParams>({
+  id: 'organization.removeUser',
+  rest: {
+    method: 'delete',
+    url: ({ organizationId }) => `/api/organization/${organizationId}/users`,
+    body: ({ userId }) => ({ userId }),
+  },
+  gql: {
+    query: gql`
+      mutation removeUserFromOrganization(
+        $data: RemoveUserFromOrganizationInput!
+      ) {
+        removeUserFromOrganization(data: $data)
+      }
+    `,
+    variables: (params) => ({ data: params }),
+  },
+});
+
+const cases: AuthMatrixCaseBase[] = [
+  { name: 'owner', role: 'owner', expected: 'allowed' },
+  { name: 'cross-owner', role: 'crossOwner', expected: 'forbidden' },
+  { name: 'anonymous', role: 'anonymous', expected: 'unauthorized' },
+];
+
+describe('remove-user-from-organization auth', () => {
+  const fresh = usingFreshProject();
+  let targetUserId: string;
+
+  beforeEach(async () => {
+    const app: INestApplication = await getTestApp();
+    const prisma = app.get(PrismaService);
+    const user = await givenStandaloneUser(app);
+    targetUserId = user.userId;
+    // Put them in the org first so the removal has something to remove.
+    await testAddUserToOrganization(prisma, {
+      organizationId: fresh.fixture.project.organizationId,
+      userId: targetUserId,
+      roleId: UserOrganizationRoles.organizationAdmin,
+    });
+  });
+
+  runAuthMatrix({
+    op: removeUserFromOrganization,
+    cases,
+    build: () => ({
+      fixture: fresh.fixture,
+      params: {
+        organizationId: fresh.fixture.project.organizationId,
+        userId: targetUserId,
+      },
+      assert: booleanMutationAssert('removeUserFromOrganization'),
+    }),
+  });
+});

--- a/src/api/__tests__/organization/users-organization.auth.e2e.spec.ts
+++ b/src/api/__tests__/organization/users-organization.auth.e2e.spec.ts
@@ -1,0 +1,67 @@
+import { gql } from 'src/testing/utils/gql';
+import {
+  operation,
+  runAuthMatrix,
+  type AuthMatrixCaseBase,
+} from 'src/testing/kit/auth-permission';
+import { usingFreshProject } from 'src/testing/scenarios/using-fresh-project';
+
+interface UsersOrgParams {
+  organizationId: string;
+}
+
+const usersOrganization = operation<UsersOrgParams>({
+  id: 'organization.usersOrganization',
+  rest: {
+    method: 'get',
+    url: ({ organizationId }) => `/api/organization/${organizationId}/users`,
+    query: () => ({ first: 10 }),
+  },
+  gql: {
+    query: gql`
+      query usersOrganization($data: GetUsersOrganizationInput!) {
+        usersOrganization(data: $data) {
+          totalCount
+          edges {
+            node {
+              id
+            }
+          }
+        }
+      }
+    `,
+    variables: ({ organizationId }) => ({
+      data: { organizationId, first: 10 },
+    }),
+  },
+});
+
+// User listing is PII — only org members can read.
+const cases: AuthMatrixCaseBase[] = [
+  { name: 'owner', role: 'owner', expected: 'allowed' },
+  { name: 'cross-owner', role: 'crossOwner', expected: 'forbidden' },
+  { name: 'anonymous', role: 'anonymous', expected: 'unauthorized' },
+];
+
+describe('users-organization auth', () => {
+  const fresh = usingFreshProject();
+
+  runAuthMatrix({
+    op: usersOrganization,
+    cases,
+    build: () => ({
+      fixture: fresh.fixture,
+      params: { organizationId: fresh.fixture.project.organizationId },
+      assert: {
+        gql: (data) => {
+          const r = data as { usersOrganization: { totalCount: number } };
+          expect(r.usersOrganization.totalCount).toBeGreaterThanOrEqual(1);
+        },
+        rest: (body) => {
+          const r = body as { totalCount: number };
+          expect(r.totalCount).toBeGreaterThanOrEqual(1);
+        },
+      },
+    }),
+  });
+});

--- a/src/api/__tests__/project/add-user-to-project.auth.e2e.spec.ts
+++ b/src/api/__tests__/project/add-user-to-project.auth.e2e.spec.ts
@@ -1,0 +1,68 @@
+import { INestApplication } from '@nestjs/common';
+import { gql } from 'src/testing/utils/gql';
+import { UserProjectRoles } from 'src/features/auth/consts';
+import { getTestApp } from 'src/testing/e2e';
+import {
+  booleanMutationAssert,
+  operation,
+  runAuthMatrix,
+  type AuthMatrixCaseBase,
+} from 'src/testing/kit/auth-permission';
+import { usingFreshProject } from 'src/testing/scenarios/using-fresh-project';
+import { givenStandaloneUser } from 'src/testing/scenarios/given-standalone-user';
+
+interface AddUserToProjectParams {
+  organizationId: string;
+  projectName: string;
+  userId: string;
+  roleId: UserProjectRoles;
+}
+
+const addUserToProject = operation<AddUserToProjectParams>({
+  id: 'project.addUser',
+  rest: {
+    method: 'post',
+    url: ({ organizationId, projectName }) =>
+      `/api/organization/${organizationId}/projects/${projectName}/users`,
+    body: ({ userId, roleId }) => ({ userId, roleId }),
+  },
+  gql: {
+    query: gql`
+      mutation addUserToProject($data: AddUserToProjectInput!) {
+        addUserToProject(data: $data)
+      }
+    `,
+    variables: (params) => ({ data: params }),
+  },
+});
+
+const cases: AuthMatrixCaseBase[] = [
+  { name: 'owner', role: 'owner', expected: 'allowed' },
+  { name: 'cross-owner', role: 'crossOwner', expected: 'forbidden' },
+  { name: 'anonymous', role: 'anonymous', expected: 'unauthorized' },
+];
+
+describe('add-user-to-project auth', () => {
+  const fresh = usingFreshProject();
+  let targetUserId: string;
+
+  beforeEach(async () => {
+    const app: INestApplication = await getTestApp();
+    ({ userId: targetUserId } = await givenStandaloneUser(app));
+  });
+
+  runAuthMatrix({
+    op: addUserToProject,
+    cases,
+    build: () => ({
+      fixture: fresh.fixture,
+      params: {
+        organizationId: fresh.fixture.project.organizationId,
+        projectName: fresh.fixture.project.projectName,
+        userId: targetUserId,
+        roleId: UserProjectRoles.developer,
+      },
+      assert: booleanMutationAssert('addUserToProject'),
+    }),
+  });
+});

--- a/src/api/__tests__/project/create-project.auth.e2e.spec.ts
+++ b/src/api/__tests__/project/create-project.auth.e2e.spec.ts
@@ -1,0 +1,72 @@
+import { nanoid } from 'nanoid';
+import { gql } from 'src/testing/utils/gql';
+import {
+  operation,
+  runAuthMatrix,
+  type AuthMatrixCaseBase,
+} from 'src/testing/kit/auth-permission';
+import { usingFreshProject } from 'src/testing/scenarios/using-fresh-project';
+
+interface CreateProjectParams {
+  organizationId: string;
+  projectName: string;
+}
+
+const createProject = operation<CreateProjectParams>({
+  id: 'project.create',
+  rest: {
+    method: 'post',
+    url: ({ organizationId }) => `/api/organization/${organizationId}/projects`,
+    body: ({ projectName }) => ({ projectName }),
+  },
+  gql: {
+    query: gql`
+      mutation createProject($data: CreateProjectInput!) {
+        createProject(data: $data) {
+          id
+          name
+          organizationId
+        }
+      }
+    `,
+    variables: ({ organizationId, projectName }) => ({
+      data: { organizationId, projectName },
+    }),
+  },
+});
+
+const cases: AuthMatrixCaseBase[] = [
+  { name: 'org-owner', role: 'owner', expected: 'allowed' },
+  { name: 'outsider', role: 'crossOwner', expected: 'forbidden' },
+  { name: 'anonymous', role: 'anonymous', expected: 'unauthorized' },
+];
+
+describe('create project auth', () => {
+  const fresh = usingFreshProject();
+
+  runAuthMatrix({
+    op: createProject,
+    cases,
+    build: () => ({
+      fixture: fresh.fixture,
+      params: {
+        organizationId: fresh.fixture.project.organizationId,
+        projectName: `new-${nanoid()}`,
+      },
+      assert: {
+        gql: (data) => {
+          const r = data as {
+            createProject: { id: string; organizationId: string };
+          };
+          expect(r.createProject.organizationId).toBe(
+            fresh.fixture.project.organizationId,
+          );
+        },
+        rest: (body) => {
+          const r = body as { id: string; organizationId: string };
+          expect(r.organizationId).toBe(fresh.fixture.project.organizationId);
+        },
+      },
+    }),
+  });
+});

--- a/src/api/__tests__/project/delete-project.auth.e2e.spec.ts
+++ b/src/api/__tests__/project/delete-project.auth.e2e.spec.ts
@@ -1,0 +1,57 @@
+import { gql } from 'src/testing/utils/gql';
+import {
+  booleanMutationAssert,
+  operation,
+  runAuthMatrix,
+  type AuthMatrixCaseBase,
+} from 'src/testing/kit/auth-permission';
+import { usingFreshProject } from 'src/testing/scenarios/using-fresh-project';
+
+interface DeleteProjectParams {
+  organizationId: string;
+  projectName: string;
+}
+
+const deleteProject = operation<DeleteProjectParams>({
+  id: 'project.delete',
+  rest: {
+    method: 'delete',
+    url: ({ organizationId, projectName }) =>
+      `/api/organization/${organizationId}/projects/${projectName}`,
+  },
+  gql: {
+    query: gql`
+      mutation deleteProject($data: DeleteProjectInput!) {
+        deleteProject(data: $data)
+      }
+    `,
+    variables: ({ organizationId, projectName }) => ({
+      data: { organizationId, projectName },
+    }),
+  },
+});
+
+// Delete requires org-owner / project-update permission; only owner passes.
+// Anon short-circuits at authentication → unauthorized (not forbidden).
+const cases: AuthMatrixCaseBase[] = [
+  { name: 'owner', role: 'owner', expected: 'allowed' },
+  { name: 'cross-owner', role: 'crossOwner', expected: 'forbidden' },
+  { name: 'anonymous', role: 'anonymous', expected: 'unauthorized' },
+];
+
+describe('delete project auth', () => {
+  const fresh = usingFreshProject();
+
+  runAuthMatrix({
+    op: deleteProject,
+    cases,
+    build: () => ({
+      fixture: fresh.fixture,
+      params: {
+        organizationId: fresh.fixture.project.organizationId,
+        projectName: fresh.fixture.project.projectName,
+      },
+      assert: booleanMutationAssert('deleteProject'),
+    }),
+  });
+});

--- a/src/api/__tests__/project/get-project.auth.e2e.spec.ts
+++ b/src/api/__tests__/project/get-project.auth.e2e.spec.ts
@@ -1,0 +1,74 @@
+import { INestApplication } from '@nestjs/common';
+import { gql } from 'src/testing/utils/gql';
+import { getTestApp } from 'src/testing/e2e';
+import {
+  operation,
+  runAuthMatrix,
+  PROJECT_VISIBILITY_MATRIX,
+} from 'src/testing/kit/auth-permission';
+import {
+  givenProjectPair,
+  type ProjectPairScenario,
+} from 'src/testing/scenarios/given-project-pair';
+
+const getProject = operation<{
+  organizationId: string;
+  projectName: string;
+}>({
+  id: 'project.get',
+  rest: {
+    method: 'get',
+    url: ({ organizationId, projectName }) =>
+      `/api/organization/${organizationId}/projects/${projectName}`,
+  },
+  gql: {
+    query: gql`
+      query project($data: GetProjectInput!) {
+        project(data: $data) {
+          id
+          name
+          isPublic
+          organizationId
+        }
+      }
+    `,
+    variables: (params) => ({ data: params }),
+  },
+});
+
+describe('get project auth', () => {
+  let app: INestApplication;
+  let projects: ProjectPairScenario;
+
+  beforeAll(async () => {
+    app = await getTestApp();
+    projects = await givenProjectPair(app);
+  });
+
+  runAuthMatrix({
+    op: getProject,
+    cases: PROJECT_VISIBILITY_MATRIX,
+    build: (c) => {
+      const fixture = projects[c.project];
+      return {
+        fixture,
+        params: {
+          organizationId: fixture.project.organizationId,
+          projectName: fixture.project.projectName,
+        },
+        assert: {
+          gql: (data) => {
+            const r = data as { project: { id: string; isPublic: boolean } };
+            expect(r.project.id).toBe(fixture.project.projectId);
+            expect(r.project.isPublic).toBe(c.project === 'public');
+          },
+          rest: (body) => {
+            const r = body as { id: string; isPublic: boolean };
+            expect(r.id).toBe(fixture.project.projectId);
+            expect(r.isPublic).toBe(c.project === 'public');
+          },
+        },
+      };
+    },
+  });
+});

--- a/src/api/__tests__/project/remove-user-from-project.auth.e2e.spec.ts
+++ b/src/api/__tests__/project/remove-user-from-project.auth.e2e.spec.ts
@@ -1,0 +1,78 @@
+import { INestApplication } from '@nestjs/common';
+import { nanoid } from 'nanoid';
+import { gql } from 'src/testing/utils/gql';
+import { UserProjectRoles } from 'src/features/auth/consts';
+import { getTestApp } from 'src/testing/e2e';
+import { PrismaService } from 'src/infrastructure/database/prisma.service';
+import {
+  booleanMutationAssert,
+  operation,
+  runAuthMatrix,
+  type AuthMatrixCaseBase,
+} from 'src/testing/kit/auth-permission';
+import { usingFreshProject } from 'src/testing/scenarios/using-fresh-project';
+import { givenStandaloneUser } from 'src/testing/scenarios/given-standalone-user';
+
+interface RemoveUserFromProjectParams {
+  organizationId: string;
+  projectName: string;
+  userId: string;
+}
+
+const removeUserFromProject = operation<RemoveUserFromProjectParams>({
+  id: 'project.removeUser',
+  rest: {
+    method: 'delete',
+    url: ({ organizationId, projectName, userId }) =>
+      `/api/organization/${organizationId}/projects/${projectName}/users/${userId}`,
+  },
+  gql: {
+    query: gql`
+      mutation removeUserFromProject($data: RemoveUserFromProjectInput!) {
+        removeUserFromProject(data: $data)
+      }
+    `,
+    variables: (params) => ({ data: params }),
+  },
+});
+
+const cases: AuthMatrixCaseBase[] = [
+  { name: 'owner', role: 'owner', expected: 'allowed' },
+  { name: 'cross-owner', role: 'crossOwner', expected: 'forbidden' },
+  { name: 'anonymous', role: 'anonymous', expected: 'unauthorized' },
+];
+
+describe('remove-user-from-project auth', () => {
+  const fresh = usingFreshProject();
+  let targetUserId: string;
+
+  beforeEach(async () => {
+    const app: INestApplication = await getTestApp();
+    const prisma = app.get(PrismaService);
+    const user = await givenStandaloneUser(app);
+    targetUserId = user.userId;
+    // Put the target into the project first so removal has something to do.
+    await prisma.userProject.create({
+      data: {
+        id: nanoid(),
+        projectId: fresh.fixture.project.projectId,
+        userId: targetUserId,
+        roleId: UserProjectRoles.developer,
+      },
+    });
+  });
+
+  runAuthMatrix({
+    op: removeUserFromProject,
+    cases,
+    build: () => ({
+      fixture: fresh.fixture,
+      params: {
+        organizationId: fresh.fixture.project.organizationId,
+        projectName: fresh.fixture.project.projectName,
+        userId: targetUserId,
+      },
+      assert: booleanMutationAssert('removeUserFromProject'),
+    }),
+  });
+});

--- a/src/api/__tests__/project/update-project.auth.e2e.spec.ts
+++ b/src/api/__tests__/project/update-project.auth.e2e.spec.ts
@@ -1,0 +1,58 @@
+import { gql } from 'src/testing/utils/gql';
+import {
+  booleanMutationAssert,
+  operation,
+  runAuthMatrix,
+  type AuthMatrixCaseBase,
+} from 'src/testing/kit/auth-permission';
+import { usingFreshProject } from 'src/testing/scenarios/using-fresh-project';
+
+interface UpdateProjectParams {
+  organizationId: string;
+  projectName: string;
+  isPublic: boolean;
+}
+
+const updateProject = operation<UpdateProjectParams>({
+  id: 'project.update',
+  rest: {
+    method: 'put',
+    url: ({ organizationId, projectName }) =>
+      `/api/organization/${organizationId}/projects/${projectName}`,
+    body: ({ isPublic }) => ({ isPublic }),
+  },
+  gql: {
+    query: gql`
+      mutation updateProject($data: UpdateProjectInput!) {
+        updateProject(data: $data)
+      }
+    `,
+    variables: ({ organizationId, projectName, isPublic }) => ({
+      data: { organizationId, projectName, isPublic },
+    }),
+  },
+});
+
+const cases: AuthMatrixCaseBase[] = [
+  { name: 'owner', role: 'owner', expected: 'allowed' },
+  { name: 'cross-owner', role: 'crossOwner', expected: 'forbidden' },
+  { name: 'anonymous', role: 'anonymous', expected: 'unauthorized' },
+];
+
+describe('update project auth', () => {
+  const fresh = usingFreshProject();
+
+  runAuthMatrix({
+    op: updateProject,
+    cases,
+    build: () => ({
+      fixture: fresh.fixture,
+      params: {
+        organizationId: fresh.fixture.project.organizationId,
+        projectName: fresh.fixture.project.projectName,
+        isPublic: true,
+      },
+      assert: booleanMutationAssert('updateProject'),
+    }),
+  });
+});

--- a/src/api/__tests__/project/update-user-project-role.auth.e2e.spec.ts
+++ b/src/api/__tests__/project/update-user-project-role.auth.e2e.spec.ts
@@ -1,0 +1,77 @@
+import { nanoid } from 'nanoid';
+import { gql } from 'src/testing/utils/gql';
+import { UserProjectRoles, UserSystemRoles } from 'src/features/auth/consts';
+import { PrismaService } from 'src/infrastructure/database/prisma.service';
+import { getTestApp } from 'src/testing/e2e';
+import {
+  booleanMutationAssert,
+  operation,
+  runAuthMatrix,
+  type AuthMatrixCaseBase,
+} from 'src/testing/kit/auth-permission';
+import { usingFreshProject } from 'src/testing/scenarios/using-fresh-project';
+
+interface UpdateUserProjectRoleParams {
+  organizationId: string;
+  projectName: string;
+  userId: string;
+  roleId: UserProjectRoles;
+}
+
+// GraphQL-only — no REST endpoint exposes role changes today.
+const updateUserProjectRole = operation<UpdateUserProjectRoleParams>({
+  id: 'project.updateUserProjectRole',
+  gql: {
+    query: gql`
+      mutation updateUserProjectRole($data: UpdateUserProjectRoleInput!) {
+        updateUserProjectRole(data: $data)
+      }
+    `,
+    variables: (params) => ({ data: params }),
+  },
+});
+
+const cases: AuthMatrixCaseBase[] = [
+  { name: 'owner', role: 'owner', expected: 'allowed' },
+  { name: 'cross-owner', role: 'crossOwner', expected: 'forbidden' },
+  { name: 'anonymous', role: 'anonymous', expected: 'unauthorized' },
+];
+
+describe('update user-project-role auth', () => {
+  const fresh = usingFreshProject();
+  let targetUserId: string;
+
+  beforeEach(async () => {
+    targetUserId = nanoid();
+    const prisma = (await getTestApp()).get(PrismaService);
+    await prisma.user.create({
+      data: {
+        id: targetUserId,
+        roleId: UserSystemRoles.systemUser,
+        password: '',
+        userProjects: {
+          create: {
+            id: nanoid(),
+            projectId: fresh.fixture.project.projectId,
+            roleId: UserProjectRoles.developer,
+          },
+        },
+      },
+    });
+  });
+
+  runAuthMatrix({
+    op: updateUserProjectRole,
+    cases,
+    build: () => ({
+      fixture: fresh.fixture,
+      params: {
+        organizationId: fresh.fixture.project.organizationId,
+        projectName: fresh.fixture.project.projectName,
+        userId: targetUserId,
+        roleId: UserProjectRoles.reader,
+      },
+      assert: booleanMutationAssert('updateUserProjectRole'),
+    }),
+  });
+});

--- a/src/api/__tests__/project/users-project.auth.e2e.spec.ts
+++ b/src/api/__tests__/project/users-project.auth.e2e.spec.ts
@@ -1,0 +1,123 @@
+import { INestApplication } from '@nestjs/common';
+import { gql } from 'src/testing/utils/gql';
+import { getTestApp } from 'src/testing/e2e';
+import {
+  operation,
+  runAuthMatrix,
+  type AuthMatrixCaseBase,
+} from 'src/testing/kit/auth-permission';
+import {
+  givenProjectPair,
+  type ProjectPairScenario,
+} from 'src/testing/scenarios/given-project-pair';
+
+interface UsersProjectParams {
+  organizationId: string;
+  projectName: string;
+}
+
+const usersProject = operation<UsersProjectParams>({
+  id: 'project.usersProject',
+  rest: {
+    method: 'get',
+    url: ({ organizationId, projectName }) =>
+      `/api/organization/${organizationId}/projects/${projectName}/users`,
+    query: () => ({ first: 10 }),
+  },
+  gql: {
+    query: gql`
+      query usersProject($data: GetUsersProjectInput!) {
+        usersProject(data: $data) {
+          totalCount
+          edges {
+            node {
+              id
+            }
+          }
+        }
+      }
+    `,
+    variables: ({ organizationId, projectName }) => ({
+      data: { organizationId, projectName, first: 10 },
+    }),
+  },
+});
+
+type Visibility = 'private' | 'public';
+type MatrixCase = AuthMatrixCaseBase & { project: Visibility };
+
+// User listing is PII — gated by project membership regardless of public-ness.
+// Public project does NOT grant anon read on /users; cross-owner also forbidden.
+const cases: MatrixCase[] = [
+  {
+    name: 'private — owner',
+    project: 'private',
+    role: 'owner',
+    expected: 'allowed',
+  },
+  {
+    name: 'private — cross-owner',
+    project: 'private',
+    role: 'crossOwner',
+    expected: 'forbidden',
+  },
+  {
+    name: 'private — anonymous',
+    project: 'private',
+    role: 'anonymous',
+    expected: 'unauthorized',
+  },
+  {
+    name: 'public  — owner',
+    project: 'public',
+    role: 'owner',
+    expected: 'allowed',
+  },
+  {
+    name: 'public  — cross-owner',
+    project: 'public',
+    role: 'crossOwner',
+    expected: 'forbidden',
+  },
+  {
+    name: 'public  — anonymous',
+    project: 'public',
+    role: 'anonymous',
+    expected: 'unauthorized',
+  },
+];
+
+describe('users-project auth', () => {
+  let app: INestApplication;
+  let projects: ProjectPairScenario;
+
+  beforeAll(async () => {
+    app = await getTestApp();
+    projects = await givenProjectPair(app);
+  });
+
+  runAuthMatrix({
+    op: usersProject,
+    cases,
+    build: (c) => {
+      const fixture = projects[c.project];
+      return {
+        fixture,
+        params: {
+          organizationId: fixture.project.organizationId,
+          projectName: fixture.project.projectName,
+        },
+        assert: {
+          gql: (data) => {
+            const r = data as { usersProject: { totalCount: number } };
+            expect(r.usersProject.totalCount).toBeGreaterThanOrEqual(0);
+          },
+          rest: (body) => {
+            const r = body as { totalCount: number };
+            expect(r.totalCount).toBeGreaterThanOrEqual(0);
+          },
+        },
+      };
+    },
+  });
+});

--- a/src/api/__tests__/revision/child-branches.auth.e2e.spec.ts
+++ b/src/api/__tests__/revision/child-branches.auth.e2e.spec.ts
@@ -1,0 +1,84 @@
+import { INestApplication } from '@nestjs/common';
+import { getTestApp } from 'src/testing/e2e';
+import {
+  operation,
+  runAuthMatrix,
+  type AuthMatrixCaseBase,
+} from 'src/testing/kit/auth-permission';
+import {
+  givenProjectPair,
+  type ProjectPairScenario,
+} from 'src/testing/scenarios/given-project-pair';
+
+// REST-only.
+const childBranches = operation<{ revisionId: string }>({
+  id: 'revision.childBranches',
+  rest: {
+    method: 'get',
+    url: ({ revisionId }) => `/api/revision/${revisionId}/child-branches`,
+  },
+});
+
+type Visibility = 'private' | 'public';
+type Case = AuthMatrixCaseBase & { project: Visibility };
+
+const cases: Case[] = [
+  {
+    name: 'private — owner',
+    project: 'private',
+    role: 'owner',
+    expected: 'allowed',
+  },
+  {
+    name: 'private — cross-owner',
+    project: 'private',
+    role: 'crossOwner',
+    expected: 'forbidden',
+  },
+  {
+    name: 'private — anonymous',
+    project: 'private',
+    role: 'anonymous',
+    expected: 'forbidden',
+  },
+  {
+    name: 'public  — owner',
+    project: 'public',
+    role: 'owner',
+    expected: 'allowed',
+  },
+  {
+    name: 'public  — cross-owner',
+    project: 'public',
+    role: 'crossOwner',
+    expected: 'allowed',
+  },
+  {
+    name: 'public  — anonymous',
+    project: 'public',
+    role: 'anonymous',
+    expected: 'allowed',
+  },
+];
+
+describe('child branches auth', () => {
+  let app: INestApplication;
+  let projects: ProjectPairScenario;
+
+  beforeAll(async () => {
+    app = await getTestApp();
+    projects = await givenProjectPair(app);
+  });
+
+  runAuthMatrix({
+    op: childBranches,
+    cases,
+    build: (c) => {
+      const fixture = projects[c.project];
+      return {
+        fixture,
+        params: { revisionId: fixture.project.draftRevisionId },
+      };
+    },
+  });
+});

--- a/src/api/__tests__/revision/create-branch.auth.e2e.spec.ts
+++ b/src/api/__tests__/revision/create-branch.auth.e2e.spec.ts
@@ -1,0 +1,45 @@
+import { gql } from 'src/testing/utils/gql';
+import { nanoid } from 'nanoid';
+import {
+  operation,
+  runAuthMatrix,
+  PROJECT_MUTATION_MATRIX,
+} from 'src/testing/kit/auth-permission';
+import { usingFreshProject } from 'src/testing/scenarios/using-fresh-project';
+
+const createBranch = operation<{ revisionId: string; branchName: string }>({
+  id: 'revision.createBranch',
+  rest: {
+    method: 'post',
+    url: ({ revisionId }) => `/api/revision/${revisionId}/child-branches`,
+    body: ({ branchName }) => ({ branchName }),
+  },
+  gql: {
+    query: gql`
+      mutation createBranch($data: CreateBranchInput!) {
+        createBranch(data: $data) {
+          id
+        }
+      }
+    `,
+    variables: ({ revisionId, branchName }) => ({
+      data: { revisionId, branchName },
+    }),
+  },
+});
+
+describe('create branch auth', () => {
+  const fresh = usingFreshProject();
+
+  runAuthMatrix({
+    op: createBranch,
+    cases: PROJECT_MUTATION_MATRIX,
+    build: () => ({
+      fixture: fresh.fixture,
+      params: {
+        revisionId: fresh.fixture.project.headRevisionId,
+        branchName: `br-${nanoid()}`,
+      },
+    }),
+  });
+});

--- a/src/api/__tests__/revision/create-table.auth.e2e.spec.ts
+++ b/src/api/__tests__/revision/create-table.auth.e2e.spec.ts
@@ -1,0 +1,59 @@
+import { nanoid } from 'nanoid';
+import { gql } from 'src/testing/utils/gql';
+import {
+  operation,
+  runAuthMatrix,
+  PROJECT_MUTATION_MATRIX,
+} from 'src/testing/kit/auth-permission';
+import { usingFreshProject } from 'src/testing/scenarios/using-fresh-project';
+
+// `createTable` is exposed by the draft resolver (GQL) and as REST POST
+// on the revision endpoint.
+const createTable = operation<{
+  revisionId: string;
+  tableId: string;
+  schema: object;
+}>({
+  id: 'revision.createTable',
+  rest: {
+    method: 'post',
+    url: ({ revisionId }) => `/api/revision/${revisionId}/tables`,
+    body: ({ tableId, schema }) => ({ tableId, schema }),
+  },
+  gql: {
+    query: gql`
+      mutation createTable($data: CreateTableInput!) {
+        createTable(data: $data) {
+          table {
+            id
+          }
+        }
+      }
+    `,
+    variables: ({ revisionId, tableId, schema }) => ({
+      data: { revisionId, tableId, schema },
+    }),
+  },
+});
+
+describe('create table auth', () => {
+  const fresh = usingFreshProject();
+
+  runAuthMatrix({
+    op: createTable,
+    cases: PROJECT_MUTATION_MATRIX,
+    build: () => ({
+      fixture: fresh.fixture,
+      params: {
+        revisionId: fresh.fixture.project.draftRevisionId,
+        tableId: `t-${nanoid()}`,
+        schema: {
+          type: 'object',
+          properties: {},
+          required: [],
+          additionalProperties: false,
+        },
+      },
+    }),
+  });
+});

--- a/src/api/__tests__/revision/get-migrations.auth.e2e.spec.ts
+++ b/src/api/__tests__/revision/get-migrations.auth.e2e.spec.ts
@@ -1,0 +1,83 @@
+import { INestApplication } from '@nestjs/common';
+import { getTestApp } from 'src/testing/e2e';
+import {
+  operation,
+  runAuthMatrix,
+  type AuthMatrixCaseBase,
+} from 'src/testing/kit/auth-permission';
+import {
+  givenProjectPair,
+  type ProjectPairScenario,
+} from 'src/testing/scenarios/given-project-pair';
+
+const getMigrations = operation<{ revisionId: string }>({
+  id: 'revision.migrations',
+  rest: {
+    method: 'get',
+    url: ({ revisionId }) => `/api/revision/${revisionId}/migrations`,
+  },
+});
+
+type Visibility = 'private' | 'public';
+type Case = AuthMatrixCaseBase & { project: Visibility };
+
+const cases: Case[] = [
+  {
+    name: 'private — owner',
+    project: 'private',
+    role: 'owner',
+    expected: 'allowed',
+  },
+  {
+    name: 'private — cross-owner',
+    project: 'private',
+    role: 'crossOwner',
+    expected: 'forbidden',
+  },
+  {
+    name: 'private — anonymous',
+    project: 'private',
+    role: 'anonymous',
+    expected: 'forbidden',
+  },
+  {
+    name: 'public  — owner',
+    project: 'public',
+    role: 'owner',
+    expected: 'allowed',
+  },
+  {
+    name: 'public  — cross-owner',
+    project: 'public',
+    role: 'crossOwner',
+    expected: 'allowed',
+  },
+  {
+    name: 'public  — anonymous',
+    project: 'public',
+    role: 'anonymous',
+    expected: 'allowed',
+  },
+];
+
+describe('get migrations auth', () => {
+  let app: INestApplication;
+  let projects: ProjectPairScenario;
+
+  beforeAll(async () => {
+    app = await getTestApp();
+    projects = await givenProjectPair(app);
+  });
+
+  runAuthMatrix({
+    op: getMigrations,
+    cases,
+    build: (c) => {
+      const fixture = projects[c.project];
+      return {
+        fixture,
+        params: { revisionId: fixture.project.draftRevisionId },
+      };
+    },
+  });
+});

--- a/src/api/__tests__/revision/get-revision.auth.e2e.spec.ts
+++ b/src/api/__tests__/revision/get-revision.auth.e2e.spec.ts
@@ -1,0 +1,52 @@
+import { INestApplication } from '@nestjs/common';
+import { gql } from 'src/testing/utils/gql';
+import { getTestApp } from 'src/testing/e2e';
+import {
+  operation,
+  runAuthMatrix,
+  PROJECT_VISIBILITY_MATRIX,
+} from 'src/testing/kit/auth-permission';
+import {
+  givenProjectPair,
+  type ProjectPairScenario,
+} from 'src/testing/scenarios/given-project-pair';
+
+const getRevision = operation<{ revisionId: string }>({
+  id: 'revision.get',
+  rest: {
+    method: 'get',
+    url: ({ revisionId }) => `/api/revision/${revisionId}`,
+  },
+  gql: {
+    query: gql`
+      query revision($data: GetRevisionInput!) {
+        revision(data: $data) {
+          id
+        }
+      }
+    `,
+    variables: (params) => ({ data: params }),
+  },
+});
+
+describe('get revision auth', () => {
+  let app: INestApplication;
+  let projects: ProjectPairScenario;
+
+  beforeAll(async () => {
+    app = await getTestApp();
+    projects = await givenProjectPair(app);
+  });
+
+  runAuthMatrix({
+    op: getRevision,
+    cases: PROJECT_VISIBILITY_MATRIX,
+    build: (c) => {
+      const fixture = projects[c.project];
+      return {
+        fixture,
+        params: { revisionId: fixture.project.draftRevisionId },
+      };
+    },
+  });
+});

--- a/src/api/__tests__/revision/list-revision-endpoints.auth.e2e.spec.ts
+++ b/src/api/__tests__/revision/list-revision-endpoints.auth.e2e.spec.ts
@@ -1,0 +1,84 @@
+import { INestApplication } from '@nestjs/common';
+import { getTestApp } from 'src/testing/e2e';
+import {
+  operation,
+  runAuthMatrix,
+  type AuthMatrixCaseBase,
+} from 'src/testing/kit/auth-permission';
+import {
+  givenProjectPair,
+  type ProjectPairScenario,
+} from 'src/testing/scenarios/given-project-pair';
+
+// REST-only: no GraphQL equivalent at the revision level.
+const listRevisionEndpoints = operation<{ revisionId: string }>({
+  id: 'revision.listEndpoints',
+  rest: {
+    method: 'get',
+    url: ({ revisionId }) => `/api/revision/${revisionId}/endpoints`,
+  },
+});
+
+type Visibility = 'private' | 'public';
+type Case = AuthMatrixCaseBase & { project: Visibility };
+
+const cases: Case[] = [
+  {
+    name: 'private — owner',
+    project: 'private',
+    role: 'owner',
+    expected: 'allowed',
+  },
+  {
+    name: 'private — cross-owner',
+    project: 'private',
+    role: 'crossOwner',
+    expected: 'forbidden',
+  },
+  {
+    name: 'private — anonymous',
+    project: 'private',
+    role: 'anonymous',
+    expected: 'forbidden',
+  },
+  {
+    name: 'public  — owner',
+    project: 'public',
+    role: 'owner',
+    expected: 'allowed',
+  },
+  {
+    name: 'public  — cross-owner',
+    project: 'public',
+    role: 'crossOwner',
+    expected: 'allowed',
+  },
+  {
+    name: 'public  — anonymous',
+    project: 'public',
+    role: 'anonymous',
+    expected: 'allowed',
+  },
+];
+
+describe('list revision endpoints auth', () => {
+  let app: INestApplication;
+  let projects: ProjectPairScenario;
+
+  beforeAll(async () => {
+    app = await getTestApp();
+    projects = await givenProjectPair(app);
+  });
+
+  runAuthMatrix({
+    op: listRevisionEndpoints,
+    cases,
+    build: (c) => {
+      const fixture = projects[c.project];
+      return {
+        fixture,
+        params: { revisionId: fixture.project.draftRevisionId },
+      };
+    },
+  });
+});

--- a/src/api/__tests__/revision/list-revision-tables.auth.e2e.spec.ts
+++ b/src/api/__tests__/revision/list-revision-tables.auth.e2e.spec.ts
@@ -1,0 +1,99 @@
+import { INestApplication } from '@nestjs/common';
+import { gql } from 'src/testing/utils/gql';
+import { getTestApp } from 'src/testing/e2e';
+import {
+  operation,
+  runAuthMatrix,
+  type AuthMatrixCaseBase,
+} from 'src/testing/kit/auth-permission';
+import {
+  givenProjectPair,
+  type ProjectPairScenario,
+} from 'src/testing/scenarios/given-project-pair';
+
+interface Params {
+  revisionId: string;
+}
+
+const listTables = operation<Params>({
+  id: 'revision.listTables',
+  rest: {
+    method: 'get',
+    url: ({ revisionId }) => `/api/revision/${revisionId}/tables`,
+    query: () => ({ first: 10 }),
+  },
+  gql: {
+    query: gql`
+      query tables($data: GetTablesInput!) {
+        tables(data: $data) {
+          totalCount
+        }
+      }
+    `,
+    variables: ({ revisionId }) => ({ data: { revisionId, first: 10 } }),
+  },
+});
+
+type Visibility = 'private' | 'public';
+type Case = AuthMatrixCaseBase & { project: Visibility };
+
+const cases: Case[] = [
+  {
+    name: 'private — owner',
+    project: 'private',
+    role: 'owner',
+    expected: 'allowed',
+  },
+  {
+    name: 'private — cross-owner',
+    project: 'private',
+    role: 'crossOwner',
+    expected: 'forbidden',
+  },
+  {
+    name: 'private — anonymous',
+    project: 'private',
+    role: 'anonymous',
+    expected: 'forbidden',
+  },
+  {
+    name: 'public  — owner',
+    project: 'public',
+    role: 'owner',
+    expected: 'allowed',
+  },
+  {
+    name: 'public  — cross-owner',
+    project: 'public',
+    role: 'crossOwner',
+    expected: 'allowed',
+  },
+  {
+    name: 'public  — anonymous',
+    project: 'public',
+    role: 'anonymous',
+    expected: 'allowed',
+  },
+];
+
+describe('list revision tables auth', () => {
+  let app: INestApplication;
+  let projects: ProjectPairScenario;
+
+  beforeAll(async () => {
+    app = await getTestApp();
+    projects = await givenProjectPair(app);
+  });
+
+  runAuthMatrix({
+    op: listTables,
+    cases,
+    build: (c) => {
+      const fixture = projects[c.project];
+      return {
+        fixture,
+        params: { revisionId: fixture.project.draftRevisionId },
+      };
+    },
+  });
+});

--- a/src/api/__tests__/revision/parent-revision.auth.e2e.spec.ts
+++ b/src/api/__tests__/revision/parent-revision.auth.e2e.spec.ts
@@ -1,0 +1,84 @@
+import { INestApplication } from '@nestjs/common';
+import { getTestApp } from 'src/testing/e2e';
+import {
+  operation,
+  runAuthMatrix,
+  type AuthMatrixCaseBase,
+} from 'src/testing/kit/auth-permission';
+import {
+  givenProjectPair,
+  type ProjectPairScenario,
+} from 'src/testing/scenarios/given-project-pair';
+
+// REST-only.
+const parentRevision = operation<{ revisionId: string }>({
+  id: 'revision.parent',
+  rest: {
+    method: 'get',
+    url: ({ revisionId }) => `/api/revision/${revisionId}/parent-revision`,
+  },
+});
+
+type Visibility = 'private' | 'public';
+type Case = AuthMatrixCaseBase & { project: Visibility };
+
+const cases: Case[] = [
+  {
+    name: 'private — owner',
+    project: 'private',
+    role: 'owner',
+    expected: 'allowed',
+  },
+  {
+    name: 'private — cross-owner',
+    project: 'private',
+    role: 'crossOwner',
+    expected: 'forbidden',
+  },
+  {
+    name: 'private — anonymous',
+    project: 'private',
+    role: 'anonymous',
+    expected: 'forbidden',
+  },
+  {
+    name: 'public  — owner',
+    project: 'public',
+    role: 'owner',
+    expected: 'allowed',
+  },
+  {
+    name: 'public  — cross-owner',
+    project: 'public',
+    role: 'crossOwner',
+    expected: 'allowed',
+  },
+  {
+    name: 'public  — anonymous',
+    project: 'public',
+    role: 'anonymous',
+    expected: 'allowed',
+  },
+];
+
+describe('parent revision auth', () => {
+  let app: INestApplication;
+  let projects: ProjectPairScenario;
+
+  beforeAll(async () => {
+    app = await getTestApp();
+    projects = await givenProjectPair(app);
+  });
+
+  runAuthMatrix({
+    op: parentRevision,
+    cases,
+    build: (c) => {
+      const fixture = projects[c.project];
+      return {
+        fixture,
+        params: { revisionId: fixture.project.draftRevisionId },
+      };
+    },
+  });
+});

--- a/src/api/__tests__/revision/revision-changes.auth.e2e.spec.ts
+++ b/src/api/__tests__/revision/revision-changes.auth.e2e.spec.ts
@@ -1,0 +1,94 @@
+import { INestApplication } from '@nestjs/common';
+import { gql } from 'src/testing/utils/gql';
+import { getTestApp } from 'src/testing/e2e';
+import {
+  operation,
+  runAuthMatrix,
+  type AuthMatrixCaseBase,
+} from 'src/testing/kit/auth-permission';
+import {
+  givenProjectPair,
+  type ProjectPairScenario,
+} from 'src/testing/scenarios/given-project-pair';
+
+const revisionChanges = operation<{ revisionId: string }>({
+  id: 'revision.changes',
+  rest: {
+    method: 'get',
+    url: ({ revisionId }) => `/api/revision/${revisionId}/changes`,
+  },
+  gql: {
+    query: gql`
+      query revisionChanges($data: GetRevisionChangesInput!) {
+        revisionChanges(data: $data) {
+          totalChanges
+        }
+      }
+    `,
+    variables: ({ revisionId }) => ({ data: { revisionId } }),
+  },
+});
+
+type Visibility = 'private' | 'public';
+type Case = AuthMatrixCaseBase & { project: Visibility };
+
+const cases: Case[] = [
+  {
+    name: 'private — owner',
+    project: 'private',
+    role: 'owner',
+    expected: 'allowed',
+  },
+  {
+    name: 'private — cross-owner',
+    project: 'private',
+    role: 'crossOwner',
+    expected: 'forbidden',
+  },
+  {
+    name: 'private — anonymous',
+    project: 'private',
+    role: 'anonymous',
+    expected: 'forbidden',
+  },
+  {
+    name: 'public  — owner',
+    project: 'public',
+    role: 'owner',
+    expected: 'allowed',
+  },
+  {
+    name: 'public  — cross-owner',
+    project: 'public',
+    role: 'crossOwner',
+    expected: 'allowed',
+  },
+  {
+    name: 'public  — anonymous',
+    project: 'public',
+    role: 'anonymous',
+    expected: 'allowed',
+  },
+];
+
+describe('revision changes auth', () => {
+  let app: INestApplication;
+  let projects: ProjectPairScenario;
+
+  beforeAll(async () => {
+    app = await getTestApp();
+    projects = await givenProjectPair(app);
+  });
+
+  runAuthMatrix({
+    op: revisionChanges,
+    cases,
+    build: (c) => {
+      const fixture = projects[c.project];
+      return {
+        fixture,
+        params: { revisionId: fixture.project.draftRevisionId },
+      };
+    },
+  });
+});

--- a/src/api/__tests__/revision/row-changes.auth.e2e.spec.ts
+++ b/src/api/__tests__/revision/row-changes.auth.e2e.spec.ts
@@ -1,0 +1,58 @@
+import { INestApplication } from '@nestjs/common';
+import { gql } from 'src/testing/utils/gql';
+import { getTestApp } from 'src/testing/e2e';
+import {
+  operation,
+  runAuthMatrix,
+  PROJECT_VISIBILITY_MATRIX,
+} from 'src/testing/kit/auth-permission';
+import {
+  givenProjectPair,
+  type ProjectPairScenario,
+} from 'src/testing/scenarios/given-project-pair';
+
+const rowChanges = operation<{ revisionId: string; tableId: string }>({
+  id: 'revision.rowChanges',
+  rest: {
+    method: 'get',
+    url: ({ revisionId }) => `/api/revision/${revisionId}/row-changes`,
+    query: ({ tableId }) => ({ first: 10, tableId }),
+  },
+  gql: {
+    query: gql`
+      query rowChanges($data: GetRowChangesInput!) {
+        rowChanges(data: $data) {
+          totalCount
+        }
+      }
+    `,
+    variables: ({ revisionId, tableId }) => ({
+      data: { revisionId, first: 10, filters: { tableId } },
+    }),
+  },
+});
+
+describe('row changes auth', () => {
+  let app: INestApplication;
+  let projects: ProjectPairScenario;
+
+  beforeAll(async () => {
+    app = await getTestApp();
+    projects = await givenProjectPair(app);
+  });
+
+  runAuthMatrix({
+    op: rowChanges,
+    cases: PROJECT_VISIBILITY_MATRIX,
+    build: (c) => {
+      const fixture = projects[c.project];
+      return {
+        fixture,
+        params: {
+          revisionId: fixture.project.draftRevisionId,
+          tableId: fixture.project.tableId,
+        },
+      };
+    },
+  });
+});

--- a/src/api/__tests__/revision/table-changes.auth.e2e.spec.ts
+++ b/src/api/__tests__/revision/table-changes.auth.e2e.spec.ts
@@ -1,0 +1,95 @@
+import { INestApplication } from '@nestjs/common';
+import { gql } from 'src/testing/utils/gql';
+import { getTestApp } from 'src/testing/e2e';
+import {
+  operation,
+  runAuthMatrix,
+  type AuthMatrixCaseBase,
+} from 'src/testing/kit/auth-permission';
+import {
+  givenProjectPair,
+  type ProjectPairScenario,
+} from 'src/testing/scenarios/given-project-pair';
+
+const tableChanges = operation<{ revisionId: string }>({
+  id: 'revision.tableChanges',
+  rest: {
+    method: 'get',
+    url: ({ revisionId }) => `/api/revision/${revisionId}/table-changes`,
+    query: () => ({ first: 10 }),
+  },
+  gql: {
+    query: gql`
+      query tableChanges($data: GetTableChangesInput!) {
+        tableChanges(data: $data) {
+          totalCount
+        }
+      }
+    `,
+    variables: ({ revisionId }) => ({ data: { revisionId, first: 10 } }),
+  },
+});
+
+type Visibility = 'private' | 'public';
+type Case = AuthMatrixCaseBase & { project: Visibility };
+
+const cases: Case[] = [
+  {
+    name: 'private — owner',
+    project: 'private',
+    role: 'owner',
+    expected: 'allowed',
+  },
+  {
+    name: 'private — cross-owner',
+    project: 'private',
+    role: 'crossOwner',
+    expected: 'forbidden',
+  },
+  {
+    name: 'private — anonymous',
+    project: 'private',
+    role: 'anonymous',
+    expected: 'forbidden',
+  },
+  {
+    name: 'public  — owner',
+    project: 'public',
+    role: 'owner',
+    expected: 'allowed',
+  },
+  {
+    name: 'public  — cross-owner',
+    project: 'public',
+    role: 'crossOwner',
+    expected: 'allowed',
+  },
+  {
+    name: 'public  — anonymous',
+    project: 'public',
+    role: 'anonymous',
+    expected: 'allowed',
+  },
+];
+
+describe('table changes auth', () => {
+  let app: INestApplication;
+  let projects: ProjectPairScenario;
+
+  beforeAll(async () => {
+    app = await getTestApp();
+    projects = await givenProjectPair(app);
+  });
+
+  runAuthMatrix({
+    op: tableChanges,
+    cases,
+    build: (c) => {
+      const fixture = projects[c.project];
+      return {
+        fixture,
+        params: { revisionId: fixture.project.draftRevisionId },
+      };
+    },
+  });
+});

--- a/src/api/__tests__/row/delete-row.auth.e2e.spec.ts
+++ b/src/api/__tests__/row/delete-row.auth.e2e.spec.ts
@@ -1,0 +1,49 @@
+import { gql } from 'src/testing/utils/gql';
+import {
+  operation,
+  runAuthMatrix,
+  PROJECT_MUTATION_MATRIX,
+} from 'src/testing/kit/auth-permission';
+import { usingFreshProject } from 'src/testing/scenarios/using-fresh-project';
+
+const deleteRow = operation<{
+  revisionId: string;
+  tableId: string;
+  rowId: string;
+}>({
+  id: 'row.delete',
+  rest: {
+    method: 'delete',
+    url: ({ revisionId, tableId, rowId }) =>
+      `/api/revision/${revisionId}/tables/${tableId}/rows/${rowId}`,
+  },
+  gql: {
+    query: gql`
+      mutation deleteRow($data: DeleteRowInput!) {
+        deleteRow(data: $data) {
+          table {
+            id
+          }
+        }
+      }
+    `,
+    variables: (params) => ({ data: params }),
+  },
+});
+
+describe('delete row auth', () => {
+  const fresh = usingFreshProject();
+
+  runAuthMatrix({
+    op: deleteRow,
+    cases: PROJECT_MUTATION_MATRIX,
+    build: () => ({
+      fixture: fresh.fixture,
+      params: {
+        revisionId: fresh.fixture.project.draftRevisionId,
+        tableId: fresh.fixture.project.tableId,
+        rowId: fresh.fixture.project.rowId,
+      },
+    }),
+  });
+});

--- a/src/api/__tests__/row/get-row.auth.e2e.spec.ts
+++ b/src/api/__tests__/row/get-row.auth.e2e.spec.ts
@@ -1,0 +1,63 @@
+import { INestApplication } from '@nestjs/common';
+import { gql } from 'src/testing/utils/gql';
+import { getTestApp } from 'src/testing/e2e';
+import {
+  operation,
+  runAuthMatrix,
+  PROJECT_VISIBILITY_MATRIX,
+} from 'src/testing/kit/auth-permission';
+import {
+  givenProjectPair,
+  type ProjectPairScenario,
+} from 'src/testing/scenarios/given-project-pair';
+
+const getRow = operation<{
+  revisionId: string;
+  tableId: string;
+  rowId: string;
+}>({
+  id: 'row.get',
+  rest: {
+    method: 'get',
+    url: ({ revisionId, tableId, rowId }) =>
+      `/api/revision/${revisionId}/tables/${tableId}/rows/${rowId}`,
+  },
+  gql: {
+    query: gql`
+      query row($data: GetRowInput!) {
+        row(data: $data) {
+          id
+        }
+      }
+    `,
+    variables: ({ revisionId, tableId, rowId }) => ({
+      data: { revisionId, tableId, rowId },
+    }),
+  },
+});
+
+describe('get row auth', () => {
+  let app: INestApplication;
+  let projects: ProjectPairScenario;
+
+  beforeAll(async () => {
+    app = await getTestApp();
+    projects = await givenProjectPair(app);
+  });
+
+  runAuthMatrix({
+    op: getRow,
+    cases: PROJECT_VISIBILITY_MATRIX,
+    build: (c) => {
+      const fixture = projects[c.project];
+      return {
+        fixture,
+        params: {
+          revisionId: fixture.project.draftRevisionId,
+          tableId: fixture.project.tableId,
+          rowId: fixture.project.rowId,
+        },
+      };
+    },
+  });
+});

--- a/src/api/__tests__/row/rename-row.auth.e2e.spec.ts
+++ b/src/api/__tests__/row/rename-row.auth.e2e.spec.ts
@@ -1,0 +1,53 @@
+import { nanoid } from 'nanoid';
+import { gql } from 'src/testing/utils/gql';
+import {
+  operation,
+  runAuthMatrix,
+  PROJECT_MUTATION_MATRIX,
+} from 'src/testing/kit/auth-permission';
+import { usingFreshProject } from 'src/testing/scenarios/using-fresh-project';
+
+const renameRow = operation<{
+  revisionId: string;
+  tableId: string;
+  rowId: string;
+  nextRowId: string;
+}>({
+  id: 'row.rename',
+  rest: {
+    method: 'patch',
+    url: ({ revisionId, tableId, rowId }) =>
+      `/api/revision/${revisionId}/tables/${tableId}/rows/${rowId}/rename`,
+    body: ({ nextRowId }) => ({ nextRowId }),
+  },
+  gql: {
+    query: gql`
+      mutation renameRow($data: RenameRowInput!) {
+        renameRow(data: $data) {
+          row {
+            id
+          }
+        }
+      }
+    `,
+    variables: (params) => ({ data: params }),
+  },
+});
+
+describe('rename row auth', () => {
+  const fresh = usingFreshProject();
+
+  runAuthMatrix({
+    op: renameRow,
+    cases: PROJECT_MUTATION_MATRIX,
+    build: () => ({
+      fixture: fresh.fixture,
+      params: {
+        revisionId: fresh.fixture.project.draftRevisionId,
+        tableId: fresh.fixture.project.tableId,
+        rowId: fresh.fixture.project.rowId,
+        nextRowId: `renamed-${nanoid()}`,
+      },
+    }),
+  });
+});

--- a/src/api/__tests__/row/row-foreign-keys.auth.e2e.spec.ts
+++ b/src/api/__tests__/row/row-foreign-keys.auth.e2e.spec.ts
@@ -1,0 +1,67 @@
+import { INestApplication } from '@nestjs/common';
+import { getTestApp } from 'src/testing/e2e';
+import {
+  operation,
+  runAuthMatrix,
+  PROJECT_VISIBILITY_MATRIX,
+} from 'src/testing/kit/auth-permission';
+import {
+  givenProjectPair,
+  type ProjectPairScenario,
+} from 'src/testing/scenarios/given-project-pair';
+
+const makeOp = (id: string, path: string) =>
+  operation<{
+    revisionId: string;
+    tableId: string;
+    rowId: string;
+    fkTableId: string;
+  }>({
+    id,
+    rest: {
+      method: 'get',
+      url: ({ revisionId, tableId, rowId }) =>
+        `/api/revision/${revisionId}/tables/${tableId}/rows/${rowId}/${path}`,
+      query: ({ fkTableId }) => ({ first: 10, foreignKeyTableId: fkTableId }),
+    },
+  });
+
+const ops = {
+  countForeignKeysBy: makeOp('row.countForeignKeysBy', 'count-foreign-keys-by'),
+  foreignKeysBy: makeOp('row.foreignKeysBy', 'foreign-keys-by'),
+  countForeignKeysTo: makeOp('row.countForeignKeysTo', 'count-foreign-keys-to'),
+  foreignKeysTo: makeOp('row.foreignKeysTo', 'foreign-keys-to'),
+};
+
+describe('row foreign-keys auth', () => {
+  let app: INestApplication;
+  let projects: ProjectPairScenario;
+
+  beforeAll(async () => {
+    app = await getTestApp();
+    projects = await givenProjectPair(app);
+  });
+
+  for (const [label, op] of Object.entries(ops)) {
+    describe(label, () => {
+      runAuthMatrix({
+        op,
+        cases: PROJECT_VISIBILITY_MATRIX,
+        build: (c) => {
+          const fixture = projects[c.project];
+          const fkTableId =
+            fixture.project.linkedTable?.tableId ?? fixture.project.tableId;
+          return {
+            fixture,
+            params: {
+              revisionId: fixture.project.draftRevisionId,
+              tableId: fixture.project.tableId,
+              rowId: fixture.project.rowId,
+              fkTableId,
+            },
+          };
+        },
+      });
+    });
+  }
+});

--- a/src/api/__tests__/row/update-row.auth.e2e.spec.ts
+++ b/src/api/__tests__/row/update-row.auth.e2e.spec.ts
@@ -1,0 +1,52 @@
+import { gql } from 'src/testing/utils/gql';
+import {
+  operation,
+  runAuthMatrix,
+  PROJECT_MUTATION_MATRIX,
+} from 'src/testing/kit/auth-permission';
+import { usingFreshProject } from 'src/testing/scenarios/using-fresh-project';
+
+const updateRow = operation<{
+  revisionId: string;
+  tableId: string;
+  rowId: string;
+  data: object;
+}>({
+  id: 'row.update',
+  rest: {
+    method: 'put',
+    url: ({ revisionId, tableId, rowId }) =>
+      `/api/revision/${revisionId}/tables/${tableId}/rows/${rowId}`,
+    body: ({ data }) => ({ data }),
+  },
+  gql: {
+    query: gql`
+      mutation updateRow($data: UpdateRowInput!) {
+        updateRow(data: $data) {
+          row {
+            id
+          }
+        }
+      }
+    `,
+    variables: (params) => ({ data: params }),
+  },
+});
+
+describe('update row auth', () => {
+  const fresh = usingFreshProject();
+
+  runAuthMatrix({
+    op: updateRow,
+    cases: PROJECT_MUTATION_MATRIX,
+    build: () => ({
+      fixture: fresh.fixture,
+      params: {
+        revisionId: fresh.fixture.project.draftRevisionId,
+        tableId: fresh.fixture.project.tableId,
+        rowId: fresh.fixture.project.rowId,
+        data: { ver: 2 },
+      },
+    }),
+  });
+});

--- a/src/api/__tests__/table/create-row.auth.e2e.spec.ts
+++ b/src/api/__tests__/table/create-row.auth.e2e.spec.ts
@@ -1,0 +1,53 @@
+import { nanoid } from 'nanoid';
+import { gql } from 'src/testing/utils/gql';
+import {
+  operation,
+  runAuthMatrix,
+  PROJECT_MUTATION_MATRIX,
+} from 'src/testing/kit/auth-permission';
+import { usingFreshProject } from 'src/testing/scenarios/using-fresh-project';
+
+const createRow = operation<{
+  revisionId: string;
+  tableId: string;
+  rowId: string;
+  data: object;
+}>({
+  id: 'table.createRow',
+  rest: {
+    method: 'post',
+    url: ({ revisionId, tableId }) =>
+      `/api/revision/${revisionId}/tables/${tableId}/create-row`,
+    body: ({ rowId, data }) => ({ rowId, data }),
+  },
+  gql: {
+    query: gql`
+      mutation createRow($data: CreateRowInput!) {
+        createRow(data: $data) {
+          row {
+            id
+          }
+        }
+      }
+    `,
+    variables: (params) => ({ data: params }),
+  },
+});
+
+describe('create row auth', () => {
+  const fresh = usingFreshProject();
+
+  runAuthMatrix({
+    op: createRow,
+    cases: PROJECT_MUTATION_MATRIX,
+    build: () => ({
+      fixture: fresh.fixture,
+      params: {
+        revisionId: fresh.fixture.project.draftRevisionId,
+        tableId: fresh.fixture.project.tableId,
+        rowId: `r-${nanoid()}`,
+        data: { ver: 1 },
+      },
+    }),
+  });
+});

--- a/src/api/__tests__/table/create-rows.auth.e2e.spec.ts
+++ b/src/api/__tests__/table/create-rows.auth.e2e.spec.ts
@@ -1,0 +1,51 @@
+import { nanoid } from 'nanoid';
+import { gql } from 'src/testing/utils/gql';
+import {
+  operation,
+  runAuthMatrix,
+  PROJECT_MUTATION_MATRIX,
+} from 'src/testing/kit/auth-permission';
+import { usingFreshProject } from 'src/testing/scenarios/using-fresh-project';
+
+const createRows = operation<{
+  revisionId: string;
+  tableId: string;
+  rows: Array<{ rowId: string; data: object }>;
+}>({
+  id: 'table.createRows',
+  rest: {
+    method: 'post',
+    url: ({ revisionId, tableId }) =>
+      `/api/revision/${revisionId}/tables/${tableId}/create-rows`,
+    body: ({ rows }) => ({ rows }),
+  },
+  gql: {
+    query: gql`
+      mutation createRows($data: CreateRowsInput!) {
+        createRows(data: $data) {
+          table {
+            id
+          }
+        }
+      }
+    `,
+    variables: (params) => ({ data: params }),
+  },
+});
+
+describe('create rows (bulk) auth', () => {
+  const fresh = usingFreshProject();
+
+  runAuthMatrix({
+    op: createRows,
+    cases: PROJECT_MUTATION_MATRIX,
+    build: () => ({
+      fixture: fresh.fixture,
+      params: {
+        revisionId: fresh.fixture.project.draftRevisionId,
+        tableId: fresh.fixture.project.tableId,
+        rows: [{ rowId: `r-${nanoid()}`, data: { ver: 1 } }],
+      },
+    }),
+  });
+});

--- a/src/api/__tests__/table/delete-rows.auth.e2e.spec.ts
+++ b/src/api/__tests__/table/delete-rows.auth.e2e.spec.ts
@@ -1,0 +1,50 @@
+import { gql } from 'src/testing/utils/gql';
+import {
+  operation,
+  runAuthMatrix,
+  PROJECT_MUTATION_MATRIX,
+} from 'src/testing/kit/auth-permission';
+import { usingFreshProject } from 'src/testing/scenarios/using-fresh-project';
+
+const deleteRows = operation<{
+  revisionId: string;
+  tableId: string;
+  rowIds: string[];
+}>({
+  id: 'table.deleteRows',
+  rest: {
+    method: 'delete',
+    url: ({ revisionId, tableId }) =>
+      `/api/revision/${revisionId}/tables/${tableId}/rows`,
+    body: ({ rowIds }) => ({ rowIds }),
+  },
+  gql: {
+    query: gql`
+      mutation deleteRows($data: DeleteRowsInput!) {
+        deleteRows(data: $data) {
+          table {
+            id
+          }
+        }
+      }
+    `,
+    variables: (params) => ({ data: params }),
+  },
+});
+
+describe('delete rows (bulk) auth', () => {
+  const fresh = usingFreshProject();
+
+  runAuthMatrix({
+    op: deleteRows,
+    cases: PROJECT_MUTATION_MATRIX,
+    build: () => ({
+      fixture: fresh.fixture,
+      params: {
+        revisionId: fresh.fixture.project.draftRevisionId,
+        tableId: fresh.fixture.project.tableId,
+        rowIds: [fresh.fixture.project.rowId],
+      },
+    }),
+  });
+});

--- a/src/api/__tests__/table/delete-table.auth.e2e.spec.ts
+++ b/src/api/__tests__/table/delete-table.auth.e2e.spec.ts
@@ -1,0 +1,44 @@
+import { gql } from 'src/testing/utils/gql';
+import {
+  operation,
+  runAuthMatrix,
+  PROJECT_MUTATION_MATRIX,
+} from 'src/testing/kit/auth-permission';
+import { usingFreshProject } from 'src/testing/scenarios/using-fresh-project';
+
+const deleteTable = operation<{ revisionId: string; tableId: string }>({
+  id: 'table.delete',
+  rest: {
+    method: 'delete',
+    url: ({ revisionId, tableId }) =>
+      `/api/revision/${revisionId}/tables/${tableId}`,
+  },
+  gql: {
+    query: gql`
+      mutation deleteTable($data: DeleteTableInput!) {
+        deleteTable(data: $data) {
+          branch {
+            id
+          }
+        }
+      }
+    `,
+    variables: (params) => ({ data: params }),
+  },
+});
+
+describe('delete table auth', () => {
+  const fresh = usingFreshProject();
+
+  runAuthMatrix({
+    op: deleteTable,
+    cases: PROJECT_MUTATION_MATRIX,
+    build: () => ({
+      fixture: fresh.fixture,
+      params: {
+        revisionId: fresh.fixture.project.draftRevisionId,
+        tableId: fresh.fixture.project.tableId,
+      },
+    }),
+  });
+});

--- a/src/api/__tests__/table/get-table.auth.e2e.spec.ts
+++ b/src/api/__tests__/table/get-table.auth.e2e.spec.ts
@@ -1,0 +1,58 @@
+import { INestApplication } from '@nestjs/common';
+import { gql } from 'src/testing/utils/gql';
+import { getTestApp } from 'src/testing/e2e';
+import {
+  operation,
+  runAuthMatrix,
+  PROJECT_VISIBILITY_MATRIX,
+} from 'src/testing/kit/auth-permission';
+import {
+  givenProjectPair,
+  type ProjectPairScenario,
+} from 'src/testing/scenarios/given-project-pair';
+
+const getTable = operation<{ revisionId: string; tableId: string }>({
+  id: 'table.get',
+  rest: {
+    method: 'get',
+    url: ({ revisionId, tableId }) =>
+      `/api/revision/${revisionId}/tables/${tableId}`,
+  },
+  gql: {
+    query: gql`
+      query table($data: GetTableInput!) {
+        table(data: $data) {
+          id
+        }
+      }
+    `,
+    variables: ({ revisionId, tableId }) => ({
+      data: { revisionId, tableId },
+    }),
+  },
+});
+
+describe('get table auth', () => {
+  let app: INestApplication;
+  let projects: ProjectPairScenario;
+
+  beforeAll(async () => {
+    app = await getTestApp();
+    projects = await givenProjectPair(app);
+  });
+
+  runAuthMatrix({
+    op: getTable,
+    cases: PROJECT_VISIBILITY_MATRIX,
+    build: (c) => {
+      const fixture = projects[c.project];
+      return {
+        fixture,
+        params: {
+          revisionId: fixture.project.draftRevisionId,
+          tableId: fixture.project.tableId,
+        },
+      };
+    },
+  });
+});

--- a/src/api/__tests__/table/list-table-rows.auth.e2e.spec.ts
+++ b/src/api/__tests__/table/list-table-rows.auth.e2e.spec.ts
@@ -1,0 +1,60 @@
+import { INestApplication } from '@nestjs/common';
+import { gql } from 'src/testing/utils/gql';
+import { getTestApp } from 'src/testing/e2e';
+import {
+  operation,
+  runAuthMatrix,
+  PROJECT_VISIBILITY_MATRIX,
+} from 'src/testing/kit/auth-permission';
+import {
+  givenProjectPair,
+  type ProjectPairScenario,
+} from 'src/testing/scenarios/given-project-pair';
+
+// REST lists rows via POST body; GQL exposes it as a Query with RowsInput.
+const listTableRows = operation<{ revisionId: string; tableId: string }>({
+  id: 'table.listRows',
+  rest: {
+    method: 'post',
+    url: ({ revisionId, tableId }) =>
+      `/api/revision/${revisionId}/tables/${tableId}/rows`,
+    body: () => ({ first: 10 }),
+  },
+  gql: {
+    query: gql`
+      query rows($data: GetRowsInput!) {
+        rows(data: $data) {
+          totalCount
+        }
+      }
+    `,
+    variables: ({ revisionId, tableId }) => ({
+      data: { revisionId, tableId, first: 10 },
+    }),
+  },
+});
+
+describe('list table rows auth', () => {
+  let app: INestApplication;
+  let projects: ProjectPairScenario;
+
+  beforeAll(async () => {
+    app = await getTestApp();
+    projects = await givenProjectPair(app);
+  });
+
+  runAuthMatrix({
+    op: listTableRows,
+    cases: PROJECT_VISIBILITY_MATRIX,
+    build: (c) => {
+      const fixture = projects[c.project];
+      return {
+        fixture,
+        params: {
+          revisionId: fixture.project.draftRevisionId,
+          tableId: fixture.project.tableId,
+        },
+      };
+    },
+  });
+});

--- a/src/api/__tests__/table/rename-table.auth.e2e.spec.ts
+++ b/src/api/__tests__/table/rename-table.auth.e2e.spec.ts
@@ -1,0 +1,51 @@
+import { nanoid } from 'nanoid';
+import { gql } from 'src/testing/utils/gql';
+import {
+  operation,
+  runAuthMatrix,
+  PROJECT_MUTATION_MATRIX,
+} from 'src/testing/kit/auth-permission';
+import { usingFreshProject } from 'src/testing/scenarios/using-fresh-project';
+
+const renameTable = operation<{
+  revisionId: string;
+  tableId: string;
+  nextTableId: string;
+}>({
+  id: 'table.rename',
+  rest: {
+    method: 'patch',
+    url: ({ revisionId, tableId }) =>
+      `/api/revision/${revisionId}/tables/${tableId}/rename`,
+    body: ({ nextTableId }) => ({ nextTableId }),
+  },
+  gql: {
+    query: gql`
+      mutation renameTable($data: RenameTableInput!) {
+        renameTable(data: $data) {
+          table {
+            id
+          }
+        }
+      }
+    `,
+    variables: (params) => ({ data: params }),
+  },
+});
+
+describe('rename table auth', () => {
+  const fresh = usingFreshProject();
+
+  runAuthMatrix({
+    op: renameTable,
+    cases: PROJECT_MUTATION_MATRIX,
+    build: () => ({
+      fixture: fresh.fixture,
+      params: {
+        revisionId: fresh.fixture.project.draftRevisionId,
+        tableId: fresh.fixture.project.tableId,
+        nextTableId: `renamed-${nanoid()}`,
+      },
+    }),
+  });
+});

--- a/src/api/__tests__/table/table-count-rows.auth.e2e.spec.ts
+++ b/src/api/__tests__/table/table-count-rows.auth.e2e.spec.ts
@@ -1,0 +1,45 @@
+import { INestApplication } from '@nestjs/common';
+import { getTestApp } from 'src/testing/e2e';
+import {
+  operation,
+  runAuthMatrix,
+  PROJECT_VISIBILITY_MATRIX,
+} from 'src/testing/kit/auth-permission';
+import {
+  givenProjectPair,
+  type ProjectPairScenario,
+} from 'src/testing/scenarios/given-project-pair';
+
+const tableCountRows = operation<{ revisionId: string; tableId: string }>({
+  id: 'table.countRows',
+  rest: {
+    method: 'get',
+    url: ({ revisionId, tableId }) =>
+      `/api/revision/${revisionId}/tables/${tableId}/count-rows`,
+  },
+});
+
+describe('table count-rows auth', () => {
+  let app: INestApplication;
+  let projects: ProjectPairScenario;
+
+  beforeAll(async () => {
+    app = await getTestApp();
+    projects = await givenProjectPair(app);
+  });
+
+  runAuthMatrix({
+    op: tableCountRows,
+    cases: PROJECT_VISIBILITY_MATRIX,
+    build: (c) => {
+      const fixture = projects[c.project];
+      return {
+        fixture,
+        params: {
+          revisionId: fixture.project.draftRevisionId,
+          tableId: fixture.project.tableId,
+        },
+      };
+    },
+  });
+});

--- a/src/api/__tests__/table/table-foreign-keys.auth.e2e.spec.ts
+++ b/src/api/__tests__/table/table-foreign-keys.auth.e2e.spec.ts
@@ -1,0 +1,66 @@
+import { INestApplication } from '@nestjs/common';
+import { getTestApp } from 'src/testing/e2e';
+import {
+  operation,
+  runAuthMatrix,
+  PROJECT_VISIBILITY_MATRIX,
+} from 'src/testing/kit/auth-permission';
+import {
+  givenProjectPair,
+  type ProjectPairScenario,
+} from 'src/testing/scenarios/given-project-pair';
+
+// Four related REST-only readonly endpoints; tested as one spec since
+// they share shape and auth contract.
+const makeOp = (id: string, path: string) =>
+  operation<{ revisionId: string; tableId: string }>({
+    id,
+    rest: {
+      method: 'get',
+      url: ({ revisionId, tableId }) =>
+        `/api/revision/${revisionId}/tables/${tableId}/${path}`,
+      query: () => ({ first: 10 }),
+    },
+  });
+
+const endpoints = {
+  countForeignKeysBy: makeOp(
+    'table.countForeignKeysBy',
+    'count-foreign-keys-by',
+  ),
+  foreignKeysBy: makeOp('table.foreignKeysBy', 'foreign-keys-by'),
+  countForeignKeysTo: makeOp(
+    'table.countForeignKeysTo',
+    'count-foreign-keys-to',
+  ),
+  foreignKeysTo: makeOp('table.foreignKeysTo', 'foreign-keys-to'),
+};
+
+describe('table foreign-keys auth', () => {
+  let app: INestApplication;
+  let projects: ProjectPairScenario;
+
+  beforeAll(async () => {
+    app = await getTestApp();
+    projects = await givenProjectPair(app);
+  });
+
+  for (const [label, op] of Object.entries(endpoints)) {
+    describe(label, () => {
+      runAuthMatrix({
+        op,
+        cases: PROJECT_VISIBILITY_MATRIX,
+        build: (c) => {
+          const fixture = projects[c.project];
+          return {
+            fixture,
+            params: {
+              revisionId: fixture.project.draftRevisionId,
+              tableId: fixture.project.tableId,
+            },
+          };
+        },
+      });
+    });
+  }
+});

--- a/src/api/__tests__/table/table-schema.auth.e2e.spec.ts
+++ b/src/api/__tests__/table/table-schema.auth.e2e.spec.ts
@@ -1,0 +1,45 @@
+import { INestApplication } from '@nestjs/common';
+import { getTestApp } from 'src/testing/e2e';
+import {
+  operation,
+  runAuthMatrix,
+  PROJECT_VISIBILITY_MATRIX,
+} from 'src/testing/kit/auth-permission';
+import {
+  givenProjectPair,
+  type ProjectPairScenario,
+} from 'src/testing/scenarios/given-project-pair';
+
+const tableSchema = operation<{ revisionId: string; tableId: string }>({
+  id: 'table.schema',
+  rest: {
+    method: 'get',
+    url: ({ revisionId, tableId }) =>
+      `/api/revision/${revisionId}/tables/${tableId}/schema`,
+  },
+});
+
+describe('table schema auth', () => {
+  let app: INestApplication;
+  let projects: ProjectPairScenario;
+
+  beforeAll(async () => {
+    app = await getTestApp();
+    projects = await givenProjectPair(app);
+  });
+
+  runAuthMatrix({
+    op: tableSchema,
+    cases: PROJECT_VISIBILITY_MATRIX,
+    build: (c) => {
+      const fixture = projects[c.project];
+      return {
+        fixture,
+        params: {
+          revisionId: fixture.project.draftRevisionId,
+          tableId: fixture.project.tableId,
+        },
+      };
+    },
+  });
+});

--- a/src/api/__tests__/table/table-views.auth.e2e.spec.ts
+++ b/src/api/__tests__/table/table-views.auth.e2e.spec.ts
@@ -1,0 +1,54 @@
+import { INestApplication } from '@nestjs/common';
+import { gql } from 'src/testing/utils/gql';
+import { getTestApp } from 'src/testing/e2e';
+import {
+  operation,
+  runAuthMatrix,
+  PROJECT_VISIBILITY_MATRIX,
+} from 'src/testing/kit/auth-permission';
+import {
+  givenProjectPair,
+  type ProjectPairScenario,
+} from 'src/testing/scenarios/given-project-pair';
+
+const tableViews = operation<{ revisionId: string; tableId: string }>({
+  id: 'views.tableViews',
+  gql: {
+    query: gql`
+      query tableViews($data: GetTableViewsInput!) {
+        tableViews(data: $data) {
+          version
+          defaultViewId
+        }
+      }
+    `,
+    variables: ({ revisionId, tableId }) => ({
+      data: { revisionId, tableId },
+    }),
+  },
+});
+
+describe('table views (readonly) auth', () => {
+  let app: INestApplication;
+  let projects: ProjectPairScenario;
+
+  beforeAll(async () => {
+    app = await getTestApp();
+    projects = await givenProjectPair(app);
+  });
+
+  runAuthMatrix({
+    op: tableViews,
+    cases: PROJECT_VISIBILITY_MATRIX,
+    build: (c) => {
+      const fixture = projects[c.project];
+      return {
+        fixture,
+        params: {
+          revisionId: fixture.project.draftRevisionId,
+          tableId: fixture.project.tableId,
+        },
+      };
+    },
+  });
+});

--- a/src/api/__tests__/table/update-rows.auth.e2e.spec.ts
+++ b/src/api/__tests__/table/update-rows.auth.e2e.spec.ts
@@ -1,0 +1,50 @@
+import { gql } from 'src/testing/utils/gql';
+import {
+  operation,
+  runAuthMatrix,
+  PROJECT_MUTATION_MATRIX,
+} from 'src/testing/kit/auth-permission';
+import { usingFreshProject } from 'src/testing/scenarios/using-fresh-project';
+
+const updateRows = operation<{
+  revisionId: string;
+  tableId: string;
+  rows: Array<{ rowId: string; data: object }>;
+}>({
+  id: 'table.updateRows',
+  rest: {
+    method: 'put',
+    url: ({ revisionId, tableId }) =>
+      `/api/revision/${revisionId}/tables/${tableId}/update-rows`,
+    body: ({ rows }) => ({ rows }),
+  },
+  gql: {
+    query: gql`
+      mutation updateRows($data: UpdateRowsInput!) {
+        updateRows(data: $data) {
+          table {
+            id
+          }
+        }
+      }
+    `,
+    variables: (params) => ({ data: params }),
+  },
+});
+
+describe('update rows (bulk) auth', () => {
+  const fresh = usingFreshProject();
+
+  runAuthMatrix({
+    op: updateRows,
+    cases: PROJECT_MUTATION_MATRIX,
+    build: () => ({
+      fixture: fresh.fixture,
+      params: {
+        revisionId: fresh.fixture.project.draftRevisionId,
+        tableId: fresh.fixture.project.tableId,
+        rows: [{ rowId: fresh.fixture.project.rowId, data: { ver: 2 } }],
+      },
+    }),
+  });
+});

--- a/src/api/__tests__/table/update-table-views.auth.e2e.spec.ts
+++ b/src/api/__tests__/table/update-table-views.auth.e2e.spec.ts
@@ -1,0 +1,54 @@
+import { gql } from 'src/testing/utils/gql';
+import {
+  operation,
+  runAuthMatrix,
+  PROJECT_MUTATION_MATRIX,
+} from 'src/testing/kit/auth-permission';
+import { usingFreshProject } from 'src/testing/scenarios/using-fresh-project';
+
+const updateTableViews = operation<{
+  revisionId: string;
+  tableId: string;
+  viewsData: object;
+}>({
+  id: 'views.updateTableViews',
+  gql: {
+    query: gql`
+      mutation updateTableViews($data: UpdateTableViewsInput!) {
+        updateTableViews(data: $data) {
+          version
+          defaultViewId
+        }
+      }
+    `,
+    variables: (params) => ({ data: params }),
+  },
+});
+
+describe('update table views auth', () => {
+  const fresh = usingFreshProject();
+
+  runAuthMatrix({
+    op: updateTableViews,
+    cases: PROJECT_MUTATION_MATRIX,
+    build: () => ({
+      fixture: fresh.fixture,
+      params: {
+        revisionId: fresh.fixture.project.draftRevisionId,
+        tableId: fresh.fixture.project.tableId,
+        viewsData: {
+          version: 1,
+          defaultViewId: 'default',
+          views: [
+            {
+              id: 'default',
+              name: 'Default',
+              columns: [],
+              sorts: [],
+            },
+          ],
+        },
+      },
+    }),
+  });
+});

--- a/src/api/__tests__/table/update-table.auth.e2e.spec.ts
+++ b/src/api/__tests__/table/update-table.auth.e2e.spec.ts
@@ -1,0 +1,58 @@
+import { gql } from 'src/testing/utils/gql';
+import {
+  operation,
+  runAuthMatrix,
+  PROJECT_MUTATION_MATRIX,
+} from 'src/testing/kit/auth-permission';
+import { usingFreshProject } from 'src/testing/scenarios/using-fresh-project';
+
+interface UpdateTableParams {
+  revisionId: string;
+  tableId: string;
+  patches: unknown[];
+}
+
+const updateTable = operation<UpdateTableParams>({
+  id: 'table.update',
+  rest: {
+    method: 'patch',
+    url: ({ revisionId, tableId }) =>
+      `/api/revision/${revisionId}/tables/${tableId}`,
+    body: ({ patches }) => ({ patches }),
+  },
+  gql: {
+    query: gql`
+      mutation updateTable($data: UpdateTableInput!) {
+        updateTable(data: $data) {
+          table {
+            id
+          }
+        }
+      }
+    `,
+    variables: (params) => ({ data: params }),
+  },
+});
+
+describe('update table auth', () => {
+  const fresh = usingFreshProject();
+
+  runAuthMatrix({
+    op: updateTable,
+    cases: PROJECT_MUTATION_MATRIX,
+    build: () => ({
+      fixture: fresh.fixture,
+      params: {
+        revisionId: fresh.fixture.project.draftRevisionId,
+        tableId: fresh.fixture.project.tableId,
+        patches: [
+          {
+            op: 'replace',
+            path: '/properties/ver',
+            value: { type: 'number', default: 0 },
+          },
+        ],
+      },
+    }),
+  });
+});

--- a/src/api/__tests__/user/me-projects.auth.e2e.spec.ts
+++ b/src/api/__tests__/user/me-projects.auth.e2e.spec.ts
@@ -1,0 +1,38 @@
+import { gql } from 'src/testing/utils/gql';
+import {
+  operation,
+  runAuthMatrix,
+  type AuthMatrixCaseBase,
+} from 'src/testing/kit/auth-permission';
+import { usingFreshProject } from 'src/testing/scenarios/using-fresh-project';
+
+const meProjects = operation<Record<string, never>>({
+  id: 'user.meProjects',
+  gql: {
+    query: gql`
+      query meProjects($data: GetMeProjectsInput!) {
+        meProjects(data: $data) {
+          totalCount
+        }
+      }
+    `,
+    variables: () => ({ data: { first: 10 } }),
+  },
+});
+
+// meProjects — any authenticated user gets their own list; anon unauthorized.
+const cases: AuthMatrixCaseBase[] = [
+  { name: 'owner', role: 'owner', expected: 'allowed' },
+  { name: 'cross-owner', role: 'crossOwner', expected: 'allowed' },
+  { name: 'anonymous', role: 'anonymous', expected: 'unauthorized' },
+];
+
+describe('meProjects auth', () => {
+  const fresh = usingFreshProject();
+
+  runAuthMatrix({
+    op: meProjects,
+    cases,
+    build: () => ({ fixture: fresh.fixture, params: {} }),
+  });
+});

--- a/src/api/__tests__/user/me.auth.e2e.spec.ts
+++ b/src/api/__tests__/user/me.auth.e2e.spec.ts
@@ -1,0 +1,67 @@
+import { gql } from 'src/testing/utils/gql';
+import {
+  operation,
+  runAuthMatrix,
+  type AuthMatrixCaseBase,
+} from 'src/testing/kit/auth-permission';
+import { usingFreshProject } from 'src/testing/scenarios/using-fresh-project';
+
+// `me` returns the authenticated user. No params.
+const me = operation<Record<string, never>>({
+  id: 'user.me',
+  rest: {
+    method: 'get',
+    url: () => `/api/user/me`,
+  },
+  gql: {
+    query: gql`
+      query me {
+        me {
+          id
+          username
+        }
+      }
+    `,
+    variables: () => ({}),
+  },
+});
+
+// Any authenticated user can fetch their own record.
+// Anon → unauthorized. There is no "cross-owner" distinction — every user
+// sees themselves. `crossOwner` token sees themselves as well (expected: allowed).
+const cases: AuthMatrixCaseBase[] = [
+  { name: 'owner', role: 'owner', expected: 'allowed' },
+  { name: 'cross-owner', role: 'crossOwner', expected: 'allowed' },
+  { name: 'anonymous', role: 'anonymous', expected: 'unauthorized' },
+];
+
+describe('me auth', () => {
+  const fresh = usingFreshProject();
+
+  runAuthMatrix({
+    op: me,
+    cases,
+    build: (c) => ({
+      fixture: fresh.fixture,
+      params: {},
+      assert: {
+        gql: (data) => {
+          const r = data as { me: { id: string } };
+          const expectedId =
+            c.role === 'owner'
+              ? fresh.fixture.owner.user.id
+              : fresh.fixture.anotherOwner.user.id;
+          expect(r.me.id).toBe(expectedId);
+        },
+        rest: (body) => {
+          const r = body as { id: string };
+          const expectedId =
+            c.role === 'owner'
+              ? fresh.fixture.owner.user.id
+              : fresh.fixture.anotherOwner.user.id;
+          expect(r.id).toBe(expectedId);
+        },
+      },
+    }),
+  });
+});

--- a/src/api/__tests__/user/search-users.auth.e2e.spec.ts
+++ b/src/api/__tests__/user/search-users.auth.e2e.spec.ts
@@ -1,0 +1,37 @@
+import { gql } from 'src/testing/utils/gql';
+import {
+  operation,
+  runAuthMatrix,
+  type AuthMatrixCaseBase,
+} from 'src/testing/kit/auth-permission';
+import { usingFreshProject } from 'src/testing/scenarios/using-fresh-project';
+
+const searchUsers = operation<Record<string, never>>({
+  id: 'user.searchUsers',
+  gql: {
+    query: gql`
+      query searchUsers($data: SearchUsersInput!) {
+        searchUsers(data: $data) {
+          totalCount
+        }
+      }
+    `,
+    variables: () => ({ data: { search: 'user', first: 10 } }),
+  },
+});
+
+const cases: AuthMatrixCaseBase[] = [
+  { name: 'owner', role: 'owner', expected: 'allowed' },
+  { name: 'cross-owner', role: 'crossOwner', expected: 'allowed' },
+  { name: 'anonymous', role: 'anonymous', expected: 'unauthorized' },
+];
+
+describe('searchUsers auth', () => {
+  const fresh = usingFreshProject();
+
+  runAuthMatrix({
+    op: searchUsers,
+    cases,
+    build: () => ({ fixture: fresh.fixture, params: {} }),
+  });
+});

--- a/src/api/graphql-api/filters/__tests__/graphql-http-exception.filter.spec.ts
+++ b/src/api/graphql-api/filters/__tests__/graphql-http-exception.filter.spec.ts
@@ -1,0 +1,77 @@
+import {
+  ArgumentsHost,
+  ForbiddenException,
+  HttpException,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { GraphQLError } from 'graphql';
+import { GraphQLHttpExceptionFilter } from 'src/api/graphql-api/filters/graphql-http-exception.filter';
+
+function gqlHost(): ArgumentsHost {
+  return {
+    getType: <T = string>() => 'graphql' as unknown as T,
+  } as unknown as ArgumentsHost;
+}
+
+function httpHost(): ArgumentsHost {
+  return {
+    getType: <T = string>() => 'http' as unknown as T,
+  } as unknown as ArgumentsHost;
+}
+
+describe('GraphQLHttpExceptionFilter', () => {
+  const filter = new GraphQLHttpExceptionFilter();
+
+  function catchAndReturn(
+    exception: HttpException,
+    host: ArgumentsHost,
+  ): unknown {
+    try {
+      filter.catch(exception, host);
+    } catch (err) {
+      return err;
+    }
+    throw new Error('filter.catch() did not throw');
+  }
+
+  it('maps UnauthorizedException to UNAUTHENTICATED extensions.code', () => {
+    const thrown = catchAndReturn(
+      new UnauthorizedException('No token'),
+      gqlHost(),
+    );
+    expect(thrown).toBeInstanceOf(GraphQLError);
+    expect((thrown as GraphQLError).message).toBe('No token');
+    expect((thrown as GraphQLError).extensions.code).toBe('UNAUTHENTICATED');
+  });
+
+  it('maps ForbiddenException to FORBIDDEN extensions.code', () => {
+    const thrown = catchAndReturn(
+      new ForbiddenException('You are not allowed'),
+      gqlHost(),
+    );
+    expect((thrown as GraphQLError).extensions.code).toBe('FORBIDDEN');
+    expect((thrown as GraphQLError).message).toBe('You are not allowed');
+  });
+
+  it('maps NotFoundException to NOT_FOUND extensions.code', () => {
+    const thrown = catchAndReturn(new NotFoundException('Gone'), gqlHost());
+    expect((thrown as GraphQLError).extensions.code).toBe('NOT_FOUND');
+  });
+
+  it('rethrows the original exception in non-GraphQL contexts (REST/MCP)', () => {
+    const original = new ForbiddenException('No');
+    const thrown = catchAndReturn(original, httpHost());
+    expect(thrown).toBe(original);
+  });
+
+  it('preserves the original message verbatim so regex-based tests keep matching', () => {
+    const thrown = catchAndReturn(
+      new ForbiddenException('You are not allowed to read on Project'),
+      gqlHost(),
+    );
+    expect((thrown as GraphQLError).message).toBe(
+      'You are not allowed to read on Project',
+    );
+  });
+});

--- a/src/api/graphql-api/filters/graphql-http-exception.filter.ts
+++ b/src/api/graphql-api/filters/graphql-http-exception.filter.ts
@@ -1,0 +1,38 @@
+import {
+  ArgumentsHost,
+  Catch,
+  ForbiddenException,
+  HttpException,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { GqlContextType, GqlExceptionFilter } from '@nestjs/graphql';
+import { GraphQLError } from 'graphql';
+
+@Catch(UnauthorizedException, ForbiddenException, NotFoundException)
+export class GraphQLHttpExceptionFilter implements GqlExceptionFilter {
+  catch(exception: HttpException, host: ArgumentsHost): never {
+    const contextType = host.getType<GqlContextType>();
+
+    if (contextType !== 'graphql') {
+      throw exception;
+    }
+
+    throw new GraphQLError(exception.message, {
+      extensions: { code: codeFor(exception) },
+    });
+  }
+}
+
+function codeFor(exception: HttpException): string {
+  if (exception instanceof UnauthorizedException) {
+    return 'UNAUTHENTICATED';
+  }
+  if (exception instanceof ForbiddenException) {
+    return 'FORBIDDEN';
+  }
+  if (exception instanceof NotFoundException) {
+    return 'NOT_FOUND';
+  }
+  return 'INTERNAL_SERVER_ERROR';
+}

--- a/src/api/graphql-api/graphql-api.module.ts
+++ b/src/api/graphql-api/graphql-api.module.ts
@@ -1,6 +1,8 @@
 import { YogaDriver, YogaDriverConfig } from '@graphql-yoga/nestjs';
 import { Module } from '@nestjs/common';
+import { APP_FILTER } from '@nestjs/core';
 import { GraphQLModule } from '@nestjs/graphql';
+import { GraphQLHttpExceptionFilter } from 'src/api/graphql-api/filters/graphql-http-exception.filter';
 import { DateTimeResolver, JSONResolver } from 'graphql-scalars';
 import { BillingConfigurationResolver } from 'src/api/graphql-api/billing/billing-configuration.resolver';
 import { BillingMutationResolver } from 'src/api/graphql-api/billing/billing-mutation.resolver';
@@ -82,6 +84,7 @@ import { SubSchemaResolver } from 'src/api/graphql-api/sub-schema/sub-schema.res
     ApiKeyModule,
   ],
   providers: [
+    { provide: APP_FILTER, useClass: GraphQLHttpExceptionFilter },
     BillingConfigurationResolver,
     BillingOrganizationResolver,
     BillingQueryResolver,

--- a/src/testing/factories/make-file-data.ts
+++ b/src/testing/factories/make-file-data.ts
@@ -1,0 +1,36 @@
+/**
+ * Schema-default payload for `$ref: File` row creation.
+ *
+ * The engine's FilePlugin rejects rows whose file field is anything other
+ * than schema defaults (it then populates `status=ready` + `fileId=<nanoid>`
+ * in the `afterCreateRow` hook). Tests that need a file row should pass
+ * this as-is to `engine.createRow({ data: { file: makeEmptyFileData() } })`
+ * and then read the resolved values back from the row.
+ */
+export interface EmptyFileData {
+  status: string;
+  fileId: string;
+  url: string;
+  fileName: string;
+  hash: string;
+  extension: string;
+  mimeType: string;
+  size: number;
+  width: number;
+  height: number;
+}
+
+export function makeEmptyFileData(): EmptyFileData {
+  return {
+    status: '',
+    fileId: '',
+    url: '',
+    fileName: '',
+    hash: '',
+    extension: '',
+    mimeType: '',
+    size: 0,
+    width: 0,
+    height: 0,
+  };
+}

--- a/src/testing/kit/auth-permission/actors.ts
+++ b/src/testing/kit/auth-permission/actors.ts
@@ -1,0 +1,66 @@
+import { nanoid } from 'nanoid';
+import type { INestApplication } from '@nestjs/common';
+import { AuthService } from 'src/features/auth/auth.service';
+import { UserSystemRoles } from 'src/features/auth/consts';
+import { PrismaService } from 'src/infrastructure/database/prisma.service';
+import { testCreateUser } from 'src/testing/factories/create-models';
+import type { ActorDescriptor, ActorRole } from './types';
+
+/**
+ * Shape the actors kit needs to resolve `owner` / `crossOwner` tokens from a
+ * fixture. Matches what `prepareData()` returns, so any fixture that
+ * extends `PrepareDataReturnType` satisfies this.
+ */
+export interface AuthActorFixture {
+  owner: { token: string };
+  anotherOwner: { token: string };
+}
+
+/**
+ * Minimal actor factories for the pilot. Richer variants from the doc
+ * (actors.user({ orgRole, inOrg }), actors.apiKey({ scopes, ... })) land
+ * when the first spec actually needs them.
+ */
+export const actors = {
+  anonymous(): ActorDescriptor {
+    return { token: null, label: 'anonymous' };
+  },
+  fromToken(token: string, label?: string): ActorDescriptor {
+    return { token, label: label ?? 'user' };
+  },
+  owner(fixture: AuthActorFixture): ActorDescriptor {
+    return { token: fixture.owner.token, label: 'owner' };
+  },
+  crossOwner(fixture: AuthActorFixture): ActorDescriptor {
+    return { token: fixture.anotherOwner.token, label: 'cross-owner' };
+  },
+  /** Dispatches a role to the right actor factory. */
+  resolveRole(fixture: AuthActorFixture, role: ActorRole): ActorDescriptor {
+    switch (role) {
+      case 'owner':
+        return actors.owner(fixture);
+      case 'crossOwner':
+        return actors.crossOwner(fixture);
+      case 'anonymous':
+        return actors.anonymous();
+    }
+  },
+  /**
+   * Seeds a systemAdmin user and returns their actor descriptor.
+   * Used for admin-only endpoints (adminUsers, adminCacheStats, etc.).
+   */
+  async admin(app: INestApplication): Promise<ActorDescriptor> {
+    const prisma = app.get(PrismaService);
+    const authService = app.get(AuthService);
+    const userId = nanoid();
+    const user = await testCreateUser(prisma, {
+      id: userId,
+      roleId: UserSystemRoles.systemAdmin,
+    });
+    const token = authService.login({
+      username: user.username ?? '',
+      sub: user.id,
+    });
+    return { token, label: 'admin' };
+  },
+};

--- a/src/testing/kit/auth-permission/assertions.ts
+++ b/src/testing/kit/auth-permission/assertions.ts
@@ -1,0 +1,23 @@
+import type { Transport } from './types';
+
+type AssertMap = Partial<Record<Transport, (result: unknown) => void>>;
+
+/**
+ * Boolean-success assert for mutations that return
+ *   - REST: `{ success: true }`
+ *   - GQL:  `{ [mutationField]: true }`
+ *
+ * Usage:
+ *   assert: booleanMutationAssert('deleteProject'),
+ */
+export function booleanMutationAssert(gqlMutationField: string): AssertMap {
+  return {
+    gql: (data) => {
+      const value = (data as Record<string, unknown>)[gqlMutationField];
+      expect(value).toBe(true);
+    },
+    rest: (body) => {
+      expect((body as { success: boolean }).success).toBe(true);
+    },
+  };
+}

--- a/src/testing/kit/auth-permission/expect-access.ts
+++ b/src/testing/kit/auth-permission/expect-access.ts
@@ -1,0 +1,126 @@
+import type { INestApplication } from '@nestjs/common';
+import request from 'supertest';
+import { gqlQueryRaw } from 'src/testing/e2e/graphql-helpers';
+import type { ActorDescriptor, Operation, Outcome, Transport } from './types';
+
+const GQL_ERROR_CODE_BY_OUTCOME: Record<Exclude<Outcome, 'allowed'>, string> = {
+  unauthorized: 'UNAUTHENTICATED',
+  forbidden: 'FORBIDDEN',
+  not_found: 'NOT_FOUND',
+};
+
+const REST_STATUS_BY_OUTCOME: Record<Exclude<Outcome, 'allowed'>, number> = {
+  unauthorized: 401,
+  forbidden: 403,
+  not_found: 404,
+};
+
+export interface ExpectAccessOptions<TParams> {
+  app: INestApplication;
+  transport: Transport;
+  actor: ActorDescriptor;
+  op: Operation<TParams>;
+  params: TParams;
+  expected: Outcome;
+  /**
+   * Per-transport assertion callbacks run only when `expected === 'allowed'`.
+   * Never attach to forbidden/not_found/unauthorized — content-leakage
+   * concerns belong in a dedicated spec.
+   */
+  assert?: Partial<Record<Transport, (result: unknown) => void>>;
+}
+
+export async function expectAccess<TParams>(
+  options: ExpectAccessOptions<TParams>,
+): Promise<void> {
+  const { transport } = options;
+  if (transport === 'gql') {
+    return dispatchGql(options);
+  }
+  if (transport === 'rest') {
+    return dispatchRest(options);
+  }
+  throw new Error(
+    `expectAccess: transport "${transport}" is not yet supported by the auth-permission kit`,
+  );
+}
+
+async function dispatchGql<TParams>(
+  options: ExpectAccessOptions<TParams>,
+): Promise<void> {
+  const { app, actor, op, params, expected, assert } = options;
+  if (!op.gql) {
+    throw new Error(
+      `expectAccess: operation "${op.id}" has no gql transport defined`,
+    );
+  }
+  const response = await gqlQueryRaw({
+    app,
+    query: op.gql.query,
+    variables: op.gql.variables(params),
+    token: actor.token ?? undefined,
+  });
+
+  if (expected === 'allowed') {
+    if (response.errors && response.errors.length > 0) {
+      throw new Error(
+        `expectAccess(${op.id}, gql): expected allowed but got errors: ${JSON.stringify(response.errors)}`,
+      );
+    }
+    assert?.gql?.(response.data);
+    return;
+  }
+
+  const expectedCode = GQL_ERROR_CODE_BY_OUTCOME[expected];
+  const actualCode = response.errors?.[0]?.extensions?.code;
+  if (actualCode !== expectedCode) {
+    throw new Error(
+      `expectAccess(${op.id}, gql): expected error code ${expectedCode} but got ${
+        actualCode ?? 'no error'
+      } (errors: ${JSON.stringify(response.errors)})`,
+    );
+  }
+}
+
+async function dispatchRest<TParams>(
+  options: ExpectAccessOptions<TParams>,
+): Promise<void> {
+  const { app, actor, op, params, expected, assert } = options;
+  if (!op.rest) {
+    throw new Error(
+      `expectAccess: operation "${op.id}" has no rest transport defined`,
+    );
+  }
+
+  const url = op.rest.url(params);
+  const req = request(app.getHttpServer())[op.rest.method](url);
+
+  if (actor.token) {
+    req.set('Authorization', `Bearer ${actor.token}`);
+  }
+  if (op.rest.query) {
+    req.query(op.rest.query(params));
+  }
+  if (op.rest.body) {
+    req.send(op.rest.body(params) as object);
+  }
+
+  const response = await req;
+
+  if (expected === 'allowed') {
+    if (response.status >= 400) {
+      throw new Error(
+        `expectAccess(${op.id}, rest ${op.rest.method.toUpperCase()} ${url}): expected allowed but got ${response.status}: ${JSON.stringify(response.body)}`,
+      );
+    }
+    assert?.rest?.(response.body);
+    return;
+  }
+
+  const expectedStatus = REST_STATUS_BY_OUTCOME[expected];
+  if (response.status !== expectedStatus) {
+    throw new Error(
+      `expectAccess(${op.id}, rest ${op.rest.method.toUpperCase()} ${url}): expected status ${expectedStatus} but got ${response.status}: ${JSON.stringify(response.body)}`,
+    );
+  }
+}

--- a/src/testing/kit/auth-permission/expect-access.ts
+++ b/src/testing/kit/auth-permission/expect-access.ts
@@ -27,7 +27,9 @@ export interface ExpectAccessOptions<TParams> {
    * Never attach to forbidden/not_found/unauthorized — content-leakage
    * concerns belong in a dedicated spec.
    */
-  assert?: Partial<Record<Transport, (result: unknown) => void>>;
+  assert?: Partial<
+    Record<Transport, (result: unknown) => void | Promise<void>>
+  >;
 }
 
 export async function expectAccess<TParams>(
@@ -67,7 +69,7 @@ async function dispatchGql<TParams>(
         `expectAccess(${op.id}, gql): expected allowed but got errors: ${JSON.stringify(response.errors)}`,
       );
     }
-    assert?.gql?.(response.data);
+    await assert?.gql?.(response.data);
     return;
   }
 
@@ -113,7 +115,7 @@ async function dispatchRest<TParams>(
         `expectAccess(${op.id}, rest ${op.rest.method.toUpperCase()} ${url}): expected allowed but got ${response.status}: ${JSON.stringify(response.body)}`,
       );
     }
-    assert?.rest?.(response.body);
+    await assert?.rest?.(response.body);
     return;
   }
 

--- a/src/testing/kit/auth-permission/index.ts
+++ b/src/testing/kit/auth-permission/index.ts
@@ -1,0 +1,28 @@
+export type {
+  Transport,
+  Outcome,
+  Operation,
+  GqlOperationShape,
+  RestOperationShape,
+  RestMethod,
+  ActorRole,
+  ActorDescriptor,
+  AuthMatrixCaseBase,
+} from './types';
+export { operation } from './operation';
+export { actors, type AuthActorFixture } from './actors';
+export { expectAccess, type ExpectAccessOptions } from './expect-access';
+export { booleanMutationAssert } from './assertions';
+export {
+  runAuthMatrix,
+  type RunAuthMatrixConfig,
+  type AuthMatrixBuild,
+} from './run-auth-matrix';
+export {
+  PROJECT_MUTATION_MATRIX,
+  ORG_MUTATION_MATRIX,
+  PROJECT_VISIBILITY_MATRIX,
+  PROJECT_PII_READ_MATRIX,
+  type ProjectVisibility,
+  type ProjectVisibilityCase,
+} from './matrices';

--- a/src/testing/kit/auth-permission/matrices.ts
+++ b/src/testing/kit/auth-permission/matrices.ts
@@ -1,0 +1,82 @@
+import type { AuthMatrixCaseBase } from './types';
+
+/**
+ * Mutation under project-scope authorization: owner allowed, cross-owner
+ * forbidden (authenticated but not a member), anon unauthorized
+ * (no credentials).
+ *
+ * Used for delete/update/create on project-scoped resources like branch,
+ * table, row, endpoint, project-user management.
+ */
+export const PROJECT_MUTATION_MATRIX: AuthMatrixCaseBase[] = [
+  { name: 'owner', role: 'owner', expected: 'allowed' },
+  { name: 'cross-owner', role: 'crossOwner', expected: 'forbidden' },
+  { name: 'anonymous', role: 'anonymous', expected: 'unauthorized' },
+];
+
+/** Mutation at org scope — same shape as project mutations. */
+export const ORG_MUTATION_MATRIX = PROJECT_MUTATION_MATRIX;
+
+export type ProjectVisibility = 'private' | 'public';
+
+export interface ProjectVisibilityCase extends AuthMatrixCaseBase {
+  project: ProjectVisibility;
+}
+
+/**
+ * Readonly on a project-scoped resource where visibility matters:
+ *
+ *   Private project: owner allowed, everyone else forbidden.
+ *   Public  project: everyone allowed (anon included).
+ *
+ * Used for get-project, get-branch, get-revision, list-branches,
+ * list-tables, get-migrations, revision-changes, sub-schema, etc.
+ */
+export const PROJECT_VISIBILITY_MATRIX: ProjectVisibilityCase[] = [
+  {
+    name: 'private — owner',
+    project: 'private',
+    role: 'owner',
+    expected: 'allowed',
+  },
+  {
+    name: 'private — cross-owner',
+    project: 'private',
+    role: 'crossOwner',
+    expected: 'forbidden',
+  },
+  {
+    name: 'private — anonymous',
+    project: 'private',
+    role: 'anonymous',
+    expected: 'forbidden',
+  },
+  {
+    name: 'public  — owner',
+    project: 'public',
+    role: 'owner',
+    expected: 'allowed',
+  },
+  {
+    name: 'public  — cross-owner',
+    project: 'public',
+    role: 'crossOwner',
+    expected: 'allowed',
+  },
+  {
+    name: 'public  — anonymous',
+    project: 'public',
+    role: 'anonymous',
+    expected: 'allowed',
+  },
+];
+
+/**
+ * Readonly PII sub-resource (users list, etc). Both private and public
+ * projects require membership; anon short-circuits at auth.
+ */
+export const PROJECT_PII_READ_MATRIX: AuthMatrixCaseBase[] = [
+  { name: 'owner', role: 'owner', expected: 'allowed' },
+  { name: 'cross-owner', role: 'crossOwner', expected: 'forbidden' },
+  { name: 'anonymous', role: 'anonymous', expected: 'unauthorized' },
+];

--- a/src/testing/kit/auth-permission/operation.ts
+++ b/src/testing/kit/auth-permission/operation.ts
@@ -1,0 +1,34 @@
+import type {
+  GqlOperationShape,
+  Operation,
+  RestOperationShape,
+  Transport,
+} from './types';
+
+/**
+ * Builds an Operation. `transports` is derived from which shapes were
+ * supplied so the matrix `describe.each(op.transports)` naturally skips
+ * transports the endpoint does not expose.
+ */
+export function operation<TParams>(config: {
+  id: string;
+  gql?: GqlOperationShape<TParams>;
+  rest?: RestOperationShape<TParams>;
+}): Operation<TParams> {
+  const transports: Transport[] = [];
+  if (config.rest) transports.push('rest');
+  if (config.gql) transports.push('gql');
+
+  if (transports.length === 0) {
+    throw new Error(
+      `operation("${config.id}") declared no transports — pass at least one of { gql, rest }`,
+    );
+  }
+
+  return {
+    id: config.id,
+    gql: config.gql,
+    rest: config.rest,
+    transports,
+  };
+}

--- a/src/testing/kit/auth-permission/run-auth-matrix.ts
+++ b/src/testing/kit/auth-permission/run-auth-matrix.ts
@@ -1,0 +1,49 @@
+import { getTestApp } from 'src/testing/e2e';
+import { actors, type AuthActorFixture } from './actors';
+import { expectAccess } from './expect-access';
+import type { AuthMatrixCaseBase, Operation, Transport } from './types';
+
+export interface AuthMatrixBuild<TParams> {
+  fixture: AuthActorFixture;
+  params: TParams;
+  assert?: Partial<Record<Transport, (result: unknown) => void>>;
+}
+
+export interface RunAuthMatrixConfig<
+  TParams,
+  TCase extends AuthMatrixCaseBase,
+> {
+  op: Operation<TParams>;
+  cases: readonly TCase[];
+  /**
+   * Called once per case, inside the `it` body. Returns the fixture used
+   * for actor-token lookup, the operation params, and (optionally) the
+   * per-transport assert map to run on the `allowed` path.
+   */
+  build: (c: TCase) => AuthMatrixBuild<TParams>;
+}
+
+/**
+ * Wraps `describe.each(op.transports) / it.each(cases)` so a spec only
+ * declares its matrix + per-case build. Identical across every auth spec,
+ * so lifting it saves ~5-8 lines per consumer.
+ */
+export function runAuthMatrix<TParams, TCase extends AuthMatrixCaseBase>(
+  config: RunAuthMatrixConfig<TParams, TCase>,
+): void {
+  describe.each(config.op.transports)('via %s', (transport) => {
+    it.each(config.cases as TCase[])('$name', async (c) => {
+      const { fixture, params, assert } = config.build(c);
+      const app = await getTestApp();
+      await expectAccess({
+        app,
+        transport,
+        actor: actors.resolveRole(fixture, c.role),
+        op: config.op,
+        params,
+        expected: c.expected,
+        assert,
+      });
+    });
+  });
+}

--- a/src/testing/kit/auth-permission/run-auth-matrix.ts
+++ b/src/testing/kit/auth-permission/run-auth-matrix.ts
@@ -6,7 +6,9 @@ import type { AuthMatrixCaseBase, Operation, Transport } from './types';
 export interface AuthMatrixBuild<TParams> {
   fixture: AuthActorFixture;
   params: TParams;
-  assert?: Partial<Record<Transport, (result: unknown) => void>>;
+  assert?: Partial<
+    Record<Transport, (result: unknown) => void | Promise<void>>
+  >;
 }
 
 export interface RunAuthMatrixConfig<

--- a/src/testing/kit/auth-permission/types.ts
+++ b/src/testing/kit/auth-permission/types.ts
@@ -1,0 +1,58 @@
+export type Transport = 'rest' | 'gql';
+
+/**
+ * Normalised outcome vocabulary the kit maps each transport's native error
+ * signal into:
+ *
+ *   REST:    401 → 'unauthorized' | 403 → 'forbidden' | 404 → 'not_found' | 2xx → 'allowed'
+ *   GraphQL: errors[0].extensions.code in { UNAUTHENTICATED, FORBIDDEN, NOT_FOUND }
+ *            or no errors → 'allowed'
+ *
+ * Tests never branch on transport — they describe *business* outcomes.
+ */
+export type Outcome = 'unauthorized' | 'forbidden' | 'not_found' | 'allowed';
+
+export type RestMethod = 'get' | 'post' | 'put' | 'patch' | 'delete';
+
+export type ActorRole = 'owner' | 'crossOwner' | 'anonymous';
+
+export interface GqlOperationShape<TParams> {
+  query: string;
+  variables: (params: TParams) => Record<string, unknown>;
+}
+
+export interface RestOperationShape<TParams> {
+  method: RestMethod;
+  url: (params: TParams) => string;
+  body?: (params: TParams) => unknown;
+  /**
+   * Query-string params for controllers using `@Query()` DTOs. Supertest
+   * serialises via `.query()`. Keep to `string | number | boolean`; nested
+   * objects fall outside NestJS's class-validator pipeline.
+   */
+  query?: (params: TParams) => Record<string, string | number | boolean>;
+}
+
+export interface Operation<TParams> {
+  id: string;
+  gql?: GqlOperationShape<TParams>;
+  rest?: RestOperationShape<TParams>;
+  transports: Transport[];
+}
+
+export interface ActorDescriptor {
+  token: string | null;
+  label?: string;
+}
+
+/**
+ * Common shape every auth-matrix case carries. Specs extend with extra
+ * columns (e.g. `project: 'private' | 'public'`) via intersection:
+ *
+ *   type Case = AuthMatrixCaseBase & { project: 'private' | 'public' };
+ */
+export interface AuthMatrixCaseBase {
+  name: string;
+  role: ActorRole;
+  expected: Outcome;
+}

--- a/src/testing/scenarios/given-file-schema-project.ts
+++ b/src/testing/scenarios/given-file-schema-project.ts
@@ -1,0 +1,108 @@
+import { INestApplication } from '@nestjs/common';
+import { nanoid } from 'nanoid';
+import { EngineApiService } from '@revisium/engine';
+import { SystemSchemaIds } from '@revisium/schema-toolkit/consts';
+import { getObjectSchema, getRefSchema } from '@revisium/schema-toolkit/mocks';
+import {
+  prepareData,
+  type PrepareDataReturnType,
+} from 'src/testing/utils/prepareProject';
+import { PrismaService } from 'src/infrastructure/database/prisma.service';
+import { makeEmptyFileData } from 'src/testing/factories/make-file-data';
+
+export interface FileSchemaProjectScenario extends PrepareDataReturnType {
+  fileTableId: string;
+  fileRowId: string;
+}
+
+export interface GivenFileSchemaProjectOptions {
+  /** Flip the project to `isPublic: true` after seeding. */
+  isPublic?: boolean;
+  /**
+   * Commit the draft after seeding. Produces a state where the file-schema
+   * table + row span two revisions (committed head + forked new draft) —
+   * useful for dedup / multi-version tests.
+   */
+  commit?: boolean;
+}
+
+/**
+ * Seeds a private project with a file-schema table (`{ file: $ref: File }`)
+ * containing a single row. Uses the engine's public CQRS API for all
+ * domain writes, so the setup exercises the same code paths production
+ * does — no hand-rolled `prismaService.table.create` / row-version wiring.
+ *
+ * Returns a superset of `PrepareDataReturnType` with the extra
+ * `fileTableId`, `fileRowId`, `fileData` fields that tests need.
+ */
+export async function givenFileSchemaProject(
+  app: INestApplication,
+  options: GivenFileSchemaProjectOptions = {},
+): Promise<FileSchemaProjectScenario> {
+  const engine = app.get(EngineApiService);
+  const prisma = app.get(PrismaService);
+
+  const base = await prepareData(app);
+
+  const fileSchema = getObjectSchema({
+    file: getRefSchema(SystemSchemaIds.File),
+  });
+  const fileTableId = `file-table-${nanoid()}`;
+  const fileRowId = `file-row-${nanoid()}`;
+
+  await engine.createTable({
+    revisionId: base.project.draftRevisionId,
+    tableId: fileTableId,
+    schema: fileSchema,
+  });
+
+  // File fields must be schema defaults on creation; the FilePlugin then
+  // populates `status=ready` + `fileId=<nanoid>` in its afterCreateRow hook.
+  await engine.createRow({
+    revisionId: base.project.draftRevisionId,
+    tableId: fileTableId,
+    rowId: fileRowId,
+    data: { file: { ...makeEmptyFileData() } },
+  });
+
+  let draftRevisionId = base.project.draftRevisionId;
+  let headRevisionId = base.project.headRevisionId;
+
+  if (options.commit) {
+    await engine.createRevision({
+      projectId: base.project.projectId,
+      branchName: base.project.branchName,
+    });
+    // After commit, a fresh draft is forked from the just-committed head.
+    // Engine's createRevision return value doesn't expose it directly; the
+    // authoritative state lives on the Revision table via isHead / isDraft.
+    const [newHead, newDraft] = await Promise.all([
+      prisma.revision.findFirstOrThrow({
+        where: { branchId: base.project.branchId, isHead: true },
+      }),
+      prisma.revision.findFirstOrThrow({
+        where: { branchId: base.project.branchId, isDraft: true },
+      }),
+    ]);
+    headRevisionId = newHead.id;
+    draftRevisionId = newDraft.id;
+  }
+
+  if (options.isPublic) {
+    await prisma.project.update({
+      where: { id: base.project.projectId },
+      data: { isPublic: true },
+    });
+  }
+
+  return {
+    ...base,
+    project: {
+      ...base.project,
+      draftRevisionId,
+      headRevisionId,
+    },
+    fileTableId,
+    fileRowId,
+  };
+}

--- a/src/testing/scenarios/given-file-schema-project.ts
+++ b/src/testing/scenarios/given-file-schema-project.ts
@@ -33,7 +33,11 @@ export interface GivenFileSchemaProjectOptions {
  * does — no hand-rolled `prismaService.table.create` / row-version wiring.
  *
  * Returns a superset of `PrepareDataReturnType` with the extra
- * `fileTableId`, `fileRowId`, `fileData` fields that tests need.
+ * `fileTableId` and `fileRowId` fields that tests need. Note that
+ * `PrepareDataReturnType.project` does not expose `isPublic`; the
+ * `options.isPublic` flag persists the change via Prisma but is not
+ * echoed back on the fixture object — consumers reading visibility
+ * should re-query the DB if they need to verify.
  */
 export async function givenFileSchemaProject(
   app: INestApplication,

--- a/src/testing/scenarios/given-project-pair.ts
+++ b/src/testing/scenarios/given-project-pair.ts
@@ -1,0 +1,30 @@
+import { INestApplication } from '@nestjs/common';
+import { PrismaService } from 'src/infrastructure/database/prisma.service';
+import {
+  prepareData,
+  type PrepareDataReturnType,
+} from 'src/testing/utils/prepareProject';
+
+export interface ProjectPairScenario {
+  private: PrepareDataReturnType;
+  public: PrepareDataReturnType;
+}
+
+/**
+ * Seeds two projects via `prepareData`, flips one to `isPublic: true`.
+ * Returns both, keyed by visibility, so auth matrices can reference
+ * `pair.private` / `pair.public` directly.
+ */
+export async function givenProjectPair(
+  app: INestApplication,
+): Promise<ProjectPairScenario> {
+  const [privateProject, publicProject] = await Promise.all([
+    prepareData(app),
+    prepareData(app),
+  ]);
+  await app.get(PrismaService).project.update({
+    where: { id: publicProject.project.projectId },
+    data: { isPublic: true },
+  });
+  return { private: privateProject, public: publicProject };
+}

--- a/src/testing/scenarios/given-standalone-user.ts
+++ b/src/testing/scenarios/given-standalone-user.ts
@@ -1,0 +1,23 @@
+import { nanoid } from 'nanoid';
+import { INestApplication } from '@nestjs/common';
+import { PrismaService } from 'src/infrastructure/database/prisma.service';
+import { testCreateUser } from 'src/testing/factories/create-models';
+
+export interface StandaloneUserScenario {
+  userId: string;
+}
+
+/**
+ * Creates a user with `systemUser` system role and no organization /
+ * project memberships. Used as a *target* for add-to-org / add-to-project
+ * auth matrices, where the operation's caller is the actor and the
+ * standalone user is who gets added.
+ */
+export async function givenStandaloneUser(
+  app: INestApplication,
+): Promise<StandaloneUserScenario> {
+  const prisma = app.get(PrismaService);
+  const userId = nanoid();
+  await testCreateUser(prisma, { id: userId });
+  return { userId };
+}

--- a/src/testing/scenarios/using-fresh-project.ts
+++ b/src/testing/scenarios/using-fresh-project.ts
@@ -1,0 +1,50 @@
+import { getTestApp } from 'src/testing/e2e';
+import {
+  prepareData,
+  type PrepareDataReturnType,
+} from 'src/testing/utils/prepareProject';
+
+export interface FreshProjectHandle {
+  /**
+   * Access the current fixture. Only safe to call inside `it` bodies
+   * (or `beforeEach` callbacks registered after this one); throws if
+   * accessed before the setup hook has run.
+   */
+  readonly fixture: PrepareDataReturnType;
+}
+
+/**
+ * Registers a `beforeEach` that seeds a fresh project via `prepareData`
+ * against the worker-cached app. Use in mutation auth specs where each
+ * case either deletes or mutates the project and must not see state from
+ * a sibling test.
+ *
+ * Must be called at describe scope — Jest's hook registration is
+ * lexical.
+ *
+ * Example:
+ *   describe('delete project auth', () => {
+ *     const fresh = usingFreshProject();
+ *     it('...', () => { fresh.fixture.project.projectName ... });
+ *   });
+ */
+export function usingFreshProject(): FreshProjectHandle {
+  let current: PrepareDataReturnType | null = null;
+
+  beforeEach(async () => {
+    const app = await getTestApp();
+    current = await prepareData(app);
+  });
+
+  return {
+    get fixture(): PrepareDataReturnType {
+      if (!current) {
+        throw new Error(
+          'usingFreshProject: fixture accessed before beforeEach ran. ' +
+            'Make sure the handle is consumed from inside it/beforeEach callbacks.',
+        );
+      }
+      return current;
+    },
+  };
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a declarative auth-permission test kit and 65 cross-transport (REST + GraphQL) auth e2e specs, plus a GraphQL exception filter that exposes consistent `extensions.code` for auth/not-found errors. Adds async-assert support and refines API key/org auth matrices to improve accuracy.

- **New Features**
  - Test kit (`src/testing/kit/auth-permission/*`): `operation`, `actors`, `expectAccess`, `runAuthMatrix`, reusable matrices (`PROJECT_MUTATION_MATRIX`, `PROJECT_VISIBILITY_MATRIX`, `PROJECT_PII_READ_MATRIX`).
  - 65 new auth e2e specs under `src/api/__tests__/` across organization, project, branch, revision, table, row, endpoint, api-key, admin, user, and configuration.
  - Scenarios/factories: `given-project-pair`, `using-fresh-project`, `given-standalone-user`, `given-file-schema-project`, `make-empty-file-data`.
  - `GraphQLHttpExceptionFilter` registered via `APP_FILTER`: maps NestJS `Unauthorized`/`Forbidden`/`NotFound` to `UNAUTHENTICATED`/`FORBIDDEN`/`NOT_FOUND` while preserving messages.
  - Kit refinements: `runAuthMatrix`/`expectAccess` now await async assert callbacks; API key specs seed real owner keys and add IDOR `not_found` coverage; `serviceApiKeys` uses explicit org-owner/cross-owner/anon cases; docs updated to match the shipped API.

- **Migration**
  - No breaking changes. GraphQL clients can branch on `errors[0].extensions.code` for auth/not-found outcomes; messages remain unchanged.

<sup>Written for commit b2f9bf64c32298f74aaa1ebfc79bc296abdc03e8. Summary will update on new commits. <a href="https://cubic.dev/pr/revisium/revisium-core/pull/507">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



