### PR TITLE
Treat session cookie resume as unauthenticated

### DIFF
--- a/src/api/__tests__/revision/revision-changes.auth.e2e.spec.ts
+++ b/src/api/__tests__/revision/revision-changes.auth.e2e.spec.ts
@@ -1,4 +1,5 @@
 import { INestApplication } from '@nestjs/common';
+import request from 'supertest';
 import { gql } from 'src/testing/utils/gql';
 import { getTestApp } from 'src/testing/e2e';
 import { gqlQueryRaw } from 'src/testing/e2e/graphql-helpers';
@@ -112,6 +113,55 @@ describe('revision changes auth', () => {
 
       expect(response.errors?.[0]?.extensions?.code).toBe('UNAUTHENTICATED');
       expect(response.data).toBeNull();
+    },
+  );
+
+  it.each([
+    ['private', () => projects.private.project.draftRevisionId],
+    ['public', () => projects.public.project.draftRevisionId],
+  ])(
+    'rejects rev_session-only cookie as unauthenticated for %s project',
+    async (_name, getRevisionId) => {
+      const response = await gqlQueryRaw({
+        app,
+        query: revisionChanges.gql!.query,
+        variables: revisionChanges.gql!.variables({
+          revisionId: getRevisionId(),
+        }),
+        headers: {
+          Cookie: 'rev_session=1',
+        },
+      });
+
+      expect(response.errors?.[0]?.extensions?.code).toBe('UNAUTHENTICATED');
+      expect(response.data).toBeNull();
+    },
+  );
+
+  it.each([
+    [
+      'private',
+      'rev_at=not-a-jwt',
+      () => projects.private.project.draftRevisionId,
+    ],
+    [
+      'public',
+      'rev_at=not-a-jwt',
+      () => projects.public.project.draftRevisionId,
+    ],
+    [
+      'private',
+      'rev_session=1',
+      () => projects.private.project.draftRevisionId,
+    ],
+    ['public', 'rev_session=1', () => projects.public.project.draftRevisionId],
+  ])(
+    'rejects %s project REST request with %s as unauthenticated',
+    async (_name, cookie, getRevisionId) => {
+      await request(app.getHttpServer())
+        .get(`/api/revision/${getRevisionId()}/changes`)
+        .set('Cookie', cookie)
+        .expect(401);
     },
   );
 });

--- a/src/features/auth/__tests__/universal-auth-guard.spec.ts
+++ b/src/features/auth/__tests__/universal-auth-guard.spec.ts
@@ -311,7 +311,7 @@ describe('HttpJwtPassportGuard', () => {
 });
 
 describe('OptionalHttpJwtPassportGuard', () => {
-  it('should return user as-is in handleRequest', () => {
+  it('should return user when authenticated', () => {
     const guard = new OptionalHttpJwtPassportGuard();
 
     expect(guard.handleRequest(null, { userId: 'u1' })).toEqual({

--- a/src/features/auth/__tests__/universal-auth.service.spec.ts
+++ b/src/features/auth/__tests__/universal-auth.service.spec.ts
@@ -132,6 +132,19 @@ describe('UniversalAuthService', () => {
       expect(result).toBe('jwt');
     });
 
+    it('should return jwt when only the rev_session cookie is present', async () => {
+      const request = {
+        headers: {},
+        query: {},
+        ip: '127.0.0.1',
+        cookies: { rev_session: '1' },
+      } as any;
+
+      const result = await service.authenticateRequest(request);
+
+      expect(result).toBe('jwt');
+    });
+
     it('returns jwt even when only the bearer header is present (no cookie)', async () => {
       // Pair test with "cookie alone" above: both independently trigger
       // 'jwt'. The downstream JwtStrategy extractor is what actually

--- a/src/features/auth/guards/universal-auth.service.ts
+++ b/src/features/auth/guards/universal-auth.service.ts
@@ -3,7 +3,10 @@ import { ApiKeyType } from 'src/__generated__/client';
 import { ApiKeyTrackingService } from 'src/features/api-key/api-key-tracking.service';
 import { ApiKeyService } from 'src/features/api-key/api-key.service';
 import { NoAuthService } from 'src/features/auth/no-auth.service';
-import { ACCESS_COOKIE_NAME } from 'src/features/auth/services/cookie.service';
+import {
+  ACCESS_COOKIE_NAME,
+  SESSION_COOKIE_NAME,
+} from 'src/features/auth/services/cookie.service';
 import { IApiKeyScope, IAuthUser, ICaslRule } from 'src/features/auth/types';
 import { PrismaService } from 'src/infrastructure/database/prisma.service';
 
@@ -42,6 +45,10 @@ export class UniversalAuthService {
         }
 
         if (request.cookies?.[ACCESS_COOKIE_NAME]) {
+          return 'jwt' as const;
+        }
+
+        if (request.cookies?.[SESSION_COOKIE_NAME] === '1') {
           return 'jwt' as const;
         }
 

--- a/src/features/auth/guards/universal/gql-universal-auth.guard.ts
+++ b/src/features/auth/guards/universal/gql-universal-auth.guard.ts
@@ -7,6 +7,7 @@ import {
 import { AuthGuard } from '@nestjs/passport';
 import { GqlExecutionContext } from '@nestjs/graphql';
 import { UniversalAuthService } from 'src/features/auth/guards/universal-auth.service';
+import { handleOptionalJwtRequest } from 'src/features/auth/guards/universal/optional-jwt-handle-request';
 
 @Injectable()
 export class GqlJwtPassportGuard extends AuthGuard('jwt') {
@@ -30,13 +31,7 @@ export class OptionalGqlJwtPassportGuard extends AuthGuard('jwt') {
     _context?: ExecutionContext,
     _status?: unknown,
   ): TUser {
-    if (err) {
-      throw err;
-    }
-    if (!user) {
-      throw new UnauthorizedException();
-    }
-    return user;
+    return handleOptionalJwtRequest(err, user);
   }
 }
 

--- a/src/features/auth/guards/universal/http-universal-auth.guard.ts
+++ b/src/features/auth/guards/universal/http-universal-auth.guard.ts
@@ -6,6 +6,7 @@ import {
 } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { UniversalAuthService } from 'src/features/auth/guards/universal-auth.service';
+import { handleOptionalJwtRequest } from 'src/features/auth/guards/universal/optional-jwt-handle-request';
 
 @Injectable()
 export class HttpJwtPassportGuard extends AuthGuard('jwt') {}
@@ -19,13 +20,7 @@ export class OptionalHttpJwtPassportGuard extends AuthGuard('jwt') {
     _context?: ExecutionContext,
     _status?: unknown,
   ): TUser {
-    if (err) {
-      throw err;
-    }
-    if (!user) {
-      throw new UnauthorizedException();
-    }
-    return user;
+    return handleOptionalJwtRequest(err, user);
   }
 }
 

--- a/src/features/auth/guards/universal/optional-jwt-handle-request.ts
+++ b/src/features/auth/guards/universal/optional-jwt-handle-request.ts
@@ -1,0 +1,14 @@
+import { UnauthorizedException } from '@nestjs/common';
+
+export function handleOptionalJwtRequest<TUser>(
+  err: unknown,
+  user: TUser | false | null | undefined,
+): TUser {
+  if (err) {
+    throw err;
+  }
+  if (!user) {
+    throw new UnauthorizedException();
+  }
+  return user;
+}


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat `rev_session`-only requests as unauthenticated. Routes them through JWT auth so missing/expired access tokens return 401 (REST) or UNAUTHENTICATED (GraphQL) instead of 403.

- **Bug Fixes**
  - Detects `rev_session` cookie-only and authenticates via JWT; revision changes endpoints now reject with 401/UNAUTHENTICATED.
  - Adds regression tests for GraphQL and REST to cover `rev_session`-only and invalid `rev_at` cookies.

- **Refactors**
  - Extracts optional-JWT guard handling into `handleOptionalJwtRequest` and reuses it in both HTTP and GraphQL guards.

<sup>Written for commit ec1eab58523a5b7cf08f0b912e6b282e24da094b. Summary will update on new commits. <a href="https://cubic.dev/pr/revisium/revisium-core/pull/520">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

