### PR TITLE
fix: silence noisy logs when billing disabled and on expected 4xx

### DIFF
--- a/ee/billing/__tests__/usage-reporter.service.spec.ts
+++ b/ee/billing/__tests__/usage-reporter.service.spec.ts
@@ -11,8 +11,10 @@ import { UsageService } from '../usage/usage.service';
 describe('UsageReporterService', () => {
   let module: TestingModule;
   let service: UsageReporterService;
-  let mockBillingClient: jest.Mocked<IBillingClient>;
+  let prisma: PrismaService;
+  let mockBillingClient: jest.Mocked<IBillingClient> & { configured: boolean };
   let mockUsageService: jest.Mocked<UsageService>;
+  let findManySpy: jest.SpyInstance;
 
   beforeAll(async () => {
     mockBillingClient = {
@@ -43,16 +45,23 @@ describe('UsageReporterService', () => {
     }).compile();
 
     service = module.get(UsageReporterService);
+    prisma = module.get(PrismaService);
   });
 
   afterAll(async () => {
-    await module.get(PrismaService).$disconnect();
+    await prisma.$disconnect();
   });
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockBillingClient.configured = true;
     mockUsageService.computeUsage.mockResolvedValue(0);
     mockBillingClient.reportUsage.mockResolvedValue(undefined);
+    findManySpy = jest.spyOn(prisma.organization, 'findMany');
+  });
+
+  afterEach(() => {
+    findManySpy.mockRestore();
   });
 
   it('should report usage for organizations', async () => {
@@ -87,5 +96,19 @@ describe('UsageReporterService', () => {
         storage_bytes: 100_000,
       }),
     );
+  });
+
+  describe('when billing client is not configured', () => {
+    beforeEach(() => {
+      mockBillingClient.configured = false;
+    });
+
+    it('should no-op without querying organizations or reporting usage', async () => {
+      await service.reportAllUsage();
+
+      expect(findManySpy).not.toHaveBeenCalled();
+      expect(mockUsageService.computeUsage).not.toHaveBeenCalled();
+      expect(mockBillingClient.reportUsage).not.toHaveBeenCalled();
+    });
   });
 });

--- a/ee/billing/usage-reporter.service.ts
+++ b/ee/billing/usage-reporter.service.ts
@@ -21,6 +21,10 @@ export class UsageReporterService {
 
   @Cron(CronExpression.EVERY_HOUR)
   async reportAllUsage(): Promise<void> {
+    if (!this.billingClient.configured) {
+      return;
+    }
+
     const orgs = await this.prisma.organization.findMany({
       select: { id: true },
     });

--- a/src/infrastructure/common/interceptors/__tests__/logging.interceptor.spec.ts
+++ b/src/infrastructure/common/interceptors/__tests__/logging.interceptor.spec.ts
@@ -1,0 +1,75 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  HttpException,
+  HttpStatus,
+  Logger,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { firstValueFrom, throwError } from 'rxjs';
+import { LoggingInterceptor } from '../logging.interceptor';
+
+describe('LoggingInterceptor', () => {
+  let interceptor: LoggingInterceptor;
+  let errorSpy: jest.SpyInstance;
+  let debugSpy: jest.SpyInstance;
+
+  const ctx = {} as ExecutionContext;
+
+  const handlerThrowing = (err: unknown): CallHandler => ({
+    handle: () => throwError(() => err),
+  });
+
+  beforeEach(() => {
+    interceptor = new LoggingInterceptor();
+    errorSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation();
+    debugSpy = jest.spyOn(Logger.prototype, 'debug').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('does not log expected 4xx HttpException as error', async () => {
+    const err = new UnauthorizedException('No refresh token');
+
+    await expect(
+      firstValueFrom(interceptor.intercept(ctx, handlerThrowing(err))),
+    ).rejects.toBe(err);
+
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('logs 5xx HttpException as error with stack', async () => {
+    const err = new HttpException('boom', HttpStatus.INTERNAL_SERVER_ERROR);
+
+    await expect(
+      firstValueFrom(interceptor.intercept(ctx, handlerThrowing(err))),
+    ).rejects.toBe(err);
+
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledWith(err, err.stack);
+  });
+
+  it('logs non-HTTP Error as error with stack', async () => {
+    const err = new Error('unexpected');
+
+    await expect(
+      firstValueFrom(interceptor.intercept(ctx, handlerThrowing(err))),
+    ).rejects.toBe(err);
+
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledWith(err, err.stack);
+  });
+
+  it('emits a debug breadcrumb for expected 4xx without raising error', async () => {
+    const err = new UnauthorizedException('No refresh token');
+
+    await expect(
+      firstValueFrom(interceptor.intercept(ctx, handlerThrowing(err))),
+    ).rejects.toBe(err);
+
+    expect(debugSpy).toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/infrastructure/common/interceptors/logging.interceptor.ts
+++ b/src/infrastructure/common/interceptors/logging.interceptor.ts
@@ -4,6 +4,8 @@ import {
   ExecutionContext,
   CallHandler,
   Logger,
+  HttpException,
+  HttpStatus,
 } from '@nestjs/common';
 import { catchError, Observable, throwError } from 'rxjs';
 
@@ -14,7 +16,13 @@ export class LoggingInterceptor implements NestInterceptor {
   intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
     return next.handle().pipe(
       catchError((err) => {
-        if (err instanceof Error) {
+        if (err instanceof HttpException) {
+          if (err.getStatus() < HttpStatus.INTERNAL_SERVER_ERROR) {
+            this.logger.debug(`${err.name}: ${err.message}`);
+          } else {
+            this.logger.error(err, err.stack);
+          }
+        } else if (err instanceof Error) {
           this.logger.error(err, err.stack);
         }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed error logging to differentiate between client errors (4xx) logged at debug level and server errors (5xx) logged at error level with stack traces.

* **Tests**
  * Added test coverage for error logging behavior with various exception types.
  * Enhanced billing usage reporter tests to verify correct behavior when billing client is not configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->