### PR TITLE
test: raise graphql/rest API coverage

### DIFF
--- a/src/api/__tests__/branch/branch-by-name-routes.auth.e2e.spec.ts
+++ b/src/api/__tests__/branch/branch-by-name-routes.auth.e2e.spec.ts
@@ -1,0 +1,67 @@
+import { INestApplication } from '@nestjs/common';
+import { getTestApp } from 'src/testing/e2e';
+import {
+  operation,
+  runAuthMatrix,
+  PROJECT_VISIBILITY_MATRIX,
+} from 'src/testing/kit/auth-permission';
+import {
+  givenProjectPair,
+  type ProjectPairScenario,
+} from 'src/testing/scenarios/given-project-pair';
+
+type BranchParams = {
+  organizationId: string;
+  projectName: string;
+  branchName: string;
+};
+
+const makeRestOp = (id: string, path: string, includeQuery = false) =>
+  operation<BranchParams>({
+    id,
+    rest: {
+      method: 'get',
+      url: ({ organizationId, projectName, branchName }) =>
+        `/api/organization/${organizationId}/projects/${projectName}/branches/${branchName}/${path}`,
+      ...(includeQuery ? { query: () => ({ first: 10 }) } : {}),
+    },
+  });
+
+const endpoints = {
+  touched: makeRestOp('branch.touched', 'touched'),
+  parentBranch: makeRestOp('branch.parentBranch', 'parent-branch'),
+  startRevision: makeRestOp('branch.startRevision', 'start-revision'),
+  headRevision: makeRestOp('branch.headRevision', 'head-revision'),
+  draftRevision: makeRestOp('branch.draftRevision', 'draft-revision'),
+  revisions: makeRestOp('branch.revisions', 'revisions', true),
+};
+
+describe('branch-by-name readonly routes auth', () => {
+  let app: INestApplication;
+  let projects: ProjectPairScenario;
+
+  beforeAll(async () => {
+    app = await getTestApp();
+    projects = await givenProjectPair(app);
+  });
+
+  for (const [label, op] of Object.entries(endpoints)) {
+    describe(label, () => {
+      runAuthMatrix({
+        op,
+        cases: PROJECT_VISIBILITY_MATRIX,
+        build: (c) => {
+          const fixture = projects[c.project];
+          return {
+            fixture,
+            params: {
+              organizationId: fixture.project.organizationId,
+              projectName: fixture.project.projectName,
+              branchName: fixture.project.branchName,
+            },
+          };
+        },
+      });
+    });
+  }
+});

--- a/src/api/__tests__/project/project-deep-query.spec.ts
+++ b/src/api/__tests__/project/project-deep-query.spec.ts
@@ -1,0 +1,124 @@
+import { INestApplication } from '@nestjs/common';
+import { gql } from 'src/testing/utils/gql';
+import { getTestApp } from 'src/testing/e2e';
+import {
+  operation,
+  runAuthMatrix,
+  PROJECT_VISIBILITY_MATRIX,
+} from 'src/testing/kit/auth-permission';
+import {
+  givenProjectPair,
+  type ProjectPairScenario,
+} from 'src/testing/scenarios/given-project-pair';
+
+type Params = { organizationId: string; projectName: string };
+
+const deepProject = operation<Params>({
+  id: 'project.deep',
+  gql: {
+    query: gql`
+      query deepProject($data: GetProjectInput!) {
+        project(data: $data) {
+          id
+          name
+          organization {
+            id
+            createdId
+          }
+          rootBranch {
+            id
+            name
+            parent {
+              branch {
+                id
+              }
+            }
+            project {
+              id
+            }
+            start {
+              id
+            }
+            head {
+              id
+            }
+            draft {
+              id
+            }
+            touched
+            revisions(data: { first: 5 }) {
+              totalCount
+              edges {
+                node {
+                  id
+                  parent {
+                    id
+                  }
+                  child {
+                    id
+                  }
+                  children {
+                    id
+                  }
+                  childBranches {
+                    branch {
+                      id
+                    }
+                  }
+                  branch {
+                    id
+                  }
+                  endpoints {
+                    id
+                    type
+                  }
+                  migrations
+                  tables(data: { first: 5 }) {
+                    totalCount
+                  }
+                  changes {
+                    totalChanges
+                  }
+                }
+              }
+            }
+          }
+          allBranches(data: { first: 5 }) {
+            totalCount
+            edges {
+              node {
+                id
+              }
+            }
+          }
+        }
+      }
+    `,
+    variables: (params) => ({ data: params }),
+  },
+});
+
+describe('project deep-query GraphQL resolvers', () => {
+  let app: INestApplication;
+  let projects: ProjectPairScenario;
+
+  beforeAll(async () => {
+    app = await getTestApp();
+    projects = await givenProjectPair(app);
+  });
+
+  runAuthMatrix({
+    op: deepProject,
+    cases: PROJECT_VISIBILITY_MATRIX,
+    build: (c) => {
+      const fixture = projects[c.project];
+      return {
+        fixture,
+        params: {
+          organizationId: fixture.project.organizationId,
+          projectName: fixture.project.projectName,
+        },
+      };
+    },
+  });
+});

--- a/src/api/__tests__/project/users-project.auth.e2e.spec.ts
+++ b/src/api/__tests__/project/users-project.auth.e2e.spec.ts
@@ -32,6 +32,10 @@ const usersProject = operation<UsersProjectParams>({
           edges {
             node {
               id
+              role {
+                id
+                name
+              }
             }
           }
         }

--- a/src/api/__tests__/row/patch-row.auth.e2e.spec.ts
+++ b/src/api/__tests__/row/patch-row.auth.e2e.spec.ts
@@ -1,0 +1,55 @@
+import { gql } from 'src/testing/utils/gql';
+import {
+  operation,
+  runAuthMatrix,
+  PROJECT_MUTATION_MATRIX,
+} from 'src/testing/kit/auth-permission';
+import { usingFreshProject } from 'src/testing/scenarios/using-fresh-project';
+
+type Patch = { op: 'replace'; path: string; value: unknown };
+type Params = {
+  revisionId: string;
+  tableId: string;
+  rowId: string;
+  patches: Patch[];
+};
+
+const patchRow = operation<Params>({
+  id: 'row.patch',
+  rest: {
+    method: 'patch',
+    url: ({ revisionId, tableId, rowId }) =>
+      `/api/revision/${revisionId}/tables/${tableId}/rows/${rowId}`,
+    body: ({ patches }) => ({ patches }),
+  },
+  gql: {
+    query: gql`
+      mutation patchRow($data: PatchRowInput!) {
+        patchRow(data: $data) {
+          row {
+            id
+          }
+        }
+      }
+    `,
+    variables: (params) => ({ data: params }),
+  },
+});
+
+describe('patch row auth', () => {
+  const fresh = usingFreshProject();
+
+  runAuthMatrix({
+    op: patchRow,
+    cases: PROJECT_MUTATION_MATRIX,
+    build: () => ({
+      fixture: fresh.fixture,
+      params: {
+        revisionId: fresh.fixture.project.draftRevisionId,
+        tableId: fresh.fixture.project.tableId,
+        rowId: fresh.fixture.project.rowId,
+        patches: [{ op: 'replace' as const, path: 'ver', value: 7 }],
+      },
+    }),
+  });
+});

--- a/src/api/__tests__/table/patch-rows.auth.e2e.spec.ts
+++ b/src/api/__tests__/table/patch-rows.auth.e2e.spec.ts
@@ -1,0 +1,60 @@
+import { gql } from 'src/testing/utils/gql';
+import {
+  operation,
+  runAuthMatrix,
+  PROJECT_MUTATION_MATRIX,
+} from 'src/testing/kit/auth-permission';
+import { usingFreshProject } from 'src/testing/scenarios/using-fresh-project';
+
+type Patch = { op: 'replace'; path: string; value: unknown };
+type Params = {
+  revisionId: string;
+  tableId: string;
+  rows: { rowId: string; patches: Patch[] }[];
+};
+
+const patchRows = operation<Params>({
+  id: 'table.patchRows',
+  rest: {
+    method: 'patch',
+    url: ({ revisionId, tableId }) =>
+      `/api/revision/${revisionId}/tables/${tableId}/patch-rows`,
+    body: ({ rows }) => ({ rows }),
+  },
+  gql: {
+    query: gql`
+      mutation patchRows($data: PatchRowsInput!) {
+        patchRows(data: $data) {
+          rows {
+            id
+          }
+        }
+      }
+    `,
+    variables: ({ revisionId, tableId, rows }) => ({
+      data: { revisionId, tableId, rows },
+    }),
+  },
+});
+
+describe('patch rows auth', () => {
+  const fresh = usingFreshProject();
+
+  runAuthMatrix({
+    op: patchRows,
+    cases: PROJECT_MUTATION_MATRIX,
+    build: () => ({
+      fixture: fresh.fixture,
+      params: {
+        revisionId: fresh.fixture.project.draftRevisionId,
+        tableId: fresh.fixture.project.tableId,
+        rows: [
+          {
+            rowId: fresh.fixture.project.rowId,
+            patches: [{ op: 'replace' as const, path: 'ver', value: 13 }],
+          },
+        ],
+      },
+    }),
+  });
+});

--- a/src/api/__tests__/table/table-deep-query.spec.ts
+++ b/src/api/__tests__/table/table-deep-query.spec.ts
@@ -1,0 +1,95 @@
+import { INestApplication } from '@nestjs/common';
+import { gql } from 'src/testing/utils/gql';
+import { getTestApp } from 'src/testing/e2e';
+import {
+  operation,
+  runAuthMatrix,
+  PROJECT_VISIBILITY_MATRIX,
+} from 'src/testing/kit/auth-permission';
+import {
+  givenProjectPair,
+  type ProjectPairScenario,
+} from 'src/testing/scenarios/given-project-pair';
+
+type Params = {
+  revisionId: string;
+  tableId: string;
+  rowId: string;
+  fkTableId: string;
+};
+
+const deepTable = operation<Params>({
+  id: 'table.deep',
+  gql: {
+    query: gql`
+      query deepTable(
+        $data: GetTableInput!
+        $rowData: GetRowInput!
+        $rowFk: GetRowForeignKeysInput!
+      ) {
+        table(data: $data) {
+          id
+          count
+          schema
+          countForeignKeysTo
+          countForeignKeysBy
+          foreignKeysTo(data: { first: 5 }) {
+            totalCount
+          }
+          foreignKeysBy(data: { first: 5 }) {
+            totalCount
+          }
+          views {
+            version
+            defaultViewId
+          }
+          rows(data: { first: 5 }) {
+            totalCount
+          }
+        }
+        row(data: $rowData) {
+          id
+          countForeignKeysTo
+          rowForeignKeysBy(data: $rowFk) {
+            totalCount
+          }
+          rowForeignKeysTo(data: $rowFk) {
+            totalCount
+          }
+        }
+      }
+    `,
+    variables: ({ revisionId, tableId, rowId, fkTableId }) => ({
+      data: { revisionId, tableId },
+      rowData: { revisionId, tableId, rowId },
+      rowFk: { foreignKeyTableId: fkTableId, first: 5 },
+    }),
+  },
+});
+
+describe('table deep-query GraphQL resolvers', () => {
+  let app: INestApplication;
+  let projects: ProjectPairScenario;
+
+  beforeAll(async () => {
+    app = await getTestApp();
+    projects = await givenProjectPair(app);
+  });
+
+  runAuthMatrix({
+    op: deepTable,
+    cases: PROJECT_VISIBILITY_MATRIX,
+    build: (c) => {
+      const fixture = projects[c.project];
+      return {
+        fixture,
+        params: {
+          revisionId: fixture.project.draftRevisionId,
+          tableId: fixture.project.tableId,
+          rowId: fixture.project.rowId,
+          fkTableId: fixture.project.tableId,
+        },
+      };
+    },
+  });
+});

--- a/src/api/__tests__/table/table-deep-query.spec.ts
+++ b/src/api/__tests__/table/table-deep-query.spec.ts
@@ -87,6 +87,9 @@ describe('table deep-query GraphQL resolvers', () => {
           revisionId: fixture.project.draftRevisionId,
           tableId: fixture.project.tableId,
           rowId: fixture.project.rowId,
+          // No related table in the default fixture; the goal here is to
+          // exercise the FK resolver's auth path + happy-path execution, not
+          // cross-table FK resolution. Returns totalCount: 0, which is fine.
           fkTableId: fixture.project.tableId,
         },
       };

--- a/src/api/__tests__/user/me.auth.e2e.spec.ts
+++ b/src/api/__tests__/user/me.auth.e2e.spec.ts
@@ -19,6 +19,11 @@ const me = operation<Record<string, never>>({
         me {
           id
           username
+          organizationId
+          role {
+            id
+            name
+          }
         }
       }
     `,

--- a/src/api/__tests__/user/user-mutations.spec.ts
+++ b/src/api/__tests__/user/user-mutations.spec.ts
@@ -1,0 +1,116 @@
+import { INestApplication } from '@nestjs/common';
+import { nanoid } from 'nanoid';
+import { AuthService } from 'src/features/auth/auth.service';
+import { UserSystemRoles } from 'src/features/auth/consts';
+import { PrismaService } from 'src/infrastructure/database/prisma.service';
+import { gql } from 'src/testing/utils/gql';
+import { getTestApp } from 'src/testing/e2e';
+import {
+  actors,
+  expectAccess,
+  operation,
+  type ActorDescriptor,
+} from 'src/testing/kit/auth-permission';
+import { usingFreshProject } from 'src/testing/scenarios/using-fresh-project';
+
+const updatePassword = operation<{
+  oldPassword: string;
+  newPassword: string;
+}>({
+  id: 'user.updatePassword',
+  gql: {
+    query: gql`
+      mutation updatePassword($data: UpdatePasswordInput!) {
+        updatePassword(data: $data)
+      }
+    `,
+    variables: (params) => ({ data: params }),
+  },
+});
+
+const setUsername = operation<{ username: string }>({
+  id: 'user.setUsername',
+  gql: {
+    query: gql`
+      mutation setUsername($data: SetUsernameInput!) {
+        setUsername(data: $data)
+      }
+    `,
+    variables: (params) => ({ data: params }),
+  },
+});
+
+const resetPassword = operation<{ userId: string; newPassword: string }>({
+  id: 'user.resetPassword',
+  gql: {
+    query: gql`
+      mutation resetPassword($data: ResetPasswordInput!) {
+        resetPassword(data: $data)
+      }
+    `,
+    variables: (params) => ({ data: params }),
+  },
+});
+
+describe('user mutations resolver coverage', () => {
+  const fresh = usingFreshProject();
+  let app: INestApplication;
+  let admin: ActorDescriptor;
+
+  beforeEach(async () => {
+    app = await getTestApp();
+    admin = await actors.admin(app);
+  });
+
+  it('updatePassword: authenticated user rotates own password', async () => {
+    await expectAccess({
+      app,
+      transport: 'gql',
+      actor: actors.owner(fresh.fixture),
+      op: updatePassword,
+      params: { oldPassword: 'password', newPassword: `pwd-${nanoid()}` },
+      expected: 'allowed',
+    });
+  });
+
+  it('setUsername: user without a username claims a fresh one', async () => {
+    const prisma = app.get(PrismaService);
+    const auth = app.get(AuthService);
+    const unnamedId = nanoid();
+    await prisma.user.create({
+      data: {
+        id: unnamedId,
+        username: null,
+        email: `${unnamedId}@example.com`,
+        password: '',
+        role: { connect: { id: UserSystemRoles.systemUser } },
+      },
+    });
+    const token = auth.login({ username: '', sub: unnamedId });
+
+    await expectAccess({
+      app,
+      transport: 'gql',
+      actor: { token, label: 'unnamed' },
+      op: setUsername,
+      params: {
+        username: `u${Math.random().toString(36).slice(2, 12)}${Date.now().toString(36)}`,
+      },
+      expected: 'allowed',
+    });
+  });
+
+  it('resetPassword: admin resets an arbitrary user', async () => {
+    await expectAccess({
+      app,
+      transport: 'gql',
+      actor: admin,
+      op: resetPassword,
+      params: {
+        userId: fresh.fixture.owner.user.id,
+        newPassword: `reset-${nanoid()}`,
+      },
+      expected: 'allowed',
+    });
+  });
+});

--- a/src/api/__tests__/user/user-mutations.spec.ts
+++ b/src/api/__tests__/user/user-mutations.spec.ts
@@ -12,6 +12,7 @@ import {
   type ActorDescriptor,
 } from 'src/testing/kit/auth-permission';
 import { usingFreshProject } from 'src/testing/scenarios/using-fresh-project';
+import { testPlaintextPassword } from 'src/testing/utils/prepareProject';
 
 const updatePassword = operation<{
   oldPassword: string;
@@ -56,61 +57,137 @@ describe('user mutations resolver coverage', () => {
   const fresh = usingFreshProject();
   let app: INestApplication;
   let admin: ActorDescriptor;
+  const pendingUserIds: string[] = [];
 
   beforeEach(async () => {
     app = await getTestApp();
     admin = await actors.admin(app);
   });
 
-  it('updatePassword: authenticated user rotates own password', async () => {
-    await expectAccess({
-      app,
-      transport: 'gql',
-      actor: actors.owner(fresh.fixture),
-      op: updatePassword,
-      params: { oldPassword: 'password', newPassword: `pwd-${nanoid()}` },
-      expected: 'allowed',
-    });
-  });
-
-  it('setUsername: user without a username claims a fresh one', async () => {
+  afterEach(async () => {
+    if (pendingUserIds.length === 0) {
+      return;
+    }
     const prisma = app.get(PrismaService);
-    const auth = app.get(AuthService);
-    const unnamedId = nanoid();
-    await prisma.user.create({
-      data: {
-        id: unnamedId,
-        username: null,
-        email: `${unnamedId}@example.com`,
-        password: '',
-        role: { connect: { id: UserSystemRoles.systemUser } },
-      },
+    await prisma.userOrganization.deleteMany({
+      where: { userId: { in: pendingUserIds } },
     });
-    const token = auth.login({ username: '', sub: unnamedId });
+    await prisma.user.deleteMany({ where: { id: { in: pendingUserIds } } });
+    pendingUserIds.length = 0;
+  });
 
-    await expectAccess({
-      app,
-      transport: 'gql',
-      actor: { token, label: 'unnamed' },
-      op: setUsername,
-      params: {
-        username: `u${Math.random().toString(36).slice(2, 12)}${Date.now().toString(36)}`,
-      },
-      expected: 'allowed',
+  describe('updatePassword', () => {
+    it('authenticated user rotates own password', async () => {
+      await expectAccess({
+        app,
+        transport: 'gql',
+        actor: actors.owner(fresh.fixture),
+        op: updatePassword,
+        params: {
+          oldPassword: testPlaintextPassword,
+          newPassword: `pwd-${nanoid()}`,
+        },
+        expected: 'allowed',
+      });
+    });
+
+    it('anonymous rejected as unauthorized', async () => {
+      await expectAccess({
+        app,
+        transport: 'gql',
+        actor: actors.anonymous(),
+        op: updatePassword,
+        params: {
+          oldPassword: testPlaintextPassword,
+          newPassword: `pwd-${nanoid()}`,
+        },
+        expected: 'unauthorized',
+      });
     });
   });
 
-  it('resetPassword: admin resets an arbitrary user', async () => {
-    await expectAccess({
-      app,
-      transport: 'gql',
-      actor: admin,
-      op: resetPassword,
-      params: {
-        userId: fresh.fixture.owner.user.id,
-        newPassword: `reset-${nanoid()}`,
-      },
-      expected: 'allowed',
+  describe('setUsername', () => {
+    it('user without a username claims a fresh one', async () => {
+      const prisma = app.get(PrismaService);
+      const auth = app.get(AuthService);
+      const unnamedId = nanoid();
+      pendingUserIds.push(unnamedId);
+      await prisma.user.create({
+        data: {
+          id: unnamedId,
+          username: null,
+          email: `${unnamedId}@example.com`,
+          password: '',
+          role: { connect: { id: UserSystemRoles.systemUser } },
+        },
+      });
+      const token = auth.login({ username: '', sub: unnamedId });
+
+      await expectAccess({
+        app,
+        transport: 'gql',
+        actor: { token, label: 'unnamed' },
+        op: setUsername,
+        params: {
+          username: `u${Math.random().toString(36).slice(2, 12)}${Date.now().toString(36)}`,
+        },
+        expected: 'allowed',
+      });
+    });
+
+    it('anonymous rejected as unauthorized', async () => {
+      await expectAccess({
+        app,
+        transport: 'gql',
+        actor: actors.anonymous(),
+        op: setUsername,
+        params: { username: `u${nanoid(10)}` },
+        expected: 'unauthorized',
+      });
+    });
+  });
+
+  describe('resetPassword', () => {
+    it('admin resets an arbitrary user', async () => {
+      await expectAccess({
+        app,
+        transport: 'gql',
+        actor: admin,
+        op: resetPassword,
+        params: {
+          userId: fresh.fixture.owner.user.id,
+          newPassword: `reset-${nanoid()}`,
+        },
+        expected: 'allowed',
+      });
+    });
+
+    it('non-admin authenticated actor rejected as forbidden', async () => {
+      await expectAccess({
+        app,
+        transport: 'gql',
+        actor: actors.owner(fresh.fixture),
+        op: resetPassword,
+        params: {
+          userId: fresh.fixture.owner.user.id,
+          newPassword: `reset-${nanoid()}`,
+        },
+        expected: 'forbidden',
+      });
+    });
+
+    it('anonymous rejected as unauthorized', async () => {
+      await expectAccess({
+        app,
+        transport: 'gql',
+        actor: actors.anonymous(),
+        op: resetPassword,
+        params: {
+          userId: fresh.fixture.owner.user.id,
+          newPassword: `reset-${nanoid()}`,
+        },
+        expected: 'unauthorized',
+      });
     });
   });
 });

--- a/src/api/mcp-api/__tests__/mcp-uri.spec.ts
+++ b/src/api/mcp-api/__tests__/mcp-uri.spec.ts
@@ -151,6 +151,42 @@ describe('MCP URI parameter', () => {
       const content = JSON.parse(data.result.content[0].text);
       expect(typeof content.count).toBe('number');
     });
+
+    it('get_table with URI works', async () => {
+      const data = await callTool(app, token, 'get_table', {
+        uri: shortUri(),
+        tableId: fixture.project.tableId,
+      });
+
+      expect(data.result.isError).toBeFalsy();
+      const content = JSON.parse(data.result.content[0].text);
+      expect(content.id).toBe(fixture.project.tableId);
+    });
+
+    it('get_table_schema with URI works', async () => {
+      const data = await callTool(app, token, 'get_table_schema', {
+        uri: shortUri(),
+        tableId: fixture.project.tableId,
+      });
+
+      expect(data.result.isError).toBeFalsy();
+    });
+
+    it('get_table_changes with URI works', async () => {
+      const data = await callTool(app, token, 'get_table_changes', {
+        uri: shortUri(),
+      });
+
+      expect(data.result.isError).toBeFalsy();
+    });
+
+    it('get_row_changes with URI works', async () => {
+      const data = await callTool(app, token, 'get_row_changes', {
+        uri: shortUri(),
+      });
+
+      expect(data.result.isError).toBeFalsy();
+    });
   });
 
   describe('read tools with full URI', () => {

--- a/src/api/mcp-api/__tests__/mcp-uri.spec.ts
+++ b/src/api/mcp-api/__tests__/mcp-uri.spec.ts
@@ -170,6 +170,8 @@ describe('MCP URI parameter', () => {
       });
 
       expect(data.result.isError).toBeFalsy();
+      const content = JSON.parse(data.result.content[0].text);
+      expect(content.type || content.properties).toBeDefined();
     });
 
     it('get_table_changes with URI works', async () => {
@@ -178,6 +180,8 @@ describe('MCP URI parameter', () => {
       });
 
       expect(data.result.isError).toBeFalsy();
+      const content = JSON.parse(data.result.content[0].text);
+      expect(Array.isArray(content.edges)).toBe(true);
     });
 
     it('get_row_changes with URI works', async () => {
@@ -186,6 +190,8 @@ describe('MCP URI parameter', () => {
       });
 
       expect(data.result.isError).toBeFalsy();
+      const content = JSON.parse(data.result.content[0].text);
+      expect(Array.isArray(content.edges)).toBe(true);
     });
   });
 

--- a/src/testing/utils/prepareProject.ts
+++ b/src/testing/utils/prepareProject.ts
@@ -45,6 +45,7 @@ const resolvePrisma = (source: PrismaOrContainer): PrismaService => {
   return source as PrismaService;
 };
 
+export const testPlaintextPassword = 'password';
 export const hashedPassword =
   '$2a$10$Uj1aVmkVJh4ZV9Ij54bFLexeFcYz71QtySoosQ5V.txpETjOgG0bW';
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Increase GraphQL and REST API test coverage across deep resolver fields, branch-by-name routes, patch mutations, user mutations, and MCP tools via URI. Expands auth matrices, adds negative-path checks, and validates minimal payload shapes.

- **Test Coverage**
  - Branch-by-name REST routes: `touched`, `parent-branch`, `start/head/draft-revision`, `revisions` (auth matrix).
  - Deep GraphQL queries for project and table to hit nested ResolveField paths and totals.
  - Row mutations: `patchRow` and `patchRows` via REST and GraphQL with mutation auth checks.
  - User mutations: `updatePassword`, `setUsername` (unnamed user flow), `resetPassword` (admin-only), including unauthorized/forbidden cases and test cleanup.
  - Extended fields in `me` and users-in-project queries to cover `organizationId` and `role`.
  - MCP tools with URI: `get_table`, `get_table_schema`, `get_table_changes`, `get_row_changes` with minimal payload shape assertions.

<sup>Written for commit e79be5e77a2c7bd0ecdd2e5247c2dfccb4b9fb58. Summary will update on new commits. <a href="https://cubic.dev/pr/revisium/revisium-core/pull/510">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

