### PR TITLE
fix: address release workflow review comments

### DIFF
--- a/.github/scripts/create-github-app-commit.mjs
+++ b/.github/scripts/create-github-app-commit.mjs
@@ -23,6 +23,14 @@ function optionalEnv(name, fallback = '') {
   return process.env[name] || fallback;
 }
 
+function positiveIntegerEnv(name, fallback) {
+  const raw = optionalEnv(name, fallback);
+  if (!/^[1-9][0-9]*$/.test(raw)) {
+    throw new Error(`${name} must be a positive integer, got "${raw}"`);
+  }
+  return Number.parseInt(raw, 10);
+}
+
 function appendOutput(name, value) {
   if (!process.env.GITHUB_OUTPUT) return;
   fs.appendFileSync(process.env.GITHUB_OUTPUT, `${name}=${value}\n`);
@@ -52,6 +60,11 @@ async function github(method, path, body) {
 
 async function sleep(ms) {
   await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function retryDelayMs(attempt) {
+  const baseDelay = Math.min(15_000, 2 ** (attempt - 1) * 1000);
+  return baseDelay + Math.floor(Math.random() * 250);
 }
 
 async function commitFiles() {
@@ -93,7 +106,7 @@ async function updateRef(refMode, targetBranch, commitSha) {
     return ref;
   }
 
-  const maxAttempts = Number(optionalEnv('REF_UPDATE_ATTEMPTS', '3'));
+  const maxAttempts = positiveIntegerEnv('REF_UPDATE_ATTEMPTS', '3');
   for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
     try {
       await github('PATCH', `/git/refs/heads/${targetBranch}`, {
@@ -107,8 +120,10 @@ async function updateRef(refMode, targetBranch, commitSha) {
         throw error;
       }
 
-      const delay = attempt * 1000;
-      console.warn(`Ref update failed with ${error.status}; retrying in ${delay}ms (${attempt}/${maxAttempts})`);
+      const delay = retryDelayMs(attempt);
+      console.warn(
+        `Ref update failed with ${error.status}: ${error.responseBody}; retrying in ${delay}ms (${attempt}/${maxAttempts})`,
+      );
       await sleep(delay);
     }
   }

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -72,23 +72,16 @@ jobs:
         run: |
           node <<'NODE'
           const pkg = require('./package.json');
-          const sections = ['dependencies', 'peerDependencies', 'optionalDependencies', 'bundledDependencies', 'bundleDependencies'];
-          const prereleasePattern = /-(alpha|beta|rc)\./;
+          const sections = ['dependencies', 'peerDependencies', 'optionalDependencies'];
+          const prereleaseVersionPattern = /(?:^|[^\w.-])v?\d+\.\d+\.\d+-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*/;
           const violations = [];
 
           for (const section of sections) {
             const deps = pkg[section];
             if (!deps) continue;
 
-            if (Array.isArray(deps)) {
-              for (const dep of deps) {
-                if (prereleasePattern.test(dep)) violations.push(`${section}: ${dep}`);
-              }
-              continue;
-            }
-
             for (const [name, version] of Object.entries(deps)) {
-              if (prereleasePattern.test(String(version))) {
+              if (prereleaseVersionPattern.test(String(version))) {
                 violations.push(`${section}: ${name}@${version}`);
               }
             }
@@ -105,7 +98,14 @@ jobs:
       - name: Ensure npm version does not already exist
         run: |
           PACKAGE_NAME=$(node -p "require('./package.json').name")
-          PUBLISHED_VERSION=$(npm view "$PACKAGE_NAME@${{ env.version }}" version 2>/dev/null || true)
+          LOOKUP_ERR=$(mktemp)
+          PUBLISHED_VERSION=$(npm view "$PACKAGE_NAME@${{ env.version }}" version 2>"$LOOKUP_ERR" || true)
+
+          if [[ -s "$LOOKUP_ERR" ]]; then
+            echo "Warning: npm registry lookup produced stderr:"
+            cat "$LOOKUP_ERR"
+          fi
+          rm -f "$LOOKUP_ERR"
 
           if [[ -n "$PUBLISHED_VERSION" ]]; then
             echo "$PACKAGE_NAME@${{ env.version }} is already published"

--- a/.github/workflows/release-train.yml
+++ b/.github/workflows/release-train.yml
@@ -265,23 +265,16 @@ jobs:
         run: |
           node <<'NODE'
           const pkg = require('./package.json');
-          const sections = ['dependencies', 'peerDependencies', 'optionalDependencies', 'bundledDependencies', 'bundleDependencies'];
-          const prereleasePattern = /-(alpha|beta|rc)\./;
+          const sections = ['dependencies', 'peerDependencies', 'optionalDependencies'];
+          const prereleaseVersionPattern = /(?:^|[^\w.-])v?\d+\.\d+\.\d+-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*/;
           const violations = [];
 
           for (const section of sections) {
             const deps = pkg[section];
             if (!deps) continue;
 
-            if (Array.isArray(deps)) {
-              for (const dep of deps) {
-                if (prereleasePattern.test(dep)) violations.push(`${section}: ${dep}`);
-              }
-              continue;
-            }
-
             for (const [name, version] of Object.entries(deps)) {
-              if (prereleasePattern.test(String(version))) {
+              if (prereleaseVersionPattern.test(String(version))) {
                 violations.push(`${section}: ${name}@${version}`);
               }
             }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Hardened release workflows and the GitHub App commit script to be more reliable and to catch prerelease dependency issues accurately. Improves ref update retries, dependency validation, and npm publish checks.

- **Bug Fixes**
  - Ref updates: validate `REF_UPDATE_ATTEMPTS` as a positive integer, use jittered exponential backoff (max 15s), and log response bodies on failures.
  - Prerelease checks: detect any semver prerelease in `dependencies`, `peerDependencies`, and `optionalDependencies`; stop scanning legacy bundle sections.
  - NPM publish: show npm registry lookup stderr as a warning when verifying if a version already exists.

<sup>Written for commit 8ce3848da722b8abee4ee50fed25fb3a91403d06. Summary will update on new commits. <a href="https://cubic.dev/pr/revisium/revisium-core/pull/523">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

