### PR TITLE
fix(cache): group auth:token-version keys in cache stats

### DIFF
--- a/src/infrastructure/cache/revisium-cache.module.ts
+++ b/src/infrastructure/cache/revisium-cache.module.ts
@@ -33,6 +33,7 @@ const CACHE_KEY_GROUPS: [RegExp, string][] = [
   [/^auth:role:permissions:/, 'auth-roles'],
   [/^auth:check-/, 'auth-checks'],
   [/^auth:api-key:/, 'auth-api-keys'],
+  [/^auth:token-version:/, 'auth-token-versions'],
   [/^billing:sub:/, 'billing-subscriptions'],
   [/^billing:usage:/, 'billing-usage'],
   [/^billing:rev-org:/, 'billing-lookups'],


### PR DESCRIPTION
`auth:token-version:${userId}` had no matching regex in `CACHE_KEY_GROUPS` (revisium-cache.module.ts), so the bentocache prometheus plugin labelled each key with its raw user id. `adminCacheStats.byCategory` ended up with one row per user (e.g. `auth:token-version:admin`, `auth:token-version:AHft48qYXeY_JgAgOnNLc`, ...), inflating prometheus label cardinality.

Added a regex bucketing these keys into `auth-token-versions`, matching the pattern used for `auth:role:permissions:`, `auth:check-`, and `auth:api-key:`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

This release includes internal infrastructure optimizations with no user-facing changes. Cache metrics monitoring has been enhanced to better track authentication token operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->