### PR TITLE
feat(api-keys): add REST endpoints for API key management

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "generate:seed:api": "ts-node prisma/seed/generateSeedApi.ts",
     "generate:seed:load": "ts-node prisma/seed/loadFromSeedApi.ts",
     "generate:internal-key": "ts-node scripts/generate-internal-key.ts",
+    "generate:openapi-snapshot": "NODE_ENV=test dotenv -e .env.test -- ts-node -r tsconfig-paths/register scripts/update-openapi-snapshot.ts",
     "seed": "ts-node prisma/seed.ts",
     "seed:prod": "node --experimental-require-module dist/prisma/seed.js",
     "build": "nest build && tsc-alias -p tsconfig.build.json",

--- a/scripts/update-openapi-snapshot.ts
+++ b/scripts/update-openapi-snapshot.ts
@@ -1,0 +1,31 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { Test } from '@nestjs/testing';
+import request from 'supertest';
+import { initSwagger } from 'src/api/rest-api/init-swagger';
+import { CoreModule } from 'src/core/core.module';
+import { registerGraphqlEnums } from 'src/api/graphql-api/registerGraphqlEnums';
+
+async function main() {
+  registerGraphqlEnums();
+
+  const moduleFixture = await Test.createTestingModule({
+    imports: [CoreModule.forRoot({ mode: 'monolith' })],
+  }).compile();
+
+  const app = moduleFixture.createNestApplication();
+  initSwagger(app);
+  await app.init();
+
+  const res = await request(app.getHttpServer()).get('/api-json').expect(200);
+
+  const out = path.resolve(__dirname, '../src/api/rest-api/openapi.json');
+  fs.writeFileSync(out, JSON.stringify(res.body, null, 2) + '\n');
+
+  await app.close();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/update-openapi-snapshot.ts
+++ b/scripts/update-openapi-snapshot.ts
@@ -14,15 +14,17 @@ async function main() {
   }).compile();
 
   const app = moduleFixture.createNestApplication();
-  initSwagger(app);
-  await app.init();
+  try {
+    initSwagger(app);
+    await app.init();
 
-  const res = await request(app.getHttpServer()).get('/api-json').expect(200);
+    const res = await request(app.getHttpServer()).get('/api-json').expect(200);
 
-  const out = path.resolve(__dirname, '../src/api/rest-api/openapi.json');
-  fs.writeFileSync(out, JSON.stringify(res.body, null, 2) + '\n');
-
-  await app.close();
+    const out = path.resolve(__dirname, '../src/api/rest-api/openapi.json');
+    fs.writeFileSync(out, JSON.stringify(res.body, null, 2) + '\n');
+  } finally {
+    await app.close();
+  }
 }
 
 main().catch((err) => {

--- a/scripts/update-openapi-snapshot.ts
+++ b/scripts/update-openapi-snapshot.ts
@@ -1,5 +1,5 @@
-import * as fs from 'fs';
-import * as path from 'path';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import { Test } from '@nestjs/testing';
 import request from 'supertest';
 import { initSwagger } from 'src/api/rest-api/init-swagger';

--- a/src/api/__tests__/api-key/api-key-rest.e2e.spec.ts
+++ b/src/api/__tests__/api-key/api-key-rest.e2e.spec.ts
@@ -1,0 +1,250 @@
+import { INestApplication } from '@nestjs/common';
+import request from 'supertest';
+import { getTestApp } from 'src/testing/e2e';
+import {
+  prepareData,
+  prepareDataWithRoles,
+  type PrepareDataReturnType,
+  type PrepareDataWithRolesReturnType,
+} from 'src/testing/utils/prepareProject';
+
+describe('API key REST endpoints (e2e)', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    app = await getTestApp();
+  });
+
+  const restRequest = (method: 'get' | 'post', url: string, token?: string) => {
+    const req = request(app.getHttpServer())[method](url);
+    if (token) {
+      req.set('Authorization', `Bearer ${token}`);
+    }
+    return req;
+  };
+
+  describe('Personal API keys', () => {
+    let preparedData: PrepareDataReturnType;
+
+    beforeEach(async () => {
+      preparedData = await prepareData(app, { fullAnotherProject: true });
+    });
+
+    it('POST /api/api-keys/personal returns secret + apiKey, secret matches rev_ format', async () => {
+      const res = await restRequest(
+        'post',
+        '/api/api-keys/personal',
+        preparedData.owner.token,
+      )
+        .send({ name: 'CI/CD Key' })
+        .expect(201);
+
+      expect(res.body.secret).toMatch(/^rev_[A-Za-z0-9_-]{22}$/);
+      expect(res.body.apiKey.id).toBeDefined();
+      expect(res.body.apiKey.type).toBe('PERSONAL');
+      expect(res.body.apiKey.name).toBe('CI/CD Key');
+      expect(res.body.apiKey.revokedAt).toBeNull();
+    });
+
+    it('POST /api/api-keys/personal accepts scope fields', async () => {
+      const res = await restRequest(
+        'post',
+        '/api/api-keys/personal',
+        preparedData.owner.token,
+      )
+        .send({
+          name: 'Scoped Key',
+          organizationId: preparedData.project.organizationId,
+          projectIds: [preparedData.project.projectId],
+          branchNames: ['master'],
+          readOnly: true,
+        })
+        .expect(201);
+
+      expect(res.body.apiKey.organizationId).toBe(
+        preparedData.project.organizationId,
+      );
+      expect(res.body.apiKey.projectIds).toEqual([
+        preparedData.project.projectId,
+      ]);
+      expect(res.body.apiKey.branchNames).toEqual(['master']);
+      expect(res.body.apiKey.readOnly).toBe(true);
+    });
+
+    it('GET /api/api-keys/personal lists current-user keys without secret', async () => {
+      await restRequest(
+        'post',
+        '/api/api-keys/personal',
+        preparedData.owner.token,
+      )
+        .send({ name: 'List Me' })
+        .expect(201);
+
+      const res = await restRequest(
+        'get',
+        '/api/api-keys/personal',
+        preparedData.owner.token,
+      ).expect(200);
+
+      expect(Array.isArray(res.body)).toBe(true);
+      expect(res.body.length).toBeGreaterThanOrEqual(1);
+      for (const key of res.body) {
+        expect(key.secret).toBeUndefined();
+        expect(key.id).toBeDefined();
+      }
+    });
+
+    it('GET /api/api-keys/:id returns own key, 404 for cross-user', async () => {
+      const created = await restRequest(
+        'post',
+        '/api/api-keys/personal',
+        preparedData.owner.token,
+      )
+        .send({ name: 'Private Key' })
+        .expect(201);
+      const keyId = created.body.apiKey.id;
+
+      const own = await restRequest(
+        'get',
+        `/api/api-keys/${keyId}`,
+        preparedData.owner.token,
+      ).expect(200);
+      expect(own.body.id).toBe(keyId);
+
+      await restRequest(
+        'get',
+        `/api/api-keys/${keyId}`,
+        preparedData.anotherOwner.token,
+      ).expect(404);
+    });
+
+    it('POST /api/api-keys/:id/rotate returns a fresh secret + new id', async () => {
+      const created = await restRequest(
+        'post',
+        '/api/api-keys/personal',
+        preparedData.owner.token,
+      )
+        .send({ name: 'To Rotate' })
+        .expect(201);
+
+      const originalId = created.body.apiKey.id;
+      const originalSecret = created.body.secret;
+
+      const rotated = await restRequest(
+        'post',
+        `/api/api-keys/${originalId}/rotate`,
+        preparedData.owner.token,
+      ).expect(201);
+
+      expect(rotated.body.secret).toMatch(/^rev_[A-Za-z0-9_-]{22}$/);
+      expect(rotated.body.secret).not.toBe(originalSecret);
+      expect(rotated.body.apiKey.id).not.toBe(originalId);
+    });
+
+    it('POST /api/api-keys/:id/revoke sets revokedAt, key auth then rejected', async () => {
+      const created = await restRequest(
+        'post',
+        '/api/api-keys/personal',
+        preparedData.owner.token,
+      )
+        .send({ name: 'To Revoke' })
+        .expect(201);
+
+      const keyId = created.body.apiKey.id;
+      const secret = created.body.secret;
+
+      const revoked = await restRequest(
+        'post',
+        `/api/api-keys/${keyId}/revoke`,
+        preparedData.owner.token,
+      ).expect(200);
+
+      expect(revoked.body.id).toBe(keyId);
+      expect(revoked.body.revokedAt).not.toBeNull();
+
+      const rowUrl = `/api/revision/${preparedData.project.draftRevisionId}/tables/${preparedData.project.tableId}/rows/${preparedData.project.rowId}`;
+      await request(app.getHttpServer())
+        .get(rowUrl)
+        .set('X-Api-Key', secret)
+        .expect(401);
+    });
+  });
+
+  describe('Service API keys', () => {
+    let preparedData: PrepareDataWithRolesReturnType;
+
+    beforeEach(async () => {
+      preparedData = await prepareDataWithRoles(app);
+    });
+
+    it('POST /api/organization/:organizationId/api-keys/service creates a service key', async () => {
+      const res = await restRequest(
+        'post',
+        `/api/organization/${preparedData.project.organizationId}/api-keys/service`,
+        preparedData.owner.token,
+      )
+        .send({
+          name: 'Integration Key',
+          permissions: {
+            rules: [{ action: ['read'], subject: ['Row', 'Table'] }],
+          },
+        })
+        .expect(201);
+
+      expect(res.body.secret).toMatch(/^rev_[A-Za-z0-9_-]{22}$/);
+      expect(res.body.apiKey.type).toBe('SERVICE');
+      expect(res.body.apiKey.organizationId).toBe(
+        preparedData.project.organizationId,
+      );
+      expect(res.body.apiKey.permissions).toEqual({
+        rules: [{ action: ['read'], subject: ['Row', 'Table'] }],
+      });
+    });
+
+    it('GET /api/organization/:organizationId/api-keys/service lists service keys', async () => {
+      await restRequest(
+        'post',
+        `/api/organization/${preparedData.project.organizationId}/api-keys/service`,
+        preparedData.owner.token,
+      )
+        .send({
+          name: 'svc-list',
+          permissions: { rules: [{ action: ['read'], subject: ['Row'] }] },
+        })
+        .expect(201);
+
+      const res = await restRequest(
+        'get',
+        `/api/organization/${preparedData.project.organizationId}/api-keys/service`,
+        preparedData.owner.token,
+      ).expect(200);
+
+      expect(Array.isArray(res.body)).toBe(true);
+      expect(res.body.length).toBeGreaterThanOrEqual(1);
+      expect(
+        res.body.every((k: { type: string }) => k.type === 'SERVICE'),
+      ).toBe(true);
+    });
+
+    it('cross-org owner cannot create service keys (403)', async () => {
+      await restRequest(
+        'post',
+        `/api/organization/${preparedData.project.organizationId}/api-keys/service`,
+        preparedData.anotherOwner.token,
+      )
+        .send({
+          name: 'cross-org',
+          permissions: { rules: [{ action: ['read'], subject: ['Row'] }] },
+        })
+        .expect(403);
+    });
+
+    it('reader cannot list service keys (403)', async () => {
+      await restRequest(
+        'get',
+        `/api/organization/${preparedData.project.organizationId}/api-keys/service`,
+        preparedData.reader.token,
+      ).expect(403);
+    });
+  });
+});

--- a/src/api/__tests__/api-key/api-key-rest.e2e.spec.ts
+++ b/src/api/__tests__/api-key/api-key-rest.e2e.spec.ts
@@ -71,13 +71,21 @@ describe('API key REST endpoints (e2e)', () => {
       expect(res.body.apiKey.readOnly).toBe(true);
     });
 
-    it('GET /api/api-keys/personal lists current-user keys without secret', async () => {
-      await restRequest(
+    it('GET /api/api-keys/personal lists own keys only, no secret', async () => {
+      const ownCreated = await restRequest(
         'post',
         '/api/api-keys/personal',
         preparedData.owner.token,
       )
         .send({ name: 'List Me' })
+        .expect(201);
+
+      const otherCreated = await restRequest(
+        'post',
+        '/api/api-keys/personal',
+        preparedData.anotherOwner.token,
+      )
+        .send({ name: 'Not Mine' })
         .expect(201);
 
       const res = await restRequest(
@@ -87,7 +95,9 @@ describe('API key REST endpoints (e2e)', () => {
       ).expect(200);
 
       expect(Array.isArray(res.body)).toBe(true);
-      expect(res.body.length).toBeGreaterThanOrEqual(1);
+      const ids = res.body.map((k: { id: string }) => k.id);
+      expect(ids).toContain(ownCreated.body.apiKey.id);
+      expect(ids).not.toContain(otherCreated.body.apiKey.id);
       for (const key of res.body) {
         expect(key.secret).toBeUndefined();
         expect(key.id).toBeDefined();
@@ -221,9 +231,11 @@ describe('API key REST endpoints (e2e)', () => {
 
       expect(Array.isArray(res.body)).toBe(true);
       expect(res.body.length).toBeGreaterThanOrEqual(1);
-      expect(
-        res.body.every((k: { type: string }) => k.type === 'SERVICE'),
-      ).toBe(true);
+      for (const key of res.body) {
+        expect(key.type).toBe('SERVICE');
+        expect(key.organizationId).toBe(preparedData.project.organizationId);
+        expect(key.secret).toBeUndefined();
+      }
     });
 
     it('cross-org owner cannot create service keys (403)', async () => {

--- a/src/api/__tests__/api-key/create-personal-api-key.auth.e2e.spec.ts
+++ b/src/api/__tests__/api-key/create-personal-api-key.auth.e2e.spec.ts
@@ -22,6 +22,11 @@ const createPersonalApiKey = operation<{ name: string; projectIds: string[] }>({
     `,
     variables: (p) => ({ data: p }),
   },
+  rest: {
+    method: 'post',
+    url: () => '/api/api-keys/personal',
+    body: (p) => p,
+  },
 });
 
 const cases: AuthMatrixCaseBase[] = [

--- a/src/api/__tests__/api-key/create-service-api-key.auth.e2e.spec.ts
+++ b/src/api/__tests__/api-key/create-service-api-key.auth.e2e.spec.ts
@@ -29,6 +29,16 @@ const createServiceApiKey = operation<CreateServiceApiKeyParams>({
     `,
     variables: (p) => ({ data: p }),
   },
+  rest: {
+    method: 'post',
+    url: ({ organizationId }) =>
+      `/api/organization/${organizationId}/api-keys/service`,
+    body: ({ name, projectIds, permissions }) => ({
+      name,
+      projectIds,
+      permissions,
+    }),
+  },
 });
 
 const cases: AuthMatrixCaseBase[] = [

--- a/src/api/__tests__/api-key/my-api-keys.auth.e2e.spec.ts
+++ b/src/api/__tests__/api-key/my-api-keys.auth.e2e.spec.ts
@@ -18,6 +18,10 @@ const myApiKeys = operation<Record<string, never>>({
     `,
     variables: () => ({}),
   },
+  rest: {
+    method: 'get',
+    url: () => '/api/api-keys/personal',
+  },
 });
 
 const cases: AuthMatrixCaseBase[] = [

--- a/src/api/__tests__/api-key/revoke-api-key.auth.e2e.spec.ts
+++ b/src/api/__tests__/api-key/revoke-api-key.auth.e2e.spec.ts
@@ -22,6 +22,10 @@ const revokeApiKey = operation<{ id: string }>({
     `,
     variables: ({ id }) => ({ id }),
   },
+  rest: {
+    method: 'post',
+    url: ({ id }) => `/api/api-keys/${id}/revoke`,
+  },
 });
 
 describe('revokeApiKey auth', () => {

--- a/src/api/__tests__/api-key/rotate-api-key.auth.e2e.spec.ts
+++ b/src/api/__tests__/api-key/rotate-api-key.auth.e2e.spec.ts
@@ -10,25 +10,28 @@ import {
 } from 'src/testing/kit/auth-permission';
 import { usingFreshProject } from 'src/testing/scenarios/using-fresh-project';
 
-const apiKeyById = operation<{ id: string }>({
-  id: 'apiKey.byId',
+const rotateApiKey = operation<{ id: string }>({
+  id: 'apiKey.rotate',
   gql: {
     query: gql`
-      query apiKeyById($id: ID!) {
-        apiKeyById(id: $id) {
-          id
+      mutation rotateApiKey($id: ID!) {
+        rotateApiKey(id: $id) {
+          apiKey {
+            id
+          }
+          secret
         }
       }
     `,
     variables: ({ id }) => ({ id }),
   },
   rest: {
-    method: 'get',
-    url: ({ id }) => `/api/api-keys/${id}`,
+    method: 'post',
+    url: ({ id }) => `/api/api-keys/${id}/rotate`,
   },
 });
 
-describe('apiKeyById auth', () => {
+describe('rotateApiKey auth', () => {
   const fresh = usingFreshProject();
   let app: INestApplication;
   let ownerKeyId: string;
@@ -43,6 +46,9 @@ describe('apiKeyById auth', () => {
     ownerKeyId = created.id;
   });
 
+  // Owner rotates own key. Cross-owner sees not_found (IDOR scoping). Anon
+  // gated at auth. Each rotate creates a new id, so the test cannot reuse
+  // ownerKeyId across cases — usingFreshProject already re-seeds beforeEach.
   const realKeyCases: AuthMatrixCaseBase[] = [
     { name: 'owner (own key)', role: 'owner', expected: 'allowed' },
     {
@@ -55,7 +61,7 @@ describe('apiKeyById auth', () => {
 
   describe('real key', () => {
     runAuthMatrix({
-      op: apiKeyById,
+      op: rotateApiKey,
       cases: realKeyCases,
       build: () => ({
         fixture: fresh.fixture,
@@ -66,7 +72,7 @@ describe('apiKeyById auth', () => {
 
   describe('non-existent key', () => {
     runAuthMatrix({
-      op: apiKeyById,
+      op: rotateApiKey,
       cases: [
         { name: 'owner (missing)', role: 'owner', expected: 'not_found' },
         {

--- a/src/api/__tests__/api-key/service-api-keys.auth.e2e.spec.ts
+++ b/src/api/__tests__/api-key/service-api-keys.auth.e2e.spec.ts
@@ -18,6 +18,11 @@ const serviceApiKeys = operation<{ organizationId: string }>({
     `,
     variables: ({ organizationId }) => ({ organizationId }),
   },
+  rest: {
+    method: 'get',
+    url: ({ organizationId }) =>
+      `/api/organization/${organizationId}/api-keys/service`,
+  },
 });
 
 // serviceApiKeys scopes by organization membership role:

--- a/src/api/rest-api/api-key/api-key-service.controller.ts
+++ b/src/api/rest-api/api-key/api-key-service.controller.ts
@@ -1,0 +1,96 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Post,
+  Request,
+  UseGuards,
+  UseInterceptors,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiCreatedResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiSecurity,
+  ApiTags,
+} from '@nestjs/swagger';
+import { Prisma } from 'src/__generated__/client';
+import { CreateServiceApiKeyDto } from 'src/api/rest-api/api-key/dto/create-service-api-key.dto';
+import { ApiKeyModel } from 'src/api/rest-api/api-key/model/api-key.model';
+import { ApiKeyWithSecretModel } from 'src/api/rest-api/api-key/model/api-key-with-secret.model';
+import { toApiKeyModel } from 'src/api/rest-api/api-key/api-key.mapper';
+import {
+  ApiCommonErrors,
+  ApiOrganizationIdParam,
+} from 'src/api/rest-api/share/decorators';
+import { ApiKeyApiService } from 'src/features/api-key/api-key-api.service';
+import { HttpJwtAuthGuard } from 'src/features/auth/guards/jwt/http-jwt-auth-guard.service';
+import { IAuthUser } from 'src/features/auth/types';
+import { RestMetricsInterceptor } from 'src/infrastructure/metrics/rest/rest-metrics.interceptor';
+
+@UseInterceptors(RestMetricsInterceptor)
+@UseGuards(HttpJwtAuthGuard)
+@ApiTags('ApiKey')
+@ApiBearerAuth('access-token')
+@ApiSecurity('api-key')
+@Controller('organization/:organizationId/api-keys')
+export class ApiKeyServiceController {
+  constructor(private readonly apiKeyApiService: ApiKeyApiService) {}
+
+  @Post('service')
+  @ApiOrganizationIdParam()
+  @ApiOperation({
+    operationId: 'createServiceApiKey',
+    summary: 'Create a service API key for an organization',
+    description:
+      'Requires `manage` on `ApiKey` for the organization (scoped further ' +
+      'to projects when `projectIds` is supplied). The plaintext secret is ' +
+      'returned only on this response.',
+  })
+  @ApiCreatedResponse({ type: ApiKeyWithSecretModel })
+  @ApiCommonErrors()
+  async createServiceApiKey(
+    @Param('organizationId') organizationId: string,
+    @Body() data: CreateServiceApiKeyDto,
+    @Request() req: { user: IAuthUser },
+  ): Promise<ApiKeyWithSecretModel> {
+    const result = await this.apiKeyApiService.createServiceApiKey({
+      ...data,
+      organizationId,
+      userId: req.user.userId,
+      permissions: data.permissions as unknown as Prisma.InputJsonValue,
+    });
+
+    const apiKey = await this.apiKeyApiService.getApiKeyById(
+      result.id,
+      req.user.userId,
+    );
+
+    return {
+      apiKey: toApiKeyModel(apiKey),
+      secret: result.key,
+    };
+  }
+
+  @Get('service')
+  @ApiOrganizationIdParam()
+  @ApiOperation({
+    operationId: 'serviceApiKeys',
+    summary: 'List organization service API keys',
+    description: 'Requires `manage` on `ApiKey` for the organization.',
+  })
+  @ApiOkResponse({ type: ApiKeyModel, isArray: true })
+  @ApiCommonErrors()
+  async serviceApiKeys(
+    @Param('organizationId') organizationId: string,
+    @Request() req: { user: IAuthUser },
+  ): Promise<ApiKeyModel[]> {
+    const keys = await this.apiKeyApiService.getServiceApiKeys(
+      organizationId,
+      req.user.userId,
+    );
+    return keys.map((key) => toApiKeyModel(key));
+  }
+}

--- a/src/api/rest-api/api-key/api-key.controller.ts
+++ b/src/api/rest-api/api-key/api-key.controller.ts
@@ -1,0 +1,157 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Post,
+  Request,
+  UseGuards,
+  UseInterceptors,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiCreatedResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiParam,
+  ApiSecurity,
+  ApiTags,
+} from '@nestjs/swagger';
+import { CreatePersonalApiKeyDto } from 'src/api/rest-api/api-key/dto/create-personal-api-key.dto';
+import { ApiKeyModel } from 'src/api/rest-api/api-key/model/api-key.model';
+import { ApiKeyWithSecretModel } from 'src/api/rest-api/api-key/model/api-key-with-secret.model';
+import { toApiKeyModel } from 'src/api/rest-api/api-key/api-key.mapper';
+import { ApiCommonErrors } from 'src/api/rest-api/share/decorators';
+import { ApiKeyApiService } from 'src/features/api-key/api-key-api.service';
+import { HttpJwtAuthGuard } from 'src/features/auth/guards/jwt/http-jwt-auth-guard.service';
+import { IAuthUser } from 'src/features/auth/types';
+import { RestMetricsInterceptor } from 'src/infrastructure/metrics/rest/rest-metrics.interceptor';
+
+@UseInterceptors(RestMetricsInterceptor)
+@UseGuards(HttpJwtAuthGuard)
+@ApiTags('ApiKey')
+@ApiBearerAuth('access-token')
+@ApiSecurity('api-key')
+@Controller('api-keys')
+export class ApiKeyController {
+  constructor(private readonly apiKeyApiService: ApiKeyApiService) {}
+
+  @Post('personal')
+  @ApiOperation({
+    operationId: 'createPersonalApiKey',
+    summary: 'Create a personal API key for the current user',
+    description:
+      'Returns the plaintext secret only on this response. ' +
+      'Store it now — it cannot be retrieved later.',
+  })
+  @ApiCreatedResponse({ type: ApiKeyWithSecretModel })
+  @ApiCommonErrors()
+  async createPersonalApiKey(
+    @Body() data: CreatePersonalApiKeyDto,
+    @Request() req: { user: IAuthUser },
+  ): Promise<ApiKeyWithSecretModel> {
+    const result = await this.apiKeyApiService.createPersonalApiKey({
+      ...data,
+      userId: req.user.userId,
+    });
+
+    const apiKey = await this.apiKeyApiService.getApiKeyById(
+      result.id,
+      req.user.userId,
+    );
+
+    return {
+      apiKey: toApiKeyModel(apiKey),
+      secret: result.key,
+    };
+  }
+
+  @Get('personal')
+  @ApiOperation({
+    operationId: 'myApiKeys',
+    summary: "List the current user's personal API keys",
+  })
+  @ApiOkResponse({ type: ApiKeyModel, isArray: true })
+  @ApiCommonErrors()
+  async myApiKeys(@Request() req: { user: IAuthUser }): Promise<ApiKeyModel[]> {
+    const keys = await this.apiKeyApiService.getMyApiKeys(req.user.userId);
+    return keys.map((key) => toApiKeyModel(key));
+  }
+
+  @Get(':id')
+  @ApiParam({ name: 'id', description: 'API key identifier' })
+  @ApiOperation({
+    operationId: 'apiKeyById',
+    summary: 'Read one API key visible to the current user',
+  })
+  @ApiOkResponse({ type: ApiKeyModel })
+  @ApiCommonErrors()
+  async apiKeyById(
+    @Param('id') id: string,
+    @Request() req: { user: IAuthUser },
+  ): Promise<ApiKeyModel> {
+    const apiKey = await this.apiKeyApiService.getApiKeyById(
+      id,
+      req.user.userId,
+    );
+    return toApiKeyModel(apiKey);
+  }
+
+  @Post(':id/rotate')
+  @ApiParam({ name: 'id', description: 'API key identifier' })
+  @ApiOperation({
+    operationId: 'rotateApiKey',
+    summary: 'Rotate a key — revokes the original and returns a new secret',
+    description:
+      'Atomically revokes the original key and creates a replacement with ' +
+      'the same scope. The new plaintext secret is returned only on this ' +
+      'response.',
+  })
+  @ApiCreatedResponse({ type: ApiKeyWithSecretModel })
+  @ApiCommonErrors()
+  async rotateApiKey(
+    @Param('id') id: string,
+    @Request() req: { user: IAuthUser },
+  ): Promise<ApiKeyWithSecretModel> {
+    const result = await this.apiKeyApiService.rotateApiKey(
+      id,
+      req.user.userId,
+    );
+
+    const apiKey = await this.apiKeyApiService.getApiKeyById(
+      result.id,
+      req.user.userId,
+    );
+
+    return {
+      apiKey: toApiKeyModel(apiKey),
+      secret: result.key,
+    };
+  }
+
+  @Post(':id/revoke')
+  @HttpCode(HttpStatus.OK)
+  @ApiParam({ name: 'id', description: 'API key identifier' })
+  @ApiOperation({
+    operationId: 'revokeApiKey',
+    summary: 'Revoke a key',
+    description:
+      'Sets `revokedAt` on the key. The record is preserved for audit; ' +
+      'subsequent authentication attempts with this key are rejected.',
+  })
+  @ApiOkResponse({ type: ApiKeyModel })
+  @ApiCommonErrors()
+  async revokeApiKey(
+    @Param('id') id: string,
+    @Request() req: { user: IAuthUser },
+  ): Promise<ApiKeyModel> {
+    await this.apiKeyApiService.revokeApiKey(id, req.user.userId);
+    const apiKey = await this.apiKeyApiService.getApiKeyById(
+      id,
+      req.user.userId,
+    );
+    return toApiKeyModel(apiKey);
+  }
+}

--- a/src/api/rest-api/api-key/api-key.mapper.ts
+++ b/src/api/rest-api/api-key/api-key.mapper.ts
@@ -1,0 +1,39 @@
+import { GetApiKeyByIdQueryReturnType } from 'src/features/api-key/queries/impl';
+import { ApiKeyModel } from 'src/api/rest-api/api-key/model/api-key.model';
+
+type ApiKeyLike = Pick<
+  GetApiKeyByIdQueryReturnType,
+  | 'id'
+  | 'prefix'
+  | 'type'
+  | 'name'
+  | 'organizationId'
+  | 'projectIds'
+  | 'branchNames'
+  | 'tableIds'
+  | 'readOnly'
+  | 'allowedIps'
+  | 'permissions'
+  | 'expiresAt'
+  | 'lastUsedAt'
+  | 'createdAt'
+  | 'revokedAt'
+>;
+
+export const toApiKeyModel = (apiKey: ApiKeyLike): ApiKeyModel => ({
+  id: apiKey.id,
+  prefix: apiKey.prefix,
+  type: apiKey.type,
+  name: apiKey.name,
+  organizationId: apiKey.organizationId ?? null,
+  projectIds: apiKey.projectIds,
+  branchNames: apiKey.branchNames,
+  tableIds: apiKey.tableIds,
+  readOnly: apiKey.readOnly,
+  allowedIps: apiKey.allowedIps,
+  permissions: apiKey.permissions ?? null,
+  expiresAt: apiKey.expiresAt ?? null,
+  lastUsedAt: apiKey.lastUsedAt ?? null,
+  createdAt: apiKey.createdAt,
+  revokedAt: apiKey.revokedAt ?? null,
+});

--- a/src/api/rest-api/api-key/dto/base-api-key-scope.dto.ts
+++ b/src/api/rest-api/api-key/dto/base-api-key-scope.dto.ts
@@ -1,0 +1,46 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+  IsArray,
+  IsBoolean,
+  IsDate,
+  IsOptional,
+  IsString,
+} from 'class-validator';
+
+export class BaseApiKeyScopeDto {
+  @ApiProperty({ required: false, type: [String] })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  projectIds?: string[];
+
+  @ApiProperty({ required: false, type: [String] })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  branchNames?: string[];
+
+  @ApiProperty({ required: false, type: [String] })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  tableIds?: string[];
+
+  @ApiProperty({ required: false, default: false })
+  @IsOptional()
+  @IsBoolean()
+  readOnly?: boolean;
+
+  @ApiProperty({ required: false, type: [String] })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  allowedIps?: string[];
+
+  @ApiProperty({ required: false, type: String, format: 'date-time' })
+  @IsOptional()
+  @Type(() => Date)
+  @IsDate()
+  expiresAt?: Date;
+}

--- a/src/api/rest-api/api-key/dto/create-personal-api-key.dto.ts
+++ b/src/api/rest-api/api-key/dto/create-personal-api-key.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsOptional, IsString } from 'class-validator';
+import { BaseApiKeyScopeDto } from 'src/api/rest-api/api-key/dto/base-api-key-scope.dto';
+
+export class CreatePersonalApiKeyDto extends BaseApiKeyScopeDto {
+  @ApiProperty()
+  @IsString()
+  name: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  organizationId?: string;
+}

--- a/src/api/rest-api/api-key/dto/create-service-api-key.dto.ts
+++ b/src/api/rest-api/api-key/dto/create-service-api-key.dto.ts
@@ -1,0 +1,61 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+  IsArray,
+  IsBoolean,
+  IsObject,
+  IsOptional,
+  IsString,
+  ValidateNested,
+} from 'class-validator';
+import { BaseApiKeyScopeDto } from 'src/api/rest-api/api-key/dto/base-api-key-scope.dto';
+
+export class CaslRuleDto {
+  @ApiProperty({ type: [String] })
+  @IsArray()
+  @IsString({ each: true })
+  action: string[];
+
+  @ApiProperty({ type: [String] })
+  @IsArray()
+  @IsString({ each: true })
+  subject: string[];
+
+  @ApiPropertyOptional({
+    type: 'object',
+    additionalProperties: true,
+  })
+  @IsOptional()
+  @IsObject()
+  conditions?: Record<string, unknown>;
+
+  @ApiProperty({ required: false, type: [String] })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  fields?: string[];
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsBoolean()
+  inverted?: boolean;
+}
+
+export class CaslPermissionsDto {
+  @ApiProperty({ type: [CaslRuleDto] })
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => CaslRuleDto)
+  rules: CaslRuleDto[];
+}
+
+export class CreateServiceApiKeyDto extends BaseApiKeyScopeDto {
+  @ApiProperty()
+  @IsString()
+  name: string;
+
+  @ApiProperty({ type: () => CaslPermissionsDto })
+  @ValidateNested()
+  @Type(() => CaslPermissionsDto)
+  permissions: CaslPermissionsDto;
+}

--- a/src/api/rest-api/api-key/model/api-key-with-secret.model.ts
+++ b/src/api/rest-api/api-key/model/api-key-with-secret.model.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { ApiKeyModel } from 'src/api/rest-api/api-key/model/api-key.model';
+
+export class ApiKeyWithSecretModel {
+  @ApiProperty({ type: () => ApiKeyModel })
+  apiKey: ApiKeyModel;
+
+  @ApiProperty({
+    description:
+      'Plaintext secret. Returned only once at creation/rotation — store it now or rotate.',
+  })
+  secret: string;
+}

--- a/src/api/rest-api/api-key/model/api-key.model.ts
+++ b/src/api/rest-api/api-key/model/api-key.model.ts
@@ -14,7 +14,7 @@ export class ApiKeyModel {
   @ApiProperty()
   name: string;
 
-  @ApiProperty({ required: false, nullable: true })
+  @ApiProperty({ type: String, required: false, nullable: true })
   organizationId?: string | null;
 
   @ApiProperty({ type: [String] })

--- a/src/api/rest-api/api-key/model/api-key.model.ts
+++ b/src/api/rest-api/api-key/model/api-key.model.ts
@@ -1,0 +1,68 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { ApiKeyType } from 'src/__generated__/client';
+
+export class ApiKeyModel {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty()
+  prefix: string;
+
+  @ApiProperty({ enum: ApiKeyType, enumName: 'ApiKeyType' })
+  type: ApiKeyType;
+
+  @ApiProperty()
+  name: string;
+
+  @ApiProperty({ required: false, nullable: true })
+  organizationId?: string | null;
+
+  @ApiProperty({ type: [String] })
+  projectIds: string[];
+
+  @ApiProperty({ type: [String] })
+  branchNames: string[];
+
+  @ApiProperty({ type: [String] })
+  tableIds: string[];
+
+  @ApiProperty()
+  readOnly: boolean;
+
+  @ApiProperty({ type: [String] })
+  allowedIps: string[];
+
+  @ApiProperty({
+    nullable: true,
+    type: 'object',
+    additionalProperties: true,
+  })
+  permissions: unknown;
+
+  @ApiProperty({
+    required: false,
+    nullable: true,
+    type: String,
+    format: 'date-time',
+  })
+  expiresAt?: Date | null;
+
+  @ApiProperty({
+    required: false,
+    nullable: true,
+    type: String,
+    format: 'date-time',
+  })
+  lastUsedAt?: Date | null;
+
+  @ApiProperty({ type: String, format: 'date-time' })
+  createdAt: Date;
+
+  @ApiProperty({
+    required: false,
+    nullable: true,
+    type: String,
+    format: 'date-time',
+  })
+  revokedAt?: Date | null;
+}

--- a/src/api/rest-api/api-key/model/index.ts
+++ b/src/api/rest-api/api-key/model/index.ts
@@ -1,0 +1,2 @@
+export * from 'src/api/rest-api/api-key/model/api-key.model';
+export * from 'src/api/rest-api/api-key/model/api-key-with-secret.model';

--- a/src/api/rest-api/init-swagger.ts
+++ b/src/api/rest-api/init-swagger.ts
@@ -43,6 +43,10 @@ export function initSwagger(app: INestApplication<any>) {
       'Endpoint',
       'API endpoint configuration for GraphQL and REST access',
     )
+    .addTag(
+      'ApiKey',
+      'Personal and service API key management — create, list, rotate, revoke',
+    )
     .build();
 
   const document = SwaggerModule.createDocument(app, documentBuilder);

--- a/src/api/rest-api/openapi.json
+++ b/src/api/rest-api/openapi.json
@@ -6840,6 +6840,503 @@
         ]
       }
     },
+    "/api/api-keys/personal": {
+      "post": {
+        "description": "Returns the plaintext secret only on this response. Store it now — it cannot be retrieved later.",
+        "operationId": "createPersonalApiKey",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreatePersonalApiKeyDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiKeyWithSecretModel"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request data or validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required. Provide a valid JWT token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient permissions for this operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api-key": []
+          },
+          {
+            "access-token": []
+          }
+        ],
+        "summary": "Create a personal API key for the current user",
+        "tags": [
+          "ApiKey"
+        ]
+      },
+      "get": {
+        "operationId": "myApiKeys",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ApiKeyModel"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request data or validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required. Provide a valid JWT token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient permissions for this operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api-key": []
+          },
+          {
+            "access-token": []
+          }
+        ],
+        "summary": "List the current user's personal API keys",
+        "tags": [
+          "ApiKey"
+        ]
+      }
+    },
+    "/api/api-keys/{id}": {
+      "get": {
+        "operationId": "apiKeyById",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "API key identifier",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiKeyModel"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request data or validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required. Provide a valid JWT token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient permissions for this operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api-key": []
+          },
+          {
+            "access-token": []
+          }
+        ],
+        "summary": "Read one API key visible to the current user",
+        "tags": [
+          "ApiKey"
+        ]
+      }
+    },
+    "/api/api-keys/{id}/rotate": {
+      "post": {
+        "description": "Atomically revokes the original key and creates a replacement with the same scope. The new plaintext secret is returned only on this response.",
+        "operationId": "rotateApiKey",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "API key identifier",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiKeyWithSecretModel"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request data or validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required. Provide a valid JWT token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient permissions for this operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api-key": []
+          },
+          {
+            "access-token": []
+          }
+        ],
+        "summary": "Rotate a key — revokes the original and returns a new secret",
+        "tags": [
+          "ApiKey"
+        ]
+      }
+    },
+    "/api/api-keys/{id}/revoke": {
+      "post": {
+        "description": "Sets `revokedAt` on the key. The record is preserved for audit; subsequent authentication attempts with this key are rejected.",
+        "operationId": "revokeApiKey",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "API key identifier",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiKeyModel"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request data or validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required. Provide a valid JWT token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient permissions for this operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api-key": []
+          },
+          {
+            "access-token": []
+          }
+        ],
+        "summary": "Revoke a key",
+        "tags": [
+          "ApiKey"
+        ]
+      }
+    },
+    "/api/organization/{organizationId}/api-keys/service": {
+      "post": {
+        "description": "Requires `manage` on `ApiKey` for the organization (scoped further to projects when `projectIds` is supplied). The plaintext secret is returned only on this response.",
+        "operationId": "createServiceApiKey",
+        "parameters": [
+          {
+            "name": "organizationId",
+            "required": true,
+            "in": "path",
+            "description": "Organization identifier (typically the owner username)",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateServiceApiKeyDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiKeyWithSecretModel"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request data or validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required. Provide a valid JWT token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient permissions for this operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api-key": []
+          },
+          {
+            "access-token": []
+          }
+        ],
+        "summary": "Create a service API key for an organization",
+        "tags": [
+          "ApiKey"
+        ]
+      },
+      "get": {
+        "description": "Requires `manage` on `ApiKey` for the organization.",
+        "operationId": "serviceApiKeys",
+        "parameters": [
+          {
+            "name": "organizationId",
+            "required": true,
+            "in": "path",
+            "description": "Organization identifier (typically the owner username)",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ApiKeyModel"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request data or validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required. Provide a valid JWT token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient permissions for this operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api-key": []
+          },
+          {
+            "access-token": []
+          }
+        ],
+        "summary": "List organization service API keys",
+        "tags": [
+          "ApiKey"
+        ]
+      }
+    },
     "/health/readiness": {
       "get": {
         "operationId": "readiness",
@@ -7279,6 +7776,10 @@
     {
       "name": "Endpoint",
       "description": "API endpoint configuration for GraphQL and REST access"
+    },
+    {
+      "name": "ApiKey",
+      "description": "Personal and service API key management — create, list, rotate, revoke"
     }
   ],
   "servers": [],
@@ -9996,6 +10497,260 @@
           "noAuth",
           "google",
           "github"
+        ]
+      },
+      "CreatePersonalApiKeyDto": {
+        "type": "object",
+        "properties": {
+          "projectIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "branchNames": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "tableIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "readOnly": {
+            "type": "boolean",
+            "default": false
+          },
+          "allowedIps": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "expiresAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "name": {
+            "type": "string"
+          },
+          "organizationId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ]
+      },
+      "ApiKeyType": {
+        "type": "string",
+        "enum": [
+          "PERSONAL",
+          "SERVICE",
+          "INTERNAL"
+        ]
+      },
+      "ApiKeyModel": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "prefix": {
+            "type": "string"
+          },
+          "type": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ApiKeyType"
+              }
+            ]
+          },
+          "name": {
+            "type": "string"
+          },
+          "organizationId": {
+            "type": "object",
+            "nullable": true
+          },
+          "projectIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "branchNames": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "tableIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "readOnly": {
+            "type": "boolean"
+          },
+          "allowedIps": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "permissions": {
+            "type": "object",
+            "nullable": true,
+            "additionalProperties": true
+          },
+          "expiresAt": {
+            "type": "string",
+            "nullable": true,
+            "format": "date-time"
+          },
+          "lastUsedAt": {
+            "type": "string",
+            "nullable": true,
+            "format": "date-time"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "revokedAt": {
+            "type": "string",
+            "nullable": true,
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "prefix",
+          "type",
+          "name",
+          "projectIds",
+          "branchNames",
+          "tableIds",
+          "readOnly",
+          "allowedIps",
+          "permissions",
+          "createdAt"
+        ]
+      },
+      "ApiKeyWithSecretModel": {
+        "type": "object",
+        "properties": {
+          "apiKey": {
+            "$ref": "#/components/schemas/ApiKeyModel"
+          },
+          "secret": {
+            "type": "string",
+            "description": "Plaintext secret. Returned only once at creation/rotation — store it now or rotate."
+          }
+        },
+        "required": [
+          "apiKey",
+          "secret"
+        ]
+      },
+      "CaslRuleDto": {
+        "type": "object",
+        "properties": {
+          "action": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "subject": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "conditions": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "inverted": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "action",
+          "subject"
+        ]
+      },
+      "CaslPermissionsDto": {
+        "type": "object",
+        "properties": {
+          "rules": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CaslRuleDto"
+            }
+          }
+        },
+        "required": [
+          "rules"
+        ]
+      },
+      "CreateServiceApiKeyDto": {
+        "type": "object",
+        "properties": {
+          "projectIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "branchNames": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "tableIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "readOnly": {
+            "type": "boolean",
+            "default": false
+          },
+          "allowedIps": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "expiresAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "name": {
+            "type": "string"
+          },
+          "permissions": {
+            "$ref": "#/components/schemas/CaslPermissionsDto"
+          }
+        },
+        "required": [
+          "name",
+          "permissions"
         ]
       }
     }

--- a/src/api/rest-api/openapi.json
+++ b/src/api/rest-api/openapi.json
@@ -10573,7 +10573,7 @@
             "type": "string"
           },
           "organizationId": {
-            "type": "object",
+            "type": "string",
             "nullable": true
           },
           "projectIds": {

--- a/src/api/rest-api/rest-api.module.ts
+++ b/src/api/rest-api/rest-api.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { ApiKeyModule } from 'src/features/api-key/api-key.module';
 import { AuthModule } from 'src/features/auth/auth.module';
 import { BranchModule } from 'src/features/branch/branch.module';
 import { EndpointModule } from 'src/features/endpoint/endpoint.module';
@@ -11,6 +12,8 @@ import { TableModule } from 'src/features/table/table.module';
 import { UserModule } from 'src/features/user/user.module';
 import { ConfigurationModule } from 'src/infrastructure/configuration/configuration.module';
 import { MetricsModule } from 'src/infrastructure/metrics/metrics.module';
+import { ApiKeyController } from 'src/api/rest-api/api-key/api-key.controller';
+import { ApiKeyServiceController } from 'src/api/rest-api/api-key/api-key-service.controller';
 import { AuthController } from 'src/api/rest-api/auth/auth.controller';
 import { BranchByNameController } from 'src/api/rest-api/branch/branch-by-name.controller';
 import { ConfigurationController } from 'src/api/rest-api/configuration/configuration.controller';
@@ -24,6 +27,7 @@ import { UserController } from 'src/api/rest-api/user/user.controller';
 
 @Module({
   imports: [
+    ApiKeyModule,
     AuthModule,
     BranchModule,
     ConfigurationModule,
@@ -48,6 +52,8 @@ import { UserController } from 'src/api/rest-api/user/user.controller';
     RowByIdController,
     EndpointByIdController,
     ConfigurationController,
+    ApiKeyController,
+    ApiKeyServiceController,
   ],
 })
 export class RestApiModule {}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * REST endpoints for personal API keys: create, list, retrieve, rotate (returns secret once), revoke
  * REST endpoints for organization service API keys: create, list
  * API keys now support project/branch/table scopes, IP allowlists, read-only mode, permissions, and expiration

* **Documentation**
  * OpenAPI/Swagger updated with ApiKey tag, new schemas, and paths for all API key endpoints

* **Tests**
  * End-to-end and auth-matrix tests added/extended for REST and GraphQL API key flows

* **Chores**
  * New script to generate/update the OpenAPI snapshot (test mode)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/revisium/revisium-core/pull/550)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->