### PR TITLE
fix: releases

### DIFF
--- a/.github/workflows/release-train.yml
+++ b/.github/workflows/release-train.yml
@@ -48,6 +48,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/stable-version-sync.yml
+++ b/.github/workflows/stable-version-sync.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           ref: master
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Disable credential persistence in release workflows to fix auth issues when pushing tags/commits. Set `persist-credentials: false` on `actions/checkout` in `release-train.yml` and `stable-version-sync.yml` so later steps use our PAT/bot token instead of `GITHUB_TOKEN`.

<sup>Written for commit cedaca86ccc3d162c73b12885446a722a967c3e8. Summary will update on new commits. <a href="https://cubic.dev/pr/revisium/revisium-core/pull/522">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

