### PR TITLE
fix usage report noise

### DIFF
--- a/docs/billing/usage-tracking.md
+++ b/docs/billing/usage-tracking.md
@@ -44,11 +44,14 @@ Usage values are cached by `BillingCacheService` (2-min TTL) and invalidated via
 `UsageReporterService` runs `@Cron(EVERY_HOUR)`:
 
 1. Fetches all organizations from local DB
-2. For each org, computes `row_versions`, `projects`, `seats`, and `storage_bytes` locally via `UsageService`
-3. Reports to payment service via `BillingClient.reportUsage(orgId, usage)`
-4. Best-effort — failures are logged and skipped
+2. Checks whether the organization has a payment subscription
+3. For subscribed orgs, computes `row_versions`, `projects`, `seats`, and `storage_bytes` locally via `UsageService`
+4. Reports to payment service via `BillingClient.reportUsage(orgId, usage)`
+5. Logs one summary with reported, skipped-no-subscription, and failed counts
 
-The payment service stores these reports in its `UsageReport` table for billing analytics and admin dashboards.
+Organizations without subscriptions are skipped before usage computation, so expected 404s from payment do not create per-org warning noise. Unexpected failures are still logged per organization.
+
+The payment service stores these reports in its `UsageReport` table for billing analytics and admin dashboards. Reports are hourly snapshots and are idempotent per subscription/hour on the payment side.
 
 ## File Structure
 

--- a/ee/billing/__tests__/usage-reporter.service.spec.ts
+++ b/ee/billing/__tests__/usage-reporter.service.spec.ts
@@ -108,7 +108,10 @@ describe('UsageReporterService', () => {
   });
 
   it('should skip organizations without subscriptions', async () => {
-    findManySpy.mockResolvedValue([{ id: 'org-with-sub' }, { id: 'org-without-sub' }]);
+    findManySpy.mockResolvedValue([
+      { id: 'org-with-sub' },
+      { id: 'org-without-sub' },
+    ]);
     mockBillingClient.getSubscription
       .mockResolvedValueOnce({
         planId: 'pro',

--- a/ee/billing/__tests__/usage-reporter.service.spec.ts
+++ b/ee/billing/__tests__/usage-reporter.service.spec.ts
@@ -55,6 +55,15 @@ describe('UsageReporterService', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockBillingClient.configured = true;
+    mockBillingClient.getSubscription.mockResolvedValue({
+      planId: 'pro',
+      status: 'active',
+      provider: null,
+      interval: null,
+      currentPeriodStart: null,
+      currentPeriodEnd: null,
+      cancelAt: null,
+    });
     mockUsageService.computeUsage.mockResolvedValue(0);
     mockBillingClient.reportUsage.mockResolvedValue(undefined);
     findManySpy = jest.spyOn(prisma.organization, 'findMany');
@@ -95,6 +104,30 @@ describe('UsageReporterService', () => {
         seats: 3,
         storage_bytes: 100_000,
       }),
+    );
+  });
+
+  it('should skip organizations without subscriptions', async () => {
+    findManySpy.mockResolvedValue([{ id: 'org-with-sub' }, { id: 'org-without-sub' }]);
+    mockBillingClient.getSubscription
+      .mockResolvedValueOnce({
+        planId: 'pro',
+        status: 'active',
+        provider: null,
+        interval: null,
+        currentPeriodStart: null,
+        currentPeriodEnd: null,
+        cancelAt: null,
+      })
+      .mockResolvedValueOnce(null);
+
+    await service.reportAllUsage();
+
+    expect(mockUsageService.computeUsage).toHaveBeenCalledTimes(4);
+    expect(mockBillingClient.reportUsage).toHaveBeenCalledTimes(1);
+    expect(mockBillingClient.reportUsage).toHaveBeenCalledWith(
+      'org-with-sub',
+      expect.any(Object),
     );
   });
 

--- a/ee/billing/usage-reporter.service.ts
+++ b/ee/billing/usage-reporter.service.ts
@@ -30,8 +30,16 @@ export class UsageReporterService {
     });
 
     let reported = 0;
+    let skippedNoSubscription = 0;
+    let failed = 0;
     for (const org of orgs) {
       try {
+        const subscription = await this.billingClient.getSubscription(org.id);
+        if (!subscription) {
+          skippedNoSubscription++;
+          continue;
+        }
+
         const [rowVersions, projects, seats, storageBytes] = await Promise.all([
           this.usageService.computeUsage(org.id, LimitMetric.ROW_VERSIONS),
           this.usageService.computeUsage(org.id, LimitMetric.PROJECTS),
@@ -47,6 +55,7 @@ export class UsageReporterService {
         });
         reported++;
       } catch (error) {
+        failed++;
         this.logger.warn(
           `Failed to report usage for org=${org.id}: ${error instanceof Error ? error.message : error}`,
         );
@@ -54,7 +63,7 @@ export class UsageReporterService {
     }
 
     this.logger.log(
-      `Usage reported for ${reported}/${orgs.length} organizations`,
+      `Usage reporting completed: reported=${reported}, skipped_no_subscription=${skippedNoSubscription}, failed=${failed}, total=${orgs.length}`,
     );
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Skip organizations without an active subscription during hourly usage reporting to avoid spurious per-org errors; track reported/skipped/failed counts.

* **Documentation**
  * Expanded hourly usage reporting workflow: subscription validation, per-org metric computation only for subscribed orgs, and idempotent hourly reporting with outcome summary.

* **Tests**
  * Added tests verifying unsubscribed orgs are skipped and successful reporting is counted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->