### PR TITLE
Fix: tables per revision counter uses revisionid

### DIFF
--- a/docs/billing/enforcement.md
+++ b/docs/billing/enforcement.md
@@ -42,7 +42,7 @@ Step 1 is an in-memory cache hit or HMAC-signed HTTP call to the payment service
 | `AddUserToOrganizationHandler` | `seats`               | `1`           | -               | Only for new users, not role updates |
 | `CreateRowHandler`             | `rows_per_table`      | `1`           | `{ tableId }`   |                                      |
 | `CreateRowsHandler`            | `rows_per_table`      | `rows.length` | `{ tableId }`   |                                      |
-| `CreateTableHandler`           | `tables_per_revision` | `1`           | `{ projectId }` |                                      |
+| `CreateTableHandler`           | `tables_per_revision` | `1`           | `{ revisionId }` |                                      |
 | `CreateBranchHandler`          | `branches_per_project`| `1`           | `{ projectId }` |                                      |
 
 ### Why These Handlers
@@ -88,12 +88,12 @@ await this.billingCheck.check(revisionId, LimitMetric.ROW_VERSIONS, rows.length)
 await this.billingCheck.check(revisionId, LimitMetric.ROWS_PER_TABLE, rows.length, { tableId });
 ```
 
-`BillingCheckService.check()` automatically resolves `organizationId` and `projectId` from the `revisionId`. For `ROWS_PER_TABLE`, `revisionId` is also passed in context so the counting method can scope the query to the correct draft revision.
+`BillingCheckService.check()` automatically resolves `organizationId` and `projectId` from the `revisionId`. For `ROWS_PER_TABLE` and `TABLES_PER_REVISION`, `revisionId` is also passed in context so the counting methods can scope queries to the correct draft revision.
 
 | Metric | Scope | What It Counts |
 |---|---|---|
 | `rows_per_table` | Per table in revision | Rows linked to a specific table within a revision |
-| `tables_per_revision` | Per project | Tables in the draft revision of the root branch |
+| `tables_per_revision` | Per revision | Tables linked to the requested draft revision |
 | `branches_per_project` | Per project | Total branches in the project |
 
 ## Error Response

--- a/docs/billing/plans.md
+++ b/docs/billing/plans.md
@@ -32,7 +32,7 @@ Scoped to a specific entity within the org.
 | Metric | What It Counts | Scope |
 |---|---|---|
 | `rows_per_table` | Rows in a specific table within a revision | Per table |
-| `tables_per_revision` | Tables in the draft revision of the root branch | Per project |
+| `tables_per_revision` | Tables linked to the requested draft revision | Per revision |
 | `branches_per_project` | Total branches in a project | Per project |
 
 ## Plans

--- a/ee/billing/__tests__/limits-enforcement-resource-level.spec.ts
+++ b/ee/billing/__tests__/limits-enforcement-resource-level.spec.ts
@@ -1,0 +1,208 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { nanoid } from 'nanoid';
+import { CoreModule } from 'src/core/core.module';
+import { BillingCheckService } from 'src/core/shared/billing-check.service';
+import { LimitExceededException } from 'src/features/billing/limit-exceeded.exception';
+import { LimitMetric } from 'src/features/billing/limits.interface';
+import { CACHE_SERVICE } from 'src/infrastructure/cache/services/cache.tokens';
+import { NoopCacheService } from 'src/infrastructure/cache/services/noop-cache.service';
+import { PrismaService } from 'src/infrastructure/database/prisma.service';
+import {
+  BILLING_CLIENT_TOKEN,
+  IBillingClient,
+  OrgLimits,
+} from '../billing-client.interface';
+
+const TABLE_CAP = 5;
+
+const FREE_LIMITS: OrgLimits = {
+  planId: 'free',
+  status: 'free',
+  limits: {
+    row_versions: 10_000,
+    projects: 3,
+    seats: 1,
+    storage_bytes: 500_000_000,
+    api_calls_per_day: 1_000,
+    rows_per_table: 1_000,
+    tables_per_revision: TABLE_CAP,
+    branches_per_project: 3,
+    endpoints_per_project: 2,
+  },
+};
+
+describe('resource-level limit enforcement', () => {
+  let module: TestingModule;
+  let billingCheck: BillingCheckService;
+  let prisma: PrismaService;
+  let mockBillingClient: jest.Mocked<IBillingClient>;
+
+  beforeAll(async () => {
+    mockBillingClient = {
+      configured: true,
+      getOrgLimits: jest.fn(),
+      createCheckout: jest.fn(),
+      cancelSubscription: jest.fn(),
+      getSubscription: jest.fn(),
+      getProviders: jest.fn(),
+      getPortalUrl: jest.fn(),
+      getPlans: jest.fn(),
+      getPlan: jest.fn(),
+      activateEarlyAccess: jest.fn(),
+      reportUsage: jest.fn(),
+    };
+
+    module = await Test.createTestingModule({
+      imports: [CoreModule.forRoot({ mode: 'monolith' })],
+    })
+      .overrideProvider(BILLING_CLIENT_TOKEN)
+      .useValue(mockBillingClient)
+      .overrideProvider(CACHE_SERVICE)
+      .useClass(NoopCacheService)
+      .compile();
+
+    billingCheck = module.get(BillingCheckService);
+    prisma = module.get(PrismaService);
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockBillingClient.getOrgLimits.mockResolvedValue(FREE_LIMITS);
+  });
+
+  afterAll(async () => {
+    await module.close();
+  });
+
+  it('rejects the next table when the master draft revision is at the cap', async () => {
+    const { masterDraftId } = await createProjectWithDrafts({
+      masterTableCount: TABLE_CAP,
+      branchTableCount: 0,
+    });
+
+    await expect(checkTableCreate(masterDraftId)).rejects.toBeInstanceOf(
+      LimitExceededException,
+    );
+  });
+
+  it('rejects the next table when a non-master draft revision is at the cap', async () => {
+    const { branchDraftId } = await createProjectWithDrafts({
+      masterTableCount: 0,
+      branchTableCount: TABLE_CAP,
+    });
+
+    await expect(checkTableCreate(branchDraftId)).rejects.toBeInstanceOf(
+      LimitExceededException,
+    );
+  });
+
+  it('keeps the master and non-master draft revision counters independent', async () => {
+    const { masterDraftId, branchDraftId } = await createProjectWithDrafts({
+      masterTableCount: TABLE_CAP,
+      branchTableCount: 0,
+    });
+
+    await expect(checkTableCreate(masterDraftId)).rejects.toBeInstanceOf(
+      LimitExceededException,
+    );
+
+    for (let i = 0; i < TABLE_CAP; i++) {
+      await expect(checkTableCreate(branchDraftId)).resolves.toBeUndefined();
+      await createTableInRevision(branchDraftId, `branch-created-${i}`);
+    }
+
+    await expect(checkTableCreate(branchDraftId)).rejects.toBeInstanceOf(
+      LimitExceededException,
+    );
+  });
+
+  async function checkTableCreate(revisionId: string) {
+    await billingCheck.check(
+      revisionId,
+      LimitMetric.TABLES_PER_REVISION,
+      1,
+    );
+  }
+
+  async function createProjectWithDrafts({
+    masterTableCount,
+    branchTableCount,
+  }: {
+    masterTableCount: number;
+    branchTableCount: number;
+  }) {
+    const orgId = nanoid();
+    const projectId = nanoid();
+    const masterBranchId = nanoid();
+    const branchId = nanoid();
+    const masterDraftId = nanoid();
+    const branchDraftId = nanoid();
+
+    await prisma.organization.create({
+      data: { id: orgId, createdId: nanoid() },
+    });
+    await prisma.project.create({
+      data: {
+        id: projectId,
+        name: `project-${projectId}`,
+        organizationId: orgId,
+      },
+    });
+    await prisma.branch.create({
+      data: {
+        id: masterBranchId,
+        name: 'master',
+        projectId,
+        isRoot: true,
+      },
+    });
+    await prisma.branch.create({
+      data: {
+        id: branchId,
+        name: `branch-${branchId}`,
+        projectId,
+      },
+    });
+    await prisma.revision.create({
+      data: {
+        id: masterDraftId,
+        branchId: masterBranchId,
+        isDraft: true,
+      },
+    });
+    await prisma.revision.create({
+      data: {
+        id: branchDraftId,
+        branchId,
+        isDraft: true,
+      },
+    });
+
+    await createTablesInRevision(masterDraftId, masterTableCount, 'master');
+    await createTablesInRevision(branchDraftId, branchTableCount, 'branch');
+
+    return { masterDraftId, branchDraftId };
+  }
+
+  async function createTablesInRevision(
+    revisionId: string,
+    count: number,
+    prefix: string,
+  ) {
+    for (let i = 0; i < count; i++) {
+      await createTableInRevision(revisionId, `${prefix}-${i}`);
+    }
+  }
+
+  async function createTableInRevision(revisionId: string, tableId: string) {
+    const tableVersionId = nanoid();
+    await prisma.table.create({
+      data: {
+        versionId: tableVersionId,
+        createdId: nanoid(),
+        id: `${tableId}-${nanoid()}`,
+        revisions: { connect: { id: revisionId } },
+      },
+    });
+  }
+});

--- a/ee/billing/__tests__/limits.service.spec.ts
+++ b/ee/billing/__tests__/limits.service.spec.ts
@@ -299,7 +299,7 @@ describe('LimitsService (Ultra-Thin)', () => {
       orgId,
       LimitMetric.TABLES_PER_REVISION,
       1,
-      { projectId },
+      { revisionId, projectId },
     );
 
     expect(result.allowed).toBe(true);

--- a/ee/billing/__tests__/usage.service.unit.spec.ts
+++ b/ee/billing/__tests__/usage.service.unit.spec.ts
@@ -6,7 +6,7 @@ import { UsageService } from '../usage/usage.service';
 
 type DbStub = {
   table: { findFirst: jest.Mock };
-  revision: { findFirst: jest.Mock };
+  revision: { findUnique: jest.Mock };
   branch: { count: jest.Mock };
   endpoint: { count: jest.Mock };
 };
@@ -14,7 +14,7 @@ type DbStub = {
 const makeService = () => {
   const db: DbStub = {
     table: { findFirst: jest.fn() },
-    revision: { findFirst: jest.fn() },
+    revision: { findUnique: jest.fn() },
     branch: { count: jest.fn() },
     endpoint: { count: jest.fn() },
   };
@@ -50,12 +50,12 @@ describe('UsageService (unit)', () => {
       ).rejects.toThrow('ROWS_PER_TABLE requires revisionId and tableId');
     });
 
-    it('throws when TABLES_PER_REVISION is called without projectId', async () => {
+    it('throws when TABLES_PER_REVISION is called without revisionId', async () => {
       const { service } = makeService();
 
       await expect(
         service.computeUsage('org-1', LimitMetric.TABLES_PER_REVISION),
-      ).rejects.toThrow('TABLES_PER_REVISION requires projectId');
+      ).rejects.toThrow('TABLES_PER_REVISION requires revisionId');
     });
 
     it('throws when BRANCHES_PER_PROJECT is called without projectId', async () => {
@@ -114,30 +114,34 @@ describe('UsageService (unit)', () => {
       expect(result).toBe(7);
     });
 
-    it('TABLES_PER_REVISION returns 0 when no draft revision is found', async () => {
+    it('TABLES_PER_REVISION returns 0 when the revision is not found', async () => {
       const { service, db } = makeService();
-      db.revision.findFirst.mockResolvedValue(null);
+      db.revision.findUnique.mockResolvedValue(null);
 
       const result = await service.computeUsage(
         'org-1',
         LimitMetric.TABLES_PER_REVISION,
-        { projectId: 'proj-1' },
+        { revisionId: 'rev-1' },
       );
 
       expect(result).toBe(0);
     });
 
-    it('TABLES_PER_REVISION returns the table count when a draft exists', async () => {
+    it('TABLES_PER_REVISION returns the table count for the requested revision', async () => {
       const { service, db } = makeService();
-      db.revision.findFirst.mockResolvedValue({ _count: { tables: 4 } });
+      db.revision.findUnique.mockResolvedValue({ _count: { tables: 4 } });
 
       const result = await service.computeUsage(
         'org-1',
         LimitMetric.TABLES_PER_REVISION,
-        { projectId: 'proj-1' },
+        { revisionId: 'rev-1' },
       );
 
       expect(result).toBe(4);
+      expect(db.revision.findUnique).toHaveBeenCalledWith({
+        where: { id: 'rev-1' },
+        select: { _count: { select: { tables: true } } },
+      });
     });
 
     it('BRANCHES_PER_PROJECT delegates to branch.count', async () => {

--- a/ee/billing/usage/usage.service.ts
+++ b/ee/billing/usage/usage.service.ts
@@ -86,10 +86,12 @@ export class UsageService {
         return this.countRowsInTable(context.revisionId, context.tableId);
       }
       case LimitMetric.TABLES_PER_REVISION: {
-        if (!context?.projectId) {
-          throw new Error('TABLES_PER_REVISION requires projectId in context');
+        if (!context?.revisionId) {
+          throw new Error(
+            'TABLES_PER_REVISION requires revisionId in context',
+          );
         }
-        return this.countTablesInRevision(context.projectId);
+        return this.countTablesInRevision(context.revisionId);
       }
       case LimitMetric.BRANCHES_PER_PROJECT: {
         if (!context?.projectId) {
@@ -174,12 +176,9 @@ export class UsageService {
     return table?._count.rows ?? 0;
   }
 
-  private async countTablesInRevision(projectId: string): Promise<number> {
-    const revision = await this.db.revision.findFirst({
-      where: {
-        isDraft: true,
-        branch: { projectId, isRoot: true },
-      },
+  private async countTablesInRevision(revisionId: string): Promise<number> {
+    const revision = await this.db.revision.findUnique({
+      where: { id: revisionId },
       select: { _count: { select: { tables: true } } },
     });
     return revision?._count.tables ?? 0;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated billing enforcement documentation with revised semantics for table-per-revision resource limits
  * Clarified that table limits are now scoped per individual revision, enabling independent tracking across draft revisions within a project

* **Tests**
  * Added comprehensive resource-level limit enforcement verification tests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->