### PR TITLE
fix: envs

### DIFF
--- a/ENV.md
+++ b/ENV.md
@@ -169,9 +169,7 @@ In monolith/standalone mode, internal keys are derived automatically from `JWT_S
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `REVISIUM_LICENSE_KEY` | - | License key for `/ee/` features. If not set, all limits are disabled (unlimited). Validated against `https://licensing.revisium.io` |
-| `REVISIUM_SSO_ENABLED` | `false` | Enable SSO module (requires valid license with `sso` feature) |
-| `REVISIUM_AUDIT_ENABLED` | `false` | Enable audit log module (requires valid license with `audit` feature) |
+| `REVISIUM_LICENSE_KEY` | - | License key for `/ee/` features. If not set, licensed enterprise features are disabled. Validated against `https://licensing.revisium.io` |
 | `REVISIUM_STANDALONE` | `false` | Self-hosted mode. Disables `.env` file loading (for Docker deployments where env vars come from the container runtime) |
 
 ---
@@ -183,7 +181,7 @@ Billing is enabled automatically when `PAYMENT_SERVICE_URL` is set. When not set
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `PAYMENT_SERVICE_URL` | - | Payment service base URL (e.g. `http://payment:8082`). Core sends HMAC-signed requests to this URL for limits, plans, subscriptions, checkout, and usage reporting |
-| `PAYMENT_SERVICE_SECRET` | - | Shared HMAC secret for service-to-service auth. Must match `CORE_CALLBACK_SECRET` on the payment service side. Used for both outgoing requests (core → payment) and incoming callbacks (payment → core) |
+| `PAYMENT_SERVICE_SECRET` | - | Shared HMAC secret for service-to-service auth. Must match `CORE_CALLBACK_SECRET` on the payment service side. Used for both outgoing requests (core → payment) and incoming callbacks (payment → core). In practice this should be set whenever billing is enabled. |
 
 ---
 

--- a/docs/billing.md
+++ b/docs/billing.md
@@ -5,7 +5,8 @@ Plan limits and usage tracking for Revisium Cloud. Enterprise feature — self-h
 ## Quick Start
 
 - Self-hosted: nothing to configure, everything is unlimited
-- Cloud: set `PAYMENT_SERVICE_URL` + `PAYMENT_SERVICE_SECRET` (+ `REVISIUM_LICENSE_KEY` for enterprise features)
+- Cloud: set `PAYMENT_SERVICE_URL` + `PAYMENT_SERVICE_SECRET`
+- `REVISIUM_LICENSE_KEY` is only needed for licensed `/ee/` enterprise features; it does not enable billing by itself
 
 ## Architecture
 
@@ -84,5 +85,5 @@ Fail-open: if payment service is unreachable and cache is cold, operations are a
 | Variable                   | Default | Description                                       |
 | -------------------------- | ------- | ------------------------------------------------- |
 | `PAYMENT_SERVICE_URL`      | —       | Payment service base URL (e.g. `http://payment:8082`). Billing is enabled when this is set |
-| `PAYMENT_SERVICE_SECRET`   | —       | Shared HMAC secret for service-to-service auth    |
-| `REVISIUM_LICENSE_KEY`     | —       | Required for any enterprise features              |
+| `PAYMENT_SERVICE_SECRET`   | —       | Shared HMAC secret for service-to-service auth. Should be set whenever `PAYMENT_SERVICE_URL` is set |
+| `REVISIUM_LICENSE_KEY`     | —       | Required only for licensed `/ee/` enterprise features |


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Clarified environment variable docs for billing and enterprise features to reduce confusion.
Removed `REVISIUM_SSO_ENABLED` and `REVISIUM_AUDIT_ENABLED` (outdated), clarified `REVISIUM_LICENSE_KEY` only gates `/ee/` features and does not enable billing, and noted `PAYMENT_SERVICE_SECRET` should be set whenever billing is enabled.

<sup>Written for commit 5160dca89028b44c393d59c6ee537a374ac448db. Summary will update on new commits. <a href="https://cubic.dev/pr/revisium/revisium-core/pull/524">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

