### PR TITLE
fix: exclude system tables from tables_per_revision counter

### DIFF
--- a/ee/billing/__tests__/limits-enforcement-resource-level.spec.ts
+++ b/ee/billing/__tests__/limits-enforcement-resource-level.spec.ts
@@ -4,6 +4,8 @@ import { CoreModule } from 'src/core/core.module';
 import { BillingCheckService } from 'src/core/shared/billing-check.service';
 import { LimitExceededException } from 'src/features/billing/limit-exceeded.exception';
 import { LimitMetric } from 'src/features/billing/limits.interface';
+import { CreateProjectHandler } from 'src/features/project/commands/handlers/create-project.handler';
+import { CreateProjectCommand } from 'src/features/project/commands/impl';
 import { CACHE_SERVICE } from 'src/infrastructure/cache/services/cache.tokens';
 import { NoopCacheService } from 'src/infrastructure/cache/services/noop-cache.service';
 import { PrismaService } from 'src/infrastructure/database/prisma.service';
@@ -34,6 +36,7 @@ const FREE_LIMITS: OrgLimits = {
 describe('resource-level limit enforcement', () => {
   let module: TestingModule;
   let billingCheck: BillingCheckService;
+  let createProjectHandler: CreateProjectHandler;
   let prisma: PrismaService;
   let mockBillingClient: jest.Mocked<IBillingClient>;
 
@@ -62,6 +65,7 @@ describe('resource-level limit enforcement', () => {
       .compile();
 
     billingCheck = module.get(BillingCheckService);
+    createProjectHandler = module.get(CreateProjectHandler);
     prisma = module.get(PrismaService);
   });
 
@@ -114,6 +118,30 @@ describe('resource-level limit enforcement', () => {
     await expect(checkTableCreate(branchDraftId)).rejects.toBeInstanceOf(
       LimitExceededException,
     );
+  });
+
+  it('allows 5 user tables on a fresh project before rejecting the 6th', async () => {
+    const { masterDraftId } = await createFreshProjectWithMasterDraft();
+
+    for (let i = 1; i <= TABLE_CAP; i++) {
+      await expect(
+        createUserTable(masterDraftId, `user-table-${i}-${nanoid()}`),
+      ).resolves.toBeUndefined();
+    }
+
+    let error: unknown;
+    try {
+      await createUserTable(masterDraftId, `user-table-6-${nanoid()}`);
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(error).toBeInstanceOf(LimitExceededException);
+    expect((error as LimitExceededException).getResponse()).toMatchObject({
+      metric: LimitMetric.TABLES_PER_REVISION,
+      limit: TABLE_CAP,
+      current: TABLE_CAP,
+    });
   });
 
   async function checkTableCreate(revisionId: string) {
@@ -182,6 +210,38 @@ describe('resource-level limit enforcement', () => {
     await createTablesInRevision(branchDraftId, branchTableCount, 'branch');
 
     return { masterDraftId, branchDraftId };
+  }
+
+  async function createFreshProjectWithMasterDraft() {
+    const orgId = nanoid();
+    await prisma.organization.create({
+      data: { id: orgId, createdId: nanoid() },
+    });
+
+    const projectId = await createProjectHandler.execute(
+      new CreateProjectCommand({
+        organizationId: orgId,
+        projectName: `project-${nanoid()}`,
+      }),
+    );
+
+    const masterDraft = await prisma.revision.findFirstOrThrow({
+      where: {
+        isDraft: true,
+        branch: {
+          projectId,
+          isRoot: true,
+        },
+      },
+      select: { id: true },
+    });
+
+    return { masterDraftId: masterDraft.id };
+  }
+
+  async function createUserTable(revisionId: string, tableId: string) {
+    await checkTableCreate(revisionId);
+    await createTableInRevision(revisionId, tableId);
   }
 
   async function createTablesInRevision(

--- a/ee/billing/__tests__/limits-enforcement-resource-level.spec.ts
+++ b/ee/billing/__tests__/limits-enforcement-resource-level.spec.ts
@@ -6,6 +6,7 @@ import { LimitExceededException } from 'src/features/billing/limit-exceeded.exce
 import { LimitMetric } from 'src/features/billing/limits.interface';
 import { CreateProjectHandler } from 'src/features/project/commands/handlers/create-project.handler';
 import { CreateProjectCommand } from 'src/features/project/commands/impl';
+import { SYSTEM_TABLE_PREFIX } from 'src/features/share/system-tables.consts';
 import { CACHE_SERVICE } from 'src/infrastructure/cache/services/cache.tokens';
 import { NoopCacheService } from 'src/infrastructure/cache/services/noop-cache.service';
 import { PrismaService } from 'src/infrastructure/database/prisma.service';
@@ -122,6 +123,14 @@ describe('resource-level limit enforcement', () => {
 
   it('allows 5 user tables on a fresh project before rejecting the 6th', async () => {
     const { masterDraftId } = await createFreshProjectWithMasterDraft();
+
+    const systemTableCount = await prisma.table.count({
+      where: {
+        revisions: { some: { id: masterDraftId } },
+        id: { startsWith: SYSTEM_TABLE_PREFIX },
+      },
+    });
+    expect(systemTableCount).toBeGreaterThan(0);
 
     for (let i = 1; i <= TABLE_CAP; i++) {
       await expect(

--- a/ee/billing/__tests__/usage.service.unit.spec.ts
+++ b/ee/billing/__tests__/usage.service.unit.spec.ts
@@ -1,11 +1,12 @@
 import { EngineApiService } from '@revisium/engine';
 import { LimitMetric } from 'src/features/billing/limits.interface';
+import { SYSTEM_TABLE_PREFIX } from 'src/features/share/system-tables.consts';
 import { PrismaService } from 'src/infrastructure/database/prisma.service';
 import { TransactionPrismaService } from 'src/infrastructure/database/transaction-prisma.service';
 import { UsageService } from '../usage/usage.service';
 
 type DbStub = {
-  table: { findFirst: jest.Mock };
+  table: { count: jest.Mock; findFirst: jest.Mock };
   revision: { findUnique: jest.Mock };
   branch: { count: jest.Mock };
   endpoint: { count: jest.Mock };
@@ -13,7 +14,7 @@ type DbStub = {
 
 const makeService = () => {
   const db: DbStub = {
-    table: { findFirst: jest.fn() },
+    table: { count: jest.fn(), findFirst: jest.fn() },
     revision: { findUnique: jest.fn() },
     branch: { count: jest.fn() },
     endpoint: { count: jest.fn() },
@@ -114,9 +115,9 @@ describe('UsageService (unit)', () => {
       expect(result).toBe(7);
     });
 
-    it('TABLES_PER_REVISION returns 0 when the revision is not found', async () => {
+    it('TABLES_PER_REVISION returns 0 when no user tables are linked', async () => {
       const { service, db } = makeService();
-      db.revision.findUnique.mockResolvedValue(null);
+      db.table.count.mockResolvedValue(0);
 
       const result = await service.computeUsage(
         'org-1',
@@ -129,7 +130,7 @@ describe('UsageService (unit)', () => {
 
     it('TABLES_PER_REVISION returns the table count for the requested revision', async () => {
       const { service, db } = makeService();
-      db.revision.findUnique.mockResolvedValue({ _count: { tables: 4 } });
+      db.table.count.mockResolvedValue(4);
 
       const result = await service.computeUsage(
         'org-1',
@@ -138,9 +139,11 @@ describe('UsageService (unit)', () => {
       );
 
       expect(result).toBe(4);
-      expect(db.revision.findUnique).toHaveBeenCalledWith({
-        where: { id: 'rev-1' },
-        select: { _count: { select: { tables: true } } },
+      expect(db.table.count).toHaveBeenCalledWith({
+        where: {
+          revisions: { some: { id: 'rev-1' } },
+          NOT: { id: { startsWith: SYSTEM_TABLE_PREFIX } },
+        },
       });
     });
 

--- a/ee/billing/usage/usage.service.ts
+++ b/ee/billing/usage/usage.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { EngineApiService } from '@revisium/engine';
 import { countOrgRowVersions } from 'src/__generated__/client/sql';
 import { LimitMetric } from 'src/features/billing/limits.interface';
+import { SYSTEM_TABLE_PREFIX } from 'src/features/share/system-tables.consts';
 import { PrismaService } from 'src/infrastructure/database/prisma.service';
 import { TransactionPrismaService } from 'src/infrastructure/database/transaction-prisma.service';
 import { buildMetric } from './build-metric';
@@ -177,11 +178,12 @@ export class UsageService {
   }
 
   private async countTablesInRevision(revisionId: string): Promise<number> {
-    const revision = await this.db.revision.findUnique({
-      where: { id: revisionId },
-      select: { _count: { select: { tables: true } } },
+    return this.db.table.count({
+      where: {
+        revisions: { some: { id: revisionId } },
+        NOT: { id: { startsWith: SYSTEM_TABLE_PREFIX } },
+      },
     });
-    return revision?._count.tables ?? 0;
   }
 
   private async countBranchesInProject(projectId: string): Promise<number> {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed table usage metrics to accurately exclude system tables from calculations, improving billing accuracy.
  * Enhanced table-per-revision limit enforcement with detailed error messages indicating current usage and limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->