### PR TITLE
ci: release train workflow with verified bot commits

### DIFF
--- a/.github/scripts/create-github-app-commit.mjs
+++ b/.github/scripts/create-github-app-commit.mjs
@@ -1,0 +1,106 @@
+import fs from 'node:fs';
+
+const apiVersion = '2022-11-28';
+
+function requiredEnv(name) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`${name} is required`);
+  }
+  return value;
+}
+
+function optionalEnv(name, fallback = '') {
+  return process.env[name] || fallback;
+}
+
+function appendOutput(name, value) {
+  if (!process.env.GITHUB_OUTPUT) return;
+  fs.appendFileSync(process.env.GITHUB_OUTPUT, `${name}=${value}\n`);
+}
+
+async function github(method, path, body) {
+  const repo = requiredEnv('GITHUB_REPOSITORY');
+  const token = requiredEnv('GH_TOKEN');
+  const response = await fetch(`https://api.github.com/repos/${repo}${path}`, {
+    method,
+    headers: {
+      accept: 'application/vnd.github+json',
+      authorization: `Bearer ${token}`,
+      'content-type': 'application/json',
+      'x-github-api-version': apiVersion,
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+
+  const text = await response.text();
+  if (!response.ok) {
+    throw new Error(`${method} ${path} failed with ${response.status}: ${text}`);
+  }
+
+  return text ? JSON.parse(text) : null;
+}
+
+function commitFiles() {
+  const files = requiredEnv('COMMIT_FILES')
+    .split(/\r?\n/)
+    .map((file) => file.trim())
+    .filter(Boolean);
+
+  if (files.length === 0) {
+    throw new Error('COMMIT_FILES must contain at least one path');
+  }
+
+  return files.map((path) => ({
+    path,
+    mode: '100644',
+    type: 'blob',
+    content: fs.readFileSync(path, 'utf8'),
+  }));
+}
+
+const baseSha = requiredEnv('BASE_SHA');
+const targetBranch = requiredEnv('TARGET_BRANCH');
+const refMode = requiredEnv('REF_MODE');
+const message = requiredEnv('COMMIT_MESSAGE');
+
+if (!['create', 'update'].includes(refMode)) {
+  throw new Error(`REF_MODE must be create or update, got ${refMode}`);
+}
+
+const baseCommit = await github('GET', `/git/commits/${baseSha}`);
+const tree = await github('POST', '/git/trees', {
+  base_tree: baseCommit.tree.sha,
+  tree: commitFiles(),
+});
+
+const commit = await github('POST', '/git/commits', {
+  message,
+  tree: tree.sha,
+  parents: [baseSha],
+});
+
+if (!commit.verification?.verified) {
+  const reason = commit.verification?.reason || 'unknown';
+  throw new Error(`GitHub did not verify the release bot commit (${reason})`);
+}
+
+const ref = `refs/heads/${targetBranch}`;
+if (refMode === 'create') {
+  await github('POST', '/git/refs', {
+    ref,
+    sha: commit.sha,
+  });
+} else {
+  await github('PATCH', `/git/refs/heads/${targetBranch}`, {
+    sha: commit.sha,
+    force: false,
+  });
+}
+
+appendOutput('commit_sha', commit.sha);
+appendOutput('verification_reason', commit.verification.reason || '');
+
+console.log(`Created verified GitHub App commit ${commit.sha} on ${ref}`);
+console.log(`Verification reason: ${commit.verification.reason || 'unknown'}`);
+console.log(optionalEnv('COMMIT_SUMMARY'));

--- a/.github/scripts/create-github-app-commit.mjs
+++ b/.github/scripts/create-github-app-commit.mjs
@@ -102,7 +102,7 @@ async function updateRef(refMode, targetBranch, commitSha) {
       });
       return ref;
     } catch (error) {
-      const retryable = error instanceof GitHubError && error.status === 409;
+      const retryable = error instanceof GitHubError && error.status >= 500 && error.status < 600;
       if (!retryable || attempt === maxAttempts) {
         throw error;
       }

--- a/.github/scripts/create-github-app-commit.mjs
+++ b/.github/scripts/create-github-app-commit.mjs
@@ -2,6 +2,15 @@ import fs from 'node:fs';
 
 const apiVersion = '2022-11-28';
 
+class GitHubError extends Error {
+  constructor(message, status, responseBody) {
+    super(message);
+    this.name = 'GitHubError';
+    this.status = status;
+    this.responseBody = responseBody;
+  }
+}
+
 function requiredEnv(name) {
   const value = process.env[name];
   if (!value) {
@@ -35,13 +44,17 @@ async function github(method, path, body) {
 
   const text = await response.text();
   if (!response.ok) {
-    throw new Error(`${method} ${path} failed with ${response.status}: ${text}`);
+    throw new GitHubError(`${method} ${path} failed with ${response.status}: ${text}`, response.status, text);
   }
 
   return text ? JSON.parse(text) : null;
 }
 
-function commitFiles() {
+async function sleep(ms) {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function commitFiles() {
   const files = requiredEnv('COMMIT_FILES')
     .split(/\r?\n/)
     .map((file) => file.trim())
@@ -51,12 +64,56 @@ function commitFiles() {
     throw new Error('COMMIT_FILES must contain at least one path');
   }
 
-  return files.map((path) => ({
-    path,
-    mode: '100644',
-    type: 'blob',
-    content: fs.readFileSync(path, 'utf8'),
-  }));
+  const entries = [];
+  for (const path of files) {
+    const blob = await github('POST', '/git/blobs', {
+      content: fs.readFileSync(path, 'utf8'),
+      encoding: 'utf-8',
+    });
+
+    entries.push({
+      path,
+      mode: '100644',
+      type: 'blob',
+      sha: blob.sha,
+    });
+  }
+
+  return entries;
+}
+
+async function updateRef(refMode, targetBranch, commitSha) {
+  const ref = `refs/heads/${targetBranch}`;
+
+  if (refMode === 'create') {
+    await github('POST', '/git/refs', {
+      ref,
+      sha: commitSha,
+    });
+    return ref;
+  }
+
+  const maxAttempts = Number(optionalEnv('REF_UPDATE_ATTEMPTS', '3'));
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      await github('PATCH', `/git/refs/heads/${targetBranch}`, {
+        sha: commitSha,
+        force: false,
+      });
+      return ref;
+    } catch (error) {
+      const retryable = error instanceof GitHubError && error.status === 409;
+      if (!retryable || attempt === maxAttempts) {
+        throw error;
+      }
+
+      const delay = attempt * 1000;
+      console.warn(`Ref update failed with ${error.status}; retrying in ${delay}ms (${attempt}/${maxAttempts})`);
+      await sleep(delay);
+    }
+  }
+
+  throw new Error(`Failed to update ${ref}`);
 }
 
 const baseSha = requiredEnv('BASE_SHA');
@@ -71,7 +128,7 @@ if (!['create', 'update'].includes(refMode)) {
 const baseCommit = await github('GET', `/git/commits/${baseSha}`);
 const tree = await github('POST', '/git/trees', {
   base_tree: baseCommit.tree.sha,
-  tree: commitFiles(),
+  tree: await commitFiles(),
 });
 
 const commit = await github('POST', '/git/commits', {
@@ -85,22 +142,15 @@ if (!commit.verification?.verified) {
   throw new Error(`GitHub did not verify the release bot commit (${reason})`);
 }
 
-const ref = `refs/heads/${targetBranch}`;
-if (refMode === 'create') {
-  await github('POST', '/git/refs', {
-    ref,
-    sha: commit.sha,
-  });
-} else {
-  await github('PATCH', `/git/refs/heads/${targetBranch}`, {
-    sha: commit.sha,
-    force: false,
-  });
-}
+const ref = await updateRef(refMode, targetBranch, commit.sha);
 
 appendOutput('commit_sha', commit.sha);
 appendOutput('verification_reason', commit.verification.reason || '');
+appendOutput('branch_ref', ref);
 
 console.log(`Created verified GitHub App commit ${commit.sha} on ${ref}`);
 console.log(`Verification reason: ${commit.verification.reason || 'unknown'}`);
-console.log(optionalEnv('COMMIT_SUMMARY'));
+const summary = optionalEnv('COMMIT_SUMMARY');
+if (summary) {
+  console.log(summary);
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,11 @@ jobs:
         uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f #docker/metadata-action@v5
         with:
           images: ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ github.ref_type == 'tag' && !contains(github.ref_name, '-') }}
+            type=raw,value=latest,enable=${{ github.ref_type == 'tag' && !contains(github.ref_name, '-') }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 #docker/build-push-action@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,13 @@ permissions:
 
 on:
   push:
-    branches: [master]
+    branches:
+      - master
+      - 'release/**'
   pull_request:
-    branches: [master]
+    branches:
+      - master
+      - 'release/**'
 
 jobs:
   checks:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -35,7 +35,9 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_ENV"
 
       - name: Install dependencies
-        run: npm ci
+        run: |
+          npm ci --ignore-scripts --prefer-offline --no-audit --no-fund
+          npm rebuild bcrypt sharp @swc/core @prisma/engines prisma
 
       - name: Validate package and lockfile versions
         run: |

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,34 +1,120 @@
 name: Publish Package to npmjs
+
 on:
-  workflow_dispatch:
-  release:
-    types: [published]
+  push:
+    tags:
+      - 'v*'
+
 jobs:
-  build:
+  publish:
     runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
         with:
           node-version: 24.11.1
           registry-url: 'https://registry.npmjs.org'
-      - run: npm ci
+
+      - name: Validate tag format
+        run: |
+          TAG=${GITHUB_REF#refs/tags/}
+          echo "Publishing for tag: $TAG"
+
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-(alpha|rc)\.[0-9]+)?$ ]]; then
+            echo "Invalid tag format: $TAG (expected vX.Y.Z, vX.Y.Z-alpha.N, or vX.Y.Z-rc.N)"
+            exit 1
+          fi
+
+          VERSION=${TAG#v}
+          echo "version=$VERSION" >> "$GITHUB_ENV"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Validate package and lockfile versions
+        run: |
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          LOCK_VERSION=$(node -p "require('./package-lock.json').version")
+          LOCK_ROOT_VERSION=$(node -p "require('./package-lock.json').packages[''].version")
+
+          echo "package.json version: $PACKAGE_VERSION"
+          echo "package-lock.json version: $LOCK_VERSION"
+          echo "package-lock root version: $LOCK_ROOT_VERSION"
+          echo "tag version: ${{ env.version }}"
+
+          if [[ "$PACKAGE_VERSION" != "${{ env.version }}" ]]; then
+            echo "Version mismatch: package.json ($PACKAGE_VERSION) != tag (${{ env.version }})"
+            exit 1
+          fi
+
+          if [[ "$LOCK_VERSION" != "${{ env.version }}" || "$LOCK_ROOT_VERSION" != "${{ env.version }}" ]]; then
+            echo "Version mismatch: package-lock.json does not match tag ${{ env.version }}"
+            exit 1
+          fi
+
+      - name: Ensure stable releases do not depend on prereleases
+        if: ${{ !contains(env.version, '-') }}
+        run: |
+          node <<'NODE'
+          const pkg = require('./package.json');
+          const sections = ['dependencies', 'peerDependencies', 'optionalDependencies', 'bundledDependencies', 'bundleDependencies'];
+          const prereleasePattern = /-(alpha|beta|rc)\./;
+          const violations = [];
+
+          for (const section of sections) {
+            const deps = pkg[section];
+            if (!deps) continue;
+
+            if (Array.isArray(deps)) {
+              for (const dep of deps) {
+                if (prereleasePattern.test(dep)) violations.push(`${section}: ${dep}`);
+              }
+              continue;
+            }
+
+            for (const [name, version] of Object.entries(deps)) {
+              if (prereleasePattern.test(String(version))) {
+                violations.push(`${section}: ${name}@${version}`);
+              }
+            }
+          }
+
+          if (violations.length > 0) {
+            console.error('Stable releases cannot depend on prerelease runtime dependencies:');
+            for (const violation of violations) console.error(`- ${violation}`);
+            process.exit(1);
+          }
+          NODE
+
+      - name: Ensure npm version does not already exist
+        run: |
+          PACKAGE_NAME=$(node -p "require('./package.json').name")
+          PUBLISHED_VERSION=$(npm view "$PACKAGE_NAME@${{ env.version }}" version 2>/dev/null || true)
+
+          if [[ -n "$PUBLISHED_VERSION" ]]; then
+            echo "$PACKAGE_NAME@${{ env.version }} is already published"
+            exit 1
+          fi
+
       - name: Determine npm tag
         id: npm-tag
         run: |
-          VERSION=$(node -p "require('./package.json').version")
+          VERSION=${{ env.version }}
           if [[ "$VERSION" =~ -alpha ]]; then
             echo "tag=alpha" >> $GITHUB_OUTPUT
-          elif [[ "$VERSION" =~ -beta ]]; then
-            echo "tag=beta" >> $GITHUB_OUTPUT
           elif [[ "$VERSION" =~ -rc ]]; then
             echo "tag=rc" >> $GITHUB_OUTPUT
           else
             echo "tag=latest" >> $GITHUB_OUTPUT
           fi
-      - run: npm publish --provenance --access public --tag ${{ steps.npm-tag.outputs.tag }}
+
+      - name: Publish to npm
+        run: npm publish --provenance --access public --tag ${{ steps.npm-tag.outputs.tag }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -42,10 +42,12 @@ jobs:
           PACKAGE_VERSION=$(node -p "require('./package.json').version")
           LOCK_VERSION=$(node -p "require('./package-lock.json').version")
           LOCK_ROOT_VERSION=$(node -p "require('./package-lock.json').packages[''].version")
+          OPENAPI_VERSION=$(node -p "require('./src/api/rest-api/openapi.json').info.version")
 
           echo "package.json version: $PACKAGE_VERSION"
           echo "package-lock.json version: $LOCK_VERSION"
           echo "package-lock root version: $LOCK_ROOT_VERSION"
+          echo "OpenAPI version: $OPENAPI_VERSION"
           echo "tag version: ${{ env.version }}"
 
           if [[ "$PACKAGE_VERSION" != "${{ env.version }}" ]]; then
@@ -55,6 +57,11 @@ jobs:
 
           if [[ "$LOCK_VERSION" != "${{ env.version }}" || "$LOCK_ROOT_VERSION" != "${{ env.version }}" ]]; then
             echo "Version mismatch: package-lock.json does not match tag ${{ env.version }}"
+            exit 1
+          fi
+
+          if [[ "$OPENAPI_VERSION" != "${{ env.version }}" ]]; then
+            echo "Version mismatch: OpenAPI ($OPENAPI_VERSION) != tag (${{ env.version }})"
             exit 1
           fi
 
@@ -88,6 +95,7 @@ jobs:
           if (violations.length > 0) {
             console.error('Stable releases cannot depend on prerelease runtime dependencies:');
             for (const violation of violations) console.error(`- ${violation}`);
+            console.error('Release stable dependency versions first, or publish this package as a prerelease.');
             process.exit(1);
           }
           NODE

--- a/.github/workflows/release-train.yml
+++ b/.github/workflows/release-train.yml
@@ -331,6 +331,17 @@ jobs:
             exit 1
           fi
 
+          while IFS= read -r FILE; do
+            [[ -z "$FILE" ]] && continue
+            case "$FILE" in
+              package.json|package-lock.json|src/api/rest-api/openapi.json) ;;
+              *)
+                echo "Release commit may not change $FILE"
+                exit 1
+                ;;
+            esac
+          done <<< "$(git diff --name-only)"
+
           if git diff --quiet; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/release-train.yml
+++ b/.github/workflows/release-train.yml
@@ -289,6 +289,7 @@ jobs:
           if (violations.length > 0) {
             console.error('Stable releases cannot depend on prerelease runtime dependencies:');
             for (const violation of violations) console.error(`- ${violation}`);
+            console.error('Release stable dependency versions first, or publish this package as a prerelease.');
             process.exit(1);
           }
           NODE
@@ -326,6 +327,27 @@ jobs:
 
       - name: Install dependencies
         run: npm ci --ignore-scripts --prefer-offline --no-audit --no-fund
+
+      - name: Rebuild native dependencies
+        run: npm rebuild bcrypt sharp @swc/core @prisma/engines prisma
+
+      - name: Create test .env
+        run: cp .env.example .env
+
+      - name: Start test services
+        run: docker compose -f docker-compose-test.yml -p revisium-core-test up -d --wait
+
+      - name: Run release validation
+        run: |
+          npm run lint:ci
+          npm run tsc
+          npx dotenv-cli -e .env.test -- npm run prisma:migrate:deploy
+          npx dotenv-cli -e .env.test -- npm run seed
+          npm run test:cov
+
+      - name: Stop test services
+        if: always()
+        run: docker compose -f docker-compose-test.yml -p revisium-core-test down --volumes
 
       - name: Build package
         run: npm run build

--- a/.github/workflows/release-train.yml
+++ b/.github/workflows/release-train.yml
@@ -34,8 +34,9 @@ concurrency:
   group: ${{ github.repository }}-release-train
   cancel-in-progress: false
 
-# Keep GITHUB_TOKEN read-only. Release branch and tag pushes use
-# PAT_TOKEN_FOR_BUMP_VERSION so downstream tag workflows are triggered.
+# Keep GITHUB_TOKEN read-only. Release commits and branch refs are created with
+# the release GitHub App so the version commit receives GitHub's Verified badge.
+# The tag is pushed with the same App token so downstream tag workflows run.
 permissions:
   contents: read
 
@@ -58,10 +59,14 @@ jobs:
           node-version: 24.11.1
           cache: 'npm'
 
-      - name: Configure git identity
-        run: |
-          git config user.name "anton62k"
-          git config user.email "anton62k@users.noreply.github.com"
+      - name: Create release app token
+        id: app-token
+        if: ${{ inputs.dry_run == false }}
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.RELEASE_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+          permission-contents: write
 
       - name: Compute release transition
         id: release
@@ -242,6 +247,11 @@ jobs:
           echo "target_branch=$TARGET_BRANCH" >> "$GITHUB_OUTPUT"
           echo "target_version=$TARGET_VERSION" >> "$GITHUB_OUTPUT"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          if [[ "$ACTION" == start-* ]]; then
+            echo "ref_mode=create" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref_mode=update" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Apply version metadata
         env:
@@ -295,6 +305,7 @@ jobs:
           NODE
 
       - name: Validate release metadata
+        id: metadata
         env:
           TARGET_VERSION: ${{ steps.release.outputs.target_version }}
         run: |
@@ -321,8 +332,9 @@ jobs:
           fi
 
           if git diff --quiet; then
-            echo "No version metadata changes were produced"
-            exit 1
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Install dependencies
@@ -352,33 +364,53 @@ jobs:
       - name: Build package
         run: npm run build
 
-      - name: Commit and tag release
+      - name: Create verified release commit
+        id: release-commit
         if: ${{ inputs.dry_run == false }}
         env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           TARGET_BRANCH: ${{ steps.release.outputs.target_branch }}
           TARGET_VERSION: ${{ steps.release.outputs.target_version }}
-          TAG: ${{ steps.release.outputs.tag }}
+          METADATA_CHANGED: ${{ steps.metadata.outputs.changed }}
+          REF_MODE: ${{ steps.release.outputs.ref_mode }}
         run: |
           set -euo pipefail
-          git add package.json package-lock.json src/api/rest-api/openapi.json
-          git commit -m "chore(release): $TARGET_VERSION"
-          git tag "$TAG"
-
-      - name: Push release branch and tag
-        if: ${{ inputs.dry_run == false }}
-        env:
-          GH_PAT: ${{ secrets.PAT_TOKEN_FOR_BUMP_VERSION }}
-          TARGET_BRANCH: ${{ steps.release.outputs.target_branch }}
-          TAG: ${{ steps.release.outputs.tag }}
-        run: |
-          set -euo pipefail
-          if [[ -z "${GH_PAT:-}" ]]; then
-            echo "PAT_TOKEN_FOR_BUMP_VERSION is required so tag pushes trigger publish workflows"
+          if [[ -z "${GH_TOKEN:-}" ]]; then
+            echo "RELEASE_BOT_CLIENT_ID and RELEASE_BOT_PRIVATE_KEY are required to create verified release commits"
             exit 1
           fi
 
-          git push "https://x-access-token:$GH_PAT@github.com/${{ github.repository }}" HEAD:"$TARGET_BRANCH"
-          git push "https://x-access-token:$GH_PAT@github.com/${{ github.repository }}" "$TAG"
+          BASE_SHA=$(git rev-parse HEAD)
+          export BASE_SHA
+          export COMMIT_MESSAGE="chore(release): $TARGET_VERSION"
+          export COMMIT_FILES=$'package.json\npackage-lock.json\nsrc/api/rest-api/openapi.json'
+          export COMMIT_SUMMARY="Metadata changed: $METADATA_CHANGED"
+
+          node .github/scripts/create-github-app-commit.mjs
+
+      - name: Push release tag
+        if: ${{ inputs.dry_run == false }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          TARGET_BRANCH: ${{ steps.release.outputs.target_branch }}
+          TAG: ${{ steps.release.outputs.tag }}
+          COMMIT_SHA: ${{ steps.release-commit.outputs.commit_sha }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${GH_TOKEN:-}" || -z "${COMMIT_SHA:-}" ]]; then
+            echo "Release App token and verified commit SHA are required before pushing the tag"
+            exit 1
+          fi
+
+          git fetch origin "refs/heads/$TARGET_BRANCH:refs/remotes/origin/$TARGET_BRANCH"
+          FETCHED_SHA=$(git rev-parse "refs/remotes/origin/$TARGET_BRANCH")
+          if [[ "$FETCHED_SHA" != "$COMMIT_SHA" ]]; then
+            echo "Release branch $TARGET_BRANCH points at $FETCHED_SHA, expected $COMMIT_SHA"
+            exit 1
+          fi
+
+          git tag "$TAG" "$COMMIT_SHA"
+          git push "https://x-access-token:$GH_TOKEN@github.com/${{ github.repository }}" "$TAG"
 
       - name: Dry run summary
         if: ${{ inputs.dry_run }}

--- a/.github/workflows/release-train.yml
+++ b/.github/workflows/release-train.yml
@@ -1,0 +1,367 @@
+name: Release Train
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: Release train transition
+        required: true
+        type: choice
+        options:
+          - start-minor-alpha
+          - start-major-alpha
+          - start-minor-rc
+          - start-major-rc
+          - start-minor-stable
+          - start-major-stable
+          - alpha-bump
+          - promote-rc
+          - rc-bump
+          - stable
+          - patch
+          - patch-alpha-start
+          - patch-rc-start
+      base_ref:
+        description: SHA or ref for start-* actions. Defaults to origin/master.
+        required: false
+      dry_run:
+        description: Validate and show the computed release without pushing.
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  group: ${{ github.repository }}-release-train
+  cancel-in-progress: false
+
+# Keep GITHUB_TOKEN read-only. Release branch and tag pushes use
+# PAT_TOKEN_FOR_BUMP_VERSION so downstream tag workflows are triggered.
+permissions:
+  contents: read
+
+jobs:
+  release-train:
+    runs-on: ubuntu-latest
+    env:
+      ACTION: ${{ inputs.action }}
+      BASE_REF: ${{ inputs.base_ref }}
+      DRY_RUN: ${{ inputs.dry_run }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24.11.1
+          cache: 'npm'
+
+      - name: Configure git identity
+        run: |
+          git config user.name "anton62k"
+          git config user.email "anton62k@users.noreply.github.com"
+
+      - name: Compute release transition
+        id: release
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          git fetch origin '+refs/heads/*:refs/remotes/origin/*' '+refs/tags/*:refs/tags/*'
+
+          CURRENT_BRANCH=${GITHUB_REF_NAME}
+          ACTION="$ACTION"
+
+          if [[ "$ACTION" == start-* ]]; then
+            if [[ "$CURRENT_BRANCH" != "master" ]]; then
+              echo "start-* actions must run from master. Current branch: $CURRENT_BRANCH"
+              exit 1
+            fi
+
+            ACTIVE_TRAINS=()
+            while IFS= read -r BRANCH; do
+              [[ -z "$BRANCH" ]] && continue
+              VERSION=$(git show "$BRANCH:package.json" | node -p "JSON.parse(require('fs').readFileSync(0, 'utf8')).version")
+              if [[ "$VERSION" =~ -(alpha|rc)\.[0-9]+$ ]]; then
+                ACTIVE_TRAINS+=("$BRANCH ($VERSION)")
+              fi
+            done < <(git for-each-ref --format='%(refname:short)' 'refs/remotes/origin/release/*')
+
+            if (( ${#ACTIVE_TRAINS[@]} > 0 )); then
+              echo "Cannot start a new release train while a prerelease train is active:"
+              printf -- '- %s\n' "${ACTIVE_TRAINS[@]}"
+              exit 1
+            fi
+
+            LATEST_STABLE_TAG=$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1 || true)
+            if [[ -z "$LATEST_STABLE_TAG" ]]; then
+              echo "No stable tag found. Create an initial stable tag before using release trains."
+              exit 1
+            fi
+
+            BASE_VERSION=${LATEST_STABLE_TAG#v}
+            IFS=. read -r MAJOR MINOR PATCH <<< "$BASE_VERSION"
+
+            case "$ACTION" in
+              start-minor-*)
+                TARGET_MAJOR="$MAJOR"
+                TARGET_MINOR=$((MINOR + 1))
+                ;;
+              start-major-*)
+                TARGET_MAJOR=$((MAJOR + 1))
+                TARGET_MINOR=0
+                ;;
+              *)
+                echo "Unsupported start action: $ACTION"
+                exit 1
+                ;;
+            esac
+
+            TARGET_BASE="$TARGET_MAJOR.$TARGET_MINOR.0"
+            case "$ACTION" in
+              *-alpha) TARGET_VERSION="$TARGET_BASE-alpha.0" ;;
+              *-rc) TARGET_VERSION="$TARGET_BASE-rc.0" ;;
+              *-stable) TARGET_VERSION="$TARGET_BASE" ;;
+              *)
+                echo "Unsupported start action: $ACTION"
+                exit 1
+                ;;
+            esac
+
+            TARGET_BRANCH="release/$TARGET_MAJOR.$TARGET_MINOR.x"
+            if git ls-remote --exit-code --heads origin "$TARGET_BRANCH" >/dev/null 2>&1; then
+              echo "Target branch already exists: $TARGET_BRANCH"
+              exit 1
+            fi
+
+            SOURCE_REF=${BASE_REF:-origin/master}
+            SOURCE_SHA=$(git rev-parse "$SOURCE_REF^{commit}")
+            if ! git merge-base --is-ancestor "$SOURCE_SHA" origin/master; then
+              echo "base_ref must resolve to a commit reachable from origin/master"
+              exit 1
+            fi
+
+            git switch -c "$TARGET_BRANCH" "$SOURCE_SHA"
+          else
+            if [[ ! "$CURRENT_BRANCH" =~ ^release/[0-9]+\.[0-9]+\.x$ ]]; then
+              echo "$ACTION must run from release/X.Y.x. Current branch: $CURRENT_BRANCH"
+              exit 1
+            fi
+
+            TARGET_BRANCH="$CURRENT_BRANCH"
+            BRANCH_LINE=${CURRENT_BRANCH#release/}
+            BRANCH_LINE=${BRANCH_LINE%.x}
+            IFS=. read -r TARGET_MAJOR TARGET_MINOR <<< "$BRANCH_LINE"
+            CURRENT_VERSION=$(node -p "require('./package.json').version")
+
+            if [[ ! "$CURRENT_VERSION" =~ ^$TARGET_MAJOR\.$TARGET_MINOR\. ]]; then
+              echo "package.json version $CURRENT_VERSION does not match branch $CURRENT_BRANCH"
+              exit 1
+            fi
+
+            case "$ACTION" in
+              alpha-bump)
+                if [[ ! "$CURRENT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+-alpha\.[0-9]+$ ]]; then
+                  echo "alpha-bump requires current version X.Y.Z-alpha.N"
+                  exit 1
+                fi
+                TARGET_VERSION=$(node -e "const v='$CURRENT_VERSION'; const m=v.match(/^(.+-alpha\.)([0-9]+)$/); console.log(m[1] + (Number(m[2]) + 1));")
+                ;;
+              promote-rc)
+                if [[ ! "$CURRENT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+-alpha\.[0-9]+$ ]]; then
+                  echo "promote-rc requires current version X.Y.Z-alpha.N"
+                  exit 1
+                fi
+                TARGET_VERSION=${CURRENT_VERSION%%-alpha.*}-rc.0
+                ;;
+              rc-bump)
+                if [[ ! "$CURRENT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$ ]]; then
+                  echo "rc-bump requires current version X.Y.Z-rc.N"
+                  exit 1
+                fi
+                TARGET_VERSION=$(node -e "const v='$CURRENT_VERSION'; const m=v.match(/^(.+-rc\.)([0-9]+)$/); console.log(m[1] + (Number(m[2]) + 1));")
+                ;;
+              stable)
+                if [[ ! "$CURRENT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+-(alpha|rc)\.[0-9]+$ ]]; then
+                  echo "stable requires current version X.Y.Z-alpha.N or X.Y.Z-rc.N"
+                  exit 1
+                fi
+                TARGET_VERSION=${CURRENT_VERSION%%-*}
+                ;;
+              patch)
+                if [[ ! "$CURRENT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                  echo "patch requires stable current version X.Y.Z"
+                  exit 1
+                fi
+                TARGET_VERSION=$(node -e "const [a,b,c]='$CURRENT_VERSION'.split('.').map(Number); console.log([a,b,c+1].join('.'));")
+                ;;
+              patch-alpha-start)
+                if [[ ! "$CURRENT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                  echo "patch-alpha-start requires stable current version X.Y.Z"
+                  exit 1
+                fi
+                TARGET_VERSION=$(node -e "const [a,b,c]='$CURRENT_VERSION'.split('.').map(Number); console.log([a,b,c+1].join('.') + '-alpha.0');")
+                ;;
+              patch-rc-start)
+                if [[ ! "$CURRENT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                  echo "patch-rc-start requires stable current version X.Y.Z"
+                  exit 1
+                fi
+                TARGET_VERSION=$(node -e "const [a,b,c]='$CURRENT_VERSION'.split('.').map(Number); console.log([a,b,c+1].join('.') + '-rc.0');")
+                ;;
+              *)
+                echo "Unsupported action on release branch: $ACTION"
+                exit 1
+                ;;
+            esac
+          fi
+
+          if [[ ! "$TARGET_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|rc)\.[0-9]+)?$ ]]; then
+            echo "Computed invalid target version: $TARGET_VERSION"
+            exit 1
+          fi
+
+          IFS=. read -r VERSION_MAJOR VERSION_MINOR _ <<< "${TARGET_VERSION%%-*}"
+          if [[ "$VERSION_MAJOR" != "$TARGET_MAJOR" || "$VERSION_MINOR" != "$TARGET_MINOR" ]]; then
+            echo "Target version $TARGET_VERSION does not match target branch $TARGET_BRANCH"
+            exit 1
+          fi
+
+          TAG="v$TARGET_VERSION"
+          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+            echo "Tag already exists locally: $TAG"
+            exit 1
+          fi
+          if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
+            echo "Tag already exists on origin: $TAG"
+            exit 1
+          fi
+
+          echo "target_branch=$TARGET_BRANCH" >> "$GITHUB_OUTPUT"
+          echo "target_version=$TARGET_VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Apply version metadata
+        env:
+          TARGET_VERSION: ${{ steps.release.outputs.target_version }}
+        run: |
+          set -euo pipefail
+          npm version "$TARGET_VERSION" --no-git-tag-version --allow-same-version
+
+          node <<'NODE'
+          const fs = require('fs');
+          const path = 'src/api/rest-api/openapi.json';
+          const version = process.env.TARGET_VERSION;
+          const doc = JSON.parse(fs.readFileSync(path, 'utf8'));
+          doc.info.version = version;
+          fs.writeFileSync(path, `${JSON.stringify(doc, null, 2)}\n`);
+          NODE
+
+      - name: Validate stable runtime dependencies
+        if: ${{ !contains(steps.release.outputs.target_version, '-') }}
+        run: |
+          node <<'NODE'
+          const pkg = require('./package.json');
+          const sections = ['dependencies', 'peerDependencies', 'optionalDependencies', 'bundledDependencies', 'bundleDependencies'];
+          const prereleasePattern = /-(alpha|beta|rc)\./;
+          const violations = [];
+
+          for (const section of sections) {
+            const deps = pkg[section];
+            if (!deps) continue;
+
+            if (Array.isArray(deps)) {
+              for (const dep of deps) {
+                if (prereleasePattern.test(dep)) violations.push(`${section}: ${dep}`);
+              }
+              continue;
+            }
+
+            for (const [name, version] of Object.entries(deps)) {
+              if (prereleasePattern.test(String(version))) {
+                violations.push(`${section}: ${name}@${version}`);
+              }
+            }
+          }
+
+          if (violations.length > 0) {
+            console.error('Stable releases cannot depend on prerelease runtime dependencies:');
+            for (const violation of violations) console.error(`- ${violation}`);
+            process.exit(1);
+          }
+          NODE
+
+      - name: Validate release metadata
+        env:
+          TARGET_VERSION: ${{ steps.release.outputs.target_version }}
+        run: |
+          set -euo pipefail
+
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          LOCK_VERSION=$(node -p "require('./package-lock.json').version")
+          LOCK_ROOT_VERSION=$(node -p "require('./package-lock.json').packages[''].version")
+          OPENAPI_VERSION=$(node -p "require('./src/api/rest-api/openapi.json').info.version")
+
+          if [[ "$PACKAGE_VERSION" != "$TARGET_VERSION" ]]; then
+            echo "package.json version mismatch: $PACKAGE_VERSION != $TARGET_VERSION"
+            exit 1
+          fi
+
+          if [[ "$LOCK_VERSION" != "$TARGET_VERSION" || "$LOCK_ROOT_VERSION" != "$TARGET_VERSION" ]]; then
+            echo "package-lock.json version mismatch"
+            exit 1
+          fi
+
+          if [[ "$OPENAPI_VERSION" != "$TARGET_VERSION" ]]; then
+            echo "OpenAPI version mismatch: $OPENAPI_VERSION != $TARGET_VERSION"
+            exit 1
+          fi
+
+          if git diff --quiet; then
+            echo "No version metadata changes were produced"
+            exit 1
+          fi
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts --prefer-offline --no-audit --no-fund
+
+      - name: Build package
+        run: npm run build
+
+      - name: Commit and tag release
+        if: ${{ inputs.dry_run == false }}
+        env:
+          TARGET_BRANCH: ${{ steps.release.outputs.target_branch }}
+          TARGET_VERSION: ${{ steps.release.outputs.target_version }}
+          TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          set -euo pipefail
+          git add package.json package-lock.json src/api/rest-api/openapi.json
+          git commit -m "chore(release): $TARGET_VERSION"
+          git tag "$TAG"
+
+      - name: Push release branch and tag
+        if: ${{ inputs.dry_run == false }}
+        env:
+          GH_PAT: ${{ secrets.PAT_TOKEN_FOR_BUMP_VERSION }}
+          TARGET_BRANCH: ${{ steps.release.outputs.target_branch }}
+          TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${GH_PAT:-}" ]]; then
+            echo "PAT_TOKEN_FOR_BUMP_VERSION is required so tag pushes trigger publish workflows"
+            exit 1
+          fi
+
+          git push "https://x-access-token:$GH_PAT@github.com/${{ github.repository }}" HEAD:"$TARGET_BRANCH"
+          git push "https://x-access-token:$GH_PAT@github.com/${{ github.repository }}" "$TAG"
+
+      - name: Dry run summary
+        if: ${{ inputs.dry_run }}
+        run: |
+          echo "Dry run only. No commit, branch, or tag was pushed."
+          echo "Target branch: ${{ steps.release.outputs.target_branch }}"
+          echo "Target version: ${{ steps.release.outputs.target_version }}"
+          echo "Tag: ${{ steps.release.outputs.tag }}"

--- a/.github/workflows/stable-version-sync.yml
+++ b/.github/workflows/stable-version-sync.yml
@@ -16,8 +16,7 @@ concurrency:
   group: ${{ github.repository }}-stable-version-sync
   cancel-in-progress: false
 
-# Keep GITHUB_TOKEN read-only. Branch push and PR creation use
-# PAT_TOKEN_FOR_BUMP_VERSION so the created PR runs normal CI.
+# Keep GITHUB_TOKEN read-only. Sync branches and PRs use the release GitHub App.
 permissions:
   contents: read
 
@@ -76,12 +75,14 @@ jobs:
           NODE
 
       - name: Validate changed files
+        id: metadata
         run: |
           set -euo pipefail
           CHANGED_FILES=$(git diff --name-only)
 
           if [[ -z "$CHANGED_FILES" ]]; then
             echo "Master already mirrors v$VERSION"
+            echo "changed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -94,33 +95,46 @@ jobs:
                 ;;
             esac
           done <<< "$CHANGED_FILES"
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Create release app token
+        id: app-token
+        if: ${{ inputs.dry_run == false && steps.metadata.outputs.changed == 'true' }}
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.RELEASE_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Create pull request
-        if: ${{ inputs.dry_run == false }}
+        if: ${{ inputs.dry_run == false && steps.metadata.outputs.changed == 'true' }}
         env:
-          GH_PAT: ${{ secrets.PAT_TOKEN_FOR_BUMP_VERSION }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
-          if [[ -z "${GH_PAT:-}" ]]; then
-            echo "PAT_TOKEN_FOR_BUMP_VERSION is required to push the sync branch and open a PR"
+          if [[ -z "${GH_TOKEN:-}" ]]; then
+            echo "RELEASE_BOT_CLIENT_ID and RELEASE_BOT_PRIVATE_KEY are required to create the sync branch and open a PR"
             exit 1
           fi
 
-          if git diff --quiet; then
-            echo "No changes to publish"
-            exit 0
+          BRANCH="chore/sync-stable-v$VERSION"
+          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            echo "Sync branch already exists: $BRANCH"
+            exit 1
           fi
 
-          BRANCH="chore/sync-stable-v$VERSION"
-          git config user.name "revisium-release-bot"
-          git config user.email "release-bot@revisium.io"
-          git switch -c "$BRANCH"
-          git add package.json package-lock.json src/api/rest-api/openapi.json
-          git commit -m "chore: sync stable version $VERSION"
-          git push "https://x-access-token:$GH_PAT@github.com/${{ github.repository }}" HEAD:"$BRANCH"
+          BASE_SHA=$(git rev-parse HEAD)
+          export BASE_SHA
+          export TARGET_BRANCH="$BRANCH"
+          export REF_MODE="create"
+          export COMMIT_MESSAGE="chore: sync stable version $VERSION"
+          export COMMIT_FILES=$'package.json\npackage-lock.json\nsrc/api/rest-api/openapi.json'
 
-          GH_TOKEN="$GH_PAT" gh pr create \
+          node .github/scripts/create-github-app-commit.mjs
+
+          gh pr create \
             --base master \
             --head "$BRANCH" \
             --title "chore: sync stable version $VERSION" \

--- a/.github/workflows/stable-version-sync.yml
+++ b/.github/workflows/stable-version-sync.yml
@@ -1,0 +1,134 @@
+name: Stable Version Sync
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Stable version to mirror on master, without leading v.
+        required: true
+      dry_run:
+        description: Validate and show changes without opening a PR.
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  group: ${{ github.repository }}-stable-version-sync
+  cancel-in-progress: false
+
+# Keep GITHUB_TOKEN read-only. Branch push and PR creation use
+# PAT_TOKEN_FOR_BUMP_VERSION so the created PR runs normal CI.
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  stable-version-sync:
+    runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ inputs.version }}
+      DRY_RUN: ${{ inputs.dry_run }}
+    steps:
+      - name: Checkout master
+        uses: actions/checkout@v4
+        with:
+          ref: master
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24.11.1
+          cache: 'npm'
+
+      - name: Validate target version
+        run: |
+          set -euo pipefail
+          git fetch origin '+refs/tags/*:refs/tags/*'
+
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Stable version sync requires X.Y.Z without prerelease suffix"
+            exit 1
+          fi
+
+          if ! git rev-parse -q --verify "refs/tags/v$VERSION" >/dev/null; then
+            echo "Stable tag does not exist: v$VERSION"
+            exit 1
+          fi
+
+          LATEST_STABLE_TAG=$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1 || true)
+          if [[ "$LATEST_STABLE_TAG" != "v$VERSION" ]]; then
+            echo "Requested version v$VERSION is not the latest stable tag ($LATEST_STABLE_TAG)"
+            exit 1
+          fi
+
+      - name: Apply stable version metadata
+        run: |
+          set -euo pipefail
+          npm version "$VERSION" --no-git-tag-version --allow-same-version
+
+          node <<'NODE'
+          const fs = require('fs');
+          const path = 'src/api/rest-api/openapi.json';
+          const version = process.env.VERSION;
+          const doc = JSON.parse(fs.readFileSync(path, 'utf8'));
+          doc.info.version = version;
+          fs.writeFileSync(path, `${JSON.stringify(doc, null, 2)}\n`);
+          NODE
+
+      - name: Validate changed files
+        run: |
+          set -euo pipefail
+          CHANGED_FILES=$(git diff --name-only)
+
+          if [[ -z "$CHANGED_FILES" ]]; then
+            echo "Master already mirrors v$VERSION"
+            exit 0
+          fi
+
+          while IFS= read -r FILE; do
+            case "$FILE" in
+              package.json|package-lock.json|src/api/rest-api/openapi.json) ;;
+              *)
+                echo "Stable version sync may not change $FILE"
+                exit 1
+                ;;
+            esac
+          done <<< "$CHANGED_FILES"
+
+      - name: Create pull request
+        if: ${{ inputs.dry_run == false }}
+        env:
+          GH_PAT: ${{ secrets.PAT_TOKEN_FOR_BUMP_VERSION }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${GH_PAT:-}" ]]; then
+            echo "PAT_TOKEN_FOR_BUMP_VERSION is required to push the sync branch and open a PR"
+            exit 1
+          fi
+
+          if git diff --quiet; then
+            echo "No changes to publish"
+            exit 0
+          fi
+
+          BRANCH="chore/sync-stable-v$VERSION"
+          git config user.name "anton62k"
+          git config user.email "anton62k@users.noreply.github.com"
+          git switch -c "$BRANCH"
+          git add package.json package-lock.json src/api/rest-api/openapi.json
+          git commit -m "chore: sync stable version $VERSION"
+          git push "https://x-access-token:$GH_PAT@github.com/${{ github.repository }}" HEAD:"$BRANCH"
+
+          GH_TOKEN="$GH_PAT" gh pr create \
+            --base master \
+            --head "$BRANCH" \
+            --title "chore: sync stable version $VERSION" \
+            --body "Mirrors the already-published stable tag v$VERSION on master. This PR updates version metadata only."
+
+      - name: Dry run summary
+        if: ${{ inputs.dry_run }}
+        run: |
+          echo "Dry run only. No branch or PR was created."
+          git diff --stat

--- a/.github/workflows/stable-version-sync.yml
+++ b/.github/workflows/stable-version-sync.yml
@@ -134,11 +134,15 @@ jobs:
 
           node .github/scripts/create-github-app-commit.mjs
 
-          gh pr create \
+          if ! gh pr create \
             --base master \
             --head "$BRANCH" \
             --title "chore: sync stable version $VERSION" \
-            --body "Mirrors the already-published stable tag v$VERSION on master. This PR updates version metadata only."
+            --body "Mirrors the already-published stable tag v$VERSION on master. This PR updates version metadata only."; then
+            echo "PR creation failed; deleting orphan branch $BRANCH"
+            gh api -X DELETE "repos/${{ github.repository }}/git/refs/heads/$BRANCH" || true
+            exit 1
+          fi
 
       - name: Dry run summary
         if: ${{ inputs.dry_run }}

--- a/.github/workflows/stable-version-sync.yml
+++ b/.github/workflows/stable-version-sync.yml
@@ -20,7 +20,6 @@ concurrency:
 # PAT_TOKEN_FOR_BUMP_VERSION so the created PR runs normal CI.
 permissions:
   contents: read
-  pull-requests: read
 
 jobs:
   stable-version-sync:
@@ -114,8 +113,8 @@ jobs:
           fi
 
           BRANCH="chore/sync-stable-v$VERSION"
-          git config user.name "anton62k"
-          git config user.email "anton62k@users.noreply.github.com"
+          git config user.name "revisium-release-bot"
+          git config user.email "release-bot@revisium.io"
           git switch -c "$BRANCH"
           git add package.json package-lock.json src/api/rest-api/openapi.json
           git commit -m "chore: sync stable version $VERSION"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a GitHub App–based release train that creates Verified release commits and tags, plus a stable-version sync workflow. Hardens `npm` publishing and Docker image tagging, and enables CI on release branches with stricter validation and safer retries.

- **New Features**
  - Release Train workflow (`workflow_dispatch`) with start/bump/promote/patch actions, dry-run, version/branch safety checks, full CI gates, and GitHub App–verified commits and tags.
  - Stable Version Sync workflow to mirror the latest stable tag onto `master` via a PR using a verified bot commit (updates only package and OpenAPI versions).
  - `create-github-app-commit.mjs` helper to commit version files as the App; fails if the commit is not Verified.

- **Refactors**
  - `npm` publish now runs on `v*` tag pushes with strict tag/metadata validation, stable-dependency guard, idempotency checks, dist-tag mapping to `alpha`/`rc`/`latest`, installs with `--ignore-scripts`, and explicitly rebuilds `bcrypt`, `sharp`, `@swc/core`, `@prisma/engines`, `prisma`.
  - Docker images are tagged by semver (`{version}`, `{major}.{minor}`) with `latest` only for stable tags; branch refs also tagged.
  - CI triggers extended to `release/**` branches.
  - Reliability: ref updates retry only on 5xx in the release bot, release-train enforces a changed-file allowlist during metadata validation, stable-version-sync deletes the orphan branch if PR creation fails, and the commit script skips logging an empty summary.

<sup>Written for commit 9be505c15585f733839e5c35e15fa0fcf993d7cd. Summary will update on new commits. <a href="https://cubic.dev/pr/revisium/revisium-core/pull/517">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

