### PR TITLE
Allow empty password on login so NO_AUTH mode can issue a JWT

### DIFF
--- a/src/__tests__/e2e/graphql/mutations/auth.spec.ts
+++ b/src/__tests__/e2e/graphql/mutations/auth.spec.ts
@@ -58,6 +58,16 @@ describe('graphql - auth mutations', () => {
       );
     });
 
+    it('login fails with Invalid credentials on empty password', async () => {
+      await gqlQueryExpectError(
+        {
+          app,
+          ...getMutation(fixture.owner.user.username!, ''),
+        },
+        /Invalid credentials/,
+      );
+    });
+
     it('login fails with Invalid credentials on non-existent user', async () => {
       // Same generic message prevents user enumeration via either the
       // response body or the response time (bcrypt compare always runs).

--- a/src/__tests__/e2e/no-auth.spec.ts
+++ b/src/__tests__/e2e/no-auth.spec.ts
@@ -1,4 +1,5 @@
 import { INestApplication } from '@nestjs/common';
+import { nanoid } from 'nanoid';
 import request from 'supertest';
 import { gql } from 'src/testing/utils/gql';
 import {
@@ -79,16 +80,15 @@ describe('NO_AUTH mode', () => {
       expect(result).toBeDefined();
     });
 
-    it('login accepts any credentials', async () => {
-      const result = await anonPost(app, '/api/auth/login', {
+    it('login accepts empty password and returns only a JSON access token', async () => {
+      const res = await anonPost(app, '/api/auth/login', {
         emailOrUsername: 'anything',
-        password: 'anything',
-      })
-        .expect(201)
-        .then((res) => res.body);
+        password: '',
+      }).expect(201);
 
-      expect(result).toHaveProperty('accessToken');
-      expect(typeof result.accessToken).toBe('string');
+      expect(res.body).toHaveProperty('accessToken');
+      expect(typeof res.body.accessToken).toBe('string');
+      expect(res.headers['set-cookie']).toBeUndefined();
     });
   });
 
@@ -113,21 +113,49 @@ describe('NO_AUTH mode', () => {
     });
 
     it('mutation works without token', async () => {
+      const branchName = `no-auth-${nanoid()}`;
       const result = await gqlQuery({
         app,
         query: gql`
-          mutation login($data: LoginInput!) {
-            login(data: $data) {
-              accessToken
+          mutation createBranch($data: CreateBranchInput!) {
+            createBranch(data: $data) {
+              name
+              isRoot
             }
           }
         `,
         variables: {
-          data: { emailOrUsername: 'anything', password: 'anything' },
+          data: {
+            revisionId: fixture.project.headRevisionId,
+            branchName,
+          },
         },
       });
 
-      expect(result.login.accessToken).toBeDefined();
+      expect(result.createBranch.name).toBe(branchName);
+      expect(result.createBranch.isRoot).toBe(false);
+    });
+
+    it('login accepts empty password and returns only a JSON access token', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/graphql')
+        .send({
+          query: gql`
+            mutation login($data: LoginInput!) {
+              login(data: $data) {
+                accessToken
+              }
+            }
+          `,
+          variables: {
+            data: { emailOrUsername: 'anything', password: '' },
+          },
+        })
+        .expect(200);
+
+      expect(res.body.errors).toBeUndefined();
+      expect(res.body.data.login.accessToken).toBeDefined();
+      expect(res.headers['set-cookie']).toBeUndefined();
     });
   });
 

--- a/src/api/graphql-api/auth/inputs/login.input.ts
+++ b/src/api/graphql-api/auth/inputs/login.input.ts
@@ -11,7 +11,6 @@ export class LoginInput {
 
   @Field()
   @IsString()
-  @IsNotEmpty()
   @MaxLength(256)
   password: string;
 }

--- a/src/api/rest-api/auth/dto/login.dto.ts
+++ b/src/api/rest-api/auth/dto/login.dto.ts
@@ -10,7 +10,6 @@ export class LoginDto {
 
   @ApiProperty({ required: true })
   @IsString()
-  @IsNotEmpty()
   @MaxLength(256)
   password: string;
 }

--- a/src/features/auth/__tests__/login-validation.spec.ts
+++ b/src/features/auth/__tests__/login-validation.spec.ts
@@ -1,0 +1,54 @@
+import { validate } from 'class-validator';
+import { LoginInput } from 'src/api/graphql-api/auth/inputs/login.input';
+import { LoginDto } from 'src/api/rest-api/auth/dto/login.dto';
+
+type LoginCredentialClass = typeof LoginInput | typeof LoginDto;
+
+const loginCredentialTypes: Array<[string, LoginCredentialClass]> = [
+  ['GraphQL LoginInput', LoginInput],
+  ['REST LoginDto', LoginDto],
+];
+
+describe('login credential validation', () => {
+  it.each(loginCredentialTypes)(
+    'allows an empty password for %s so no-auth mode can issue a JWT',
+    async (_name, CredentialType) => {
+      const data = Object.assign(new CredentialType(), {
+        emailOrUsername: 'admin',
+        password: '',
+      });
+
+      await expect(validate(data)).resolves.toHaveLength(0);
+    },
+  );
+
+  it.each(loginCredentialTypes)(
+    'still requires a non-empty emailOrUsername for %s',
+    async (_name, CredentialType) => {
+      const data = Object.assign(new CredentialType(), {
+        emailOrUsername: '',
+        password: '',
+      });
+
+      const errors = await validate(data);
+
+      expect(errors.map((error) => error.property)).toContain(
+        'emailOrUsername',
+      );
+    },
+  );
+
+  it.each(loginCredentialTypes)(
+    'still requires password to be a string for %s',
+    async (_name, CredentialType) => {
+      const data = Object.assign(new CredentialType(), {
+        emailOrUsername: 'admin',
+        password: 123,
+      });
+
+      const errors = await validate(data);
+
+      expect(errors.map((error) => error.property)).toContain('password');
+    },
+  );
+});

--- a/src/features/auth/__tests__/no-auth.spec.ts
+++ b/src/features/auth/__tests__/no-auth.spec.ts
@@ -157,7 +157,7 @@ describe('JWT Guards with NO_AUTH enabled', () => {
 });
 
 describe('LoginHandler with NO_AUTH enabled', () => {
-  it('should return token for any credentials', async () => {
+  it('should return token for empty password credentials', async () => {
     const signAccessToken = jest
       .fn()
       .mockReturnValue({ accessToken: 'no-auth-token', expiresIn: 1800 });
@@ -183,8 +183,8 @@ describe('LoginHandler with NO_AUTH enabled', () => {
 
     const handler = module.get<LoginHandler>(LoginHandler);
     const command = new LoginCommand({
-      emailOrUsername: 'anything',
-      password: 'anything',
+      emailOrUsername: 'admin',
+      password: '',
     });
 
     const result = await handler.execute(command);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Allow empty passwords on login so NO_AUTH mode can issue a JWT without setting cookies. Normal auth keeps rejecting empty passwords with “Invalid credentials”.

- **Bug Fixes**
  - Removed `@IsNotEmpty()` from `password` in `LoginDto` and `LoginInput` to allow empty strings.
  - In NO_AUTH mode, login accepts an empty password and returns only a JSON `accessToken` (no `Set-Cookie`).
  - Added tests to verify validation rules and ensure normal mode still rejects empty passwords.

<sup>Written for commit 895550a40ec1a25a1ad0e77f873eb4b07cbb1bb2. Summary will update on new commits. <a href="https://cubic.dev/pr/revisium/revisium-core/pull/526">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

