### PR TITLE
Fix optional JWT auth failure handling

### DIFF
--- a/src/api/__tests__/revision/revision-changes.auth.e2e.spec.ts
+++ b/src/api/__tests__/revision/revision-changes.auth.e2e.spec.ts
@@ -1,6 +1,7 @@
 import { INestApplication } from '@nestjs/common';
 import { gql } from 'src/testing/utils/gql';
 import { getTestApp } from 'src/testing/e2e';
+import { gqlQueryRaw } from 'src/testing/e2e/graphql-helpers';
 import {
   operation,
   runAuthMatrix,
@@ -91,4 +92,26 @@ describe('revision changes auth', () => {
       };
     },
   });
+
+  it.each([
+    ['private', () => projects.private.project.draftRevisionId],
+    ['public', () => projects.public.project.draftRevisionId],
+  ])(
+    'rejects invalid rev_at cookie as unauthenticated for %s project',
+    async (_name, getRevisionId) => {
+      const response = await gqlQueryRaw({
+        app,
+        query: revisionChanges.gql!.query,
+        variables: revisionChanges.gql!.variables({
+          revisionId: getRevisionId(),
+        }),
+        headers: {
+          Cookie: 'rev_at=not-a-jwt',
+        },
+      });
+
+      expect(response.errors?.[0]?.extensions?.code).toBe('UNAUTHENTICATED');
+      expect(response.data).toBeNull();
+    },
+  );
 });

--- a/src/features/auth/__tests__/universal-auth-guard.spec.ts
+++ b/src/features/auth/__tests__/universal-auth-guard.spec.ts
@@ -130,6 +130,7 @@ describe('OptionalHttpUniversalAuthGuard', () => {
     const result = await guard.canActivate(context);
 
     expect(result).toBe(true);
+    expect(jwtGuard.canActivate).not.toHaveBeenCalled();
   });
 
   it('should return true when authenticated', async () => {
@@ -220,6 +221,7 @@ describe('OptionalGqlUniversalAuthGuard', () => {
     const result = await guard.canActivate(context);
 
     expect(result).toBe(true);
+    expect(jwtGuard.canActivate).not.toHaveBeenCalled();
   });
 
   it('should return true when authenticated', async () => {
@@ -268,20 +270,36 @@ describe('OptionalGqlJwtPassportGuard', () => {
     expect(result).toBe(request);
   });
 
-  it('should return user or null', () => {
+  it('should return user', () => {
     const guard = new OptionalGqlJwtPassportGuard();
 
-    expect(guard.handleRequest(null, undefined)).toBeNull();
     expect(guard.handleRequest(null, { userId: 'u1' })).toEqual({
       userId: 'u1',
     });
   });
 
-  it('should return null on error instead of error object', () => {
+  it('should throw UnauthorizedException when JWT path returns no user', () => {
+    const guard = new OptionalGqlJwtPassportGuard();
+
+    expect(() => guard.handleRequest(null, undefined)).toThrow(
+      UnauthorizedException,
+    );
+  });
+
+  it('should propagate JWT validation errors', () => {
     const guard = new OptionalGqlJwtPassportGuard();
     const error = new Error('auth failed');
 
-    expect(guard.handleRequest(error, null)).toBeNull();
+    expect(() => guard.handleRequest(error, null)).toThrow('auth failed');
+  });
+
+  it('should throw when passport reports JWT info without a user', () => {
+    const guard = new OptionalGqlJwtPassportGuard();
+    const info = new Error('jwt expired');
+
+    expect(() => guard.handleRequest(null, null, info)).toThrow(
+      UnauthorizedException,
+    );
   });
 });
 
@@ -299,6 +317,29 @@ describe('OptionalHttpJwtPassportGuard', () => {
     expect(guard.handleRequest(null, { userId: 'u1' })).toEqual({
       userId: 'u1',
     });
-    expect(guard.handleRequest(null, undefined)).toBeUndefined();
+  });
+
+  it('should throw UnauthorizedException when JWT path returns no user', () => {
+    const guard = new OptionalHttpJwtPassportGuard();
+
+    expect(() => guard.handleRequest(null, undefined)).toThrow(
+      UnauthorizedException,
+    );
+  });
+
+  it('should propagate JWT validation errors', () => {
+    const guard = new OptionalHttpJwtPassportGuard();
+    const error = new Error('auth failed');
+
+    expect(() => guard.handleRequest(error, null)).toThrow('auth failed');
+  });
+
+  it('should throw when passport reports JWT info without a user', () => {
+    const guard = new OptionalHttpJwtPassportGuard();
+    const info = new Error('jwt expired');
+
+    expect(() => guard.handleRequest(null, null, info)).toThrow(
+      UnauthorizedException,
+    );
   });
 });

--- a/src/features/auth/guards/universal/gql-universal-auth.guard.ts
+++ b/src/features/auth/guards/universal/gql-universal-auth.guard.ts
@@ -23,8 +23,20 @@ export class OptionalGqlJwtPassportGuard extends AuthGuard('jwt') {
     return ctx.getContext().req;
   }
 
-  handleRequest(_err: any, user: any) {
-    return user || null;
+  handleRequest<TUser = unknown>(
+    err: unknown,
+    user: TUser | false | null | undefined,
+    _info?: unknown,
+    _context?: ExecutionContext,
+    _status?: unknown,
+  ): TUser {
+    if (err) {
+      throw err;
+    }
+    if (!user) {
+      throw new UnauthorizedException();
+    }
+    return user;
   }
 }
 

--- a/src/features/auth/guards/universal/http-universal-auth.guard.ts
+++ b/src/features/auth/guards/universal/http-universal-auth.guard.ts
@@ -12,7 +12,19 @@ export class HttpJwtPassportGuard extends AuthGuard('jwt') {}
 
 @Injectable()
 export class OptionalHttpJwtPassportGuard extends AuthGuard('jwt') {
-  handleRequest(_err: any, user: any) {
+  handleRequest<TUser = unknown>(
+    err: unknown,
+    user: TUser | false | null | undefined,
+    _info?: unknown,
+    _context?: ExecutionContext,
+    _status?: unknown,
+  ): TUser {
+    if (err) {
+      throw err;
+    }
+    if (!user) {
+      throw new UnauthorizedException();
+    }
     return user;
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix optional JWT auth so malformed or expired tokens are rejected. Invalid JWTs now return UNAUTHENTICATED instead of falling back to anonymous access.

- **Bug Fixes**
  - Hardened `OptionalGqlJwtPassportGuard` and `OptionalHttpJwtPassportGuard` to surface JWT errors and throw `UnauthorizedException` when no user is resolved, including when Passport provides only `info`.
  - Expanded tests: e2e rejects invalid `rev_at` cookie with UNAUTHENTICATED; unit tests cover error propagation, no-user cases, and ensure `OptionalGqlUniversalAuthGuard`/`OptionalHttpUniversalAuthGuard` skip the JWT guard when no auth is present.

<sup>Written for commit 966d519319fe68bf14665ac806ed981e6d3e237a. Summary will update on new commits. <a href="https://cubic.dev/pr/revisium/revisium-core/pull/519">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

